### PR TITLE
Dictionary.Empty

### DIFF
--- a/src/SourceCode.Clay.Collections/Dictionary.cs
+++ b/src/SourceCode.Clay.Collections/Dictionary.cs
@@ -21,11 +21,13 @@ namespace SourceCode.Clay.Collections
 
         #endregion
 
-        private sealed class EmptyImpl<TKey, TValue> : IDictionary<TKey, TValue>
+        internal sealed class EmptyImpl<TKey, TValue> : IDictionary<TKey, TValue>
         {
             #region Constants
 
             internal static readonly IDictionary<TKey, TValue> Value = new EmptyImpl<TKey, TValue>();
+
+            internal static readonly IReadOnlyDictionary<TKey, TValue> ReadOnlyValue = (IReadOnlyDictionary<TKey, TValue>)Value;
 
             #endregion
 

--- a/src/SourceCode.Clay.Collections/Dictionary.cs
+++ b/src/SourceCode.Clay.Collections/Dictionary.cs
@@ -1,0 +1,112 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+
+namespace SourceCode.Clay.Collections
+{
+    /// <summary>
+    /// Useful properties and methods for <see cref="IDictionary{TKey, TValue}"/>.
+    /// </summary>
+    public static class Dictionary
+    {
+        #region Constants
+
+        /// <summary>
+        /// Returns an empty dictionary that is immutable.
+        /// </summary>
+        /// <typeparam name="TKey">The type of keys in the dictionary.</typeparam>
+        /// <typeparam name="TValue">The type of values in the dictionary.</typeparam>
+        /// <returns>Returns an empty <see cref="IDictionary{TKey, TValue}".</returns>
+        public static IDictionary<TKey, TValue> Empty<TKey, TValue>() => EmptyImpl<TKey, TValue>.Value;
+
+        #endregion
+
+        private sealed class EmptyImpl<TKey, TValue> : IDictionary<TKey, TValue>
+        {
+            #region Constants
+
+            internal static readonly IDictionary<TKey, TValue> Value = new EmptyImpl<TKey, TValue>();
+
+            #endregion
+
+            #region Fields
+
+            private readonly IReadOnlyDictionary<TKey, TValue> _dict = new Dictionary<TKey, TValue>(0);
+
+            #endregion
+
+            #region Properties
+
+            public TValue this[TKey key]
+            {
+                get => _dict[key];
+                set => throw new InvalidOperationException();
+            }
+
+            public ICollection<TKey> Keys => Array.Empty<TKey>();
+
+            public ICollection<TValue> Values => Array.Empty<TValue>();
+
+            public int Count => 0;
+
+            public bool IsReadOnly => true;
+
+            #endregion
+
+            #region Constructors
+
+            private EmptyImpl()
+            { }
+
+            #endregion
+
+            #region Methods
+
+            public void Add(TKey key, TValue value)
+                => throw new InvalidOperationException();
+
+            public void Add(KeyValuePair<TKey, TValue> item)
+                => throw new InvalidOperationException();
+
+            public void Clear()
+            {
+                // No-op
+            }
+
+            public bool Contains(KeyValuePair<TKey, TValue> item) => false;
+
+            public bool ContainsKey(TKey key) => false;
+
+            public void CopyTo(KeyValuePair<TKey, TValue>[] array, int arrayIndex)
+            {
+                // No-op
+            }
+
+            public bool Remove(TKey key) => false;
+
+            public bool Remove(KeyValuePair<TKey, TValue> item) => false;
+
+            public bool TryGetValue(TKey key, out TValue value)
+            {
+                value = default(TValue);
+                return false;
+            }
+
+            #endregion
+
+            #region IEnumerable
+
+            IEnumerator<KeyValuePair<TKey, TValue>> IEnumerable<KeyValuePair<TKey, TValue>>.GetEnumerator()
+            {
+                yield break;
+            }
+
+            IEnumerator IEnumerable.GetEnumerator()
+            {
+                yield break;
+            }
+
+            #endregion
+        }
+    }
+}

--- a/src/SourceCode.Clay.Collections/ReadOnlyDictionary.cs
+++ b/src/SourceCode.Clay.Collections/ReadOnlyDictionary.cs
@@ -1,0 +1,84 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+
+namespace SourceCode.Clay.Collections
+{
+    /// <summary>
+    /// Useful properties and methods for <see cref="IReadOnlyDictionary{TKey, TValue}"/>.
+    /// </summary>
+    public static class ReadOnlyDictionary
+    {
+        #region Constants
+
+        /// <summary>
+        /// Returns an empty readonly dictionary.
+        /// </summary>
+        /// <typeparam name="TKey">The type of keys in the dictionary.</typeparam>
+        /// <typeparam name="TValue">The type of values in the dictionary.</typeparam>
+        /// <returns>Returns an empty <see cref="IReadOnlyDictionary{TKey, TValue}".</returns>
+        public static IReadOnlyDictionary<TKey, TValue> Empty<TKey, TValue>() => EmptyImpl<TKey, TValue>.Value;
+
+        #endregion
+
+        private sealed class EmptyImpl<TKey, TValue> : IReadOnlyDictionary<TKey, TValue>
+        {
+            #region Constants
+
+            internal static readonly IReadOnlyDictionary<TKey, TValue> Value = new EmptyImpl<TKey, TValue>();
+
+            #endregion
+
+            #region Fields
+
+            private readonly IReadOnlyDictionary<TKey, TValue> _dict = new Dictionary<TKey, TValue>(0);
+
+            #endregion
+
+            #region Properties
+
+            public TValue this[TKey key] => _dict[key];
+
+            public IEnumerable<TKey> Keys => Array.Empty<TKey>();
+
+            public IEnumerable<TValue> Values => Array.Empty<TValue>();
+
+            public int Count => 0;
+
+            #endregion
+
+            #region Constructors
+
+            private EmptyImpl()
+            { }
+
+            #endregion
+
+            #region Methods
+
+            public bool ContainsKey(TKey key) => false;
+
+            public bool TryGetValue(TKey key, out TValue value)
+            {
+                value = default(TValue);
+                return false;
+            }
+
+            #endregion
+
+            #region IEnumerable
+
+            IEnumerator<KeyValuePair<TKey, TValue>> IEnumerable<KeyValuePair<TKey, TValue>>.GetEnumerator()
+            {
+                yield break;
+            }
+
+            IEnumerator IEnumerable.GetEnumerator()
+            {
+                yield break;
+            }
+
+            #endregion
+        }
+    }
+}

--- a/src/SourceCode.Clay.Collections/ReadOnlyDictionary.cs
+++ b/src/SourceCode.Clay.Collections/ReadOnlyDictionary.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Collections;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 
 namespace SourceCode.Clay.Collections
 {
@@ -17,68 +15,8 @@ namespace SourceCode.Clay.Collections
         /// <typeparam name="TKey">The type of keys in the dictionary.</typeparam>
         /// <typeparam name="TValue">The type of values in the dictionary.</typeparam>
         /// <returns>Returns an empty <see cref="IReadOnlyDictionary{TKey, TValue}".</returns>
-        public static IReadOnlyDictionary<TKey, TValue> Empty<TKey, TValue>() => EmptyImpl<TKey, TValue>.Value;
+        public static IReadOnlyDictionary<TKey, TValue> Empty<TKey, TValue>() => Dictionary.EmptyImpl<TKey, TValue>.ReadOnlyValue;
 
         #endregion
-
-        private sealed class EmptyImpl<TKey, TValue> : IReadOnlyDictionary<TKey, TValue>
-        {
-            #region Constants
-
-            internal static readonly IReadOnlyDictionary<TKey, TValue> Value = new EmptyImpl<TKey, TValue>();
-
-            #endregion
-
-            #region Fields
-
-            private readonly IReadOnlyDictionary<TKey, TValue> _dict = new Dictionary<TKey, TValue>(0);
-
-            #endregion
-
-            #region Properties
-
-            public TValue this[TKey key] => _dict[key];
-
-            public IEnumerable<TKey> Keys => Array.Empty<TKey>();
-
-            public IEnumerable<TValue> Values => Array.Empty<TValue>();
-
-            public int Count => 0;
-
-            #endregion
-
-            #region Constructors
-
-            private EmptyImpl()
-            { }
-
-            #endregion
-
-            #region Methods
-
-            public bool ContainsKey(TKey key) => false;
-
-            public bool TryGetValue(TKey key, out TValue value)
-            {
-                value = default(TValue);
-                return false;
-            }
-
-            #endregion
-
-            #region IEnumerable
-
-            IEnumerator<KeyValuePair<TKey, TValue>> IEnumerable<KeyValuePair<TKey, TValue>>.GetEnumerator()
-            {
-                yield break;
-            }
-
-            IEnumerator IEnumerable.GetEnumerator()
-            {
-                yield break;
-            }
-
-            #endregion
-        }
     }
 }


### PR DESCRIPTION
Similar pattern to Array.Empty<T>(). 
Useful for assigning an empty dictionary, without allocating memory.