### PR TITLE
NetCoreApp2.0 prep

### DIFF
--- a/src/SourceCode.Clay.Buffers.Tests/BufferComparerTests.cs
+++ b/src/SourceCode.Clay.Buffers.Tests/BufferComparerTests.cs
@@ -143,8 +143,11 @@ namespace SourceCode.Clay.Buffers.Tests
             var a = GenerateArray(16);
             var b = GenerateArray(16);
             var c = GenerateArray(16, 1);
+            var d = GenerateArray(15);
+
             Assert.Equal(a, b, BufferComparer.Default);
             Assert.NotEqual(a, c, BufferComparer.Default);
+            Assert.NotEqual(a, d, BufferComparer.Default);
         }
 
         [Trait("Type", "Unit")]
@@ -154,8 +157,11 @@ namespace SourceCode.Clay.Buffers.Tests
             var a = GenerateArray(16).ToList();
             var b = GenerateArray(16).ToList();
             var c = GenerateArray(16, 1).ToList();
+            var d = GenerateArray(15).ToList();
+
             Assert.Equal(a, b, BufferComparer.Default);
             Assert.NotEqual(a, c, BufferComparer.Default);
+            Assert.NotEqual(a, d, BufferComparer.Default);
         }
 
         [Trait("Type", "Unit")]
@@ -165,8 +171,11 @@ namespace SourceCode.Clay.Buffers.Tests
             var a = new ReadOnlyListWrapper<byte>(GenerateArray(16));
             var b = new ReadOnlyListWrapper<byte>(GenerateArray(16));
             var c = new ReadOnlyListWrapper<byte>(GenerateArray(16, 1));
+            var d = new ReadOnlyListWrapper<byte>(GenerateArray(15));
+
             Assert.Equal(a, b, BufferComparer.Default);
             Assert.NotEqual(a, c, BufferComparer.Default);
+            Assert.NotEqual(a, d, BufferComparer.Default);
         }
 
         [Trait("Type", "Unit")]
@@ -176,8 +185,85 @@ namespace SourceCode.Clay.Buffers.Tests
             var a = GenerateArray(16).Take(16);
             var b = GenerateArray(16).Take(16);
             var c = GenerateArray(16, 1).Take(16);
+            var d = GenerateArray(16).Take(15);
+
             Assert.Equal(a, b, BufferComparer.Default);
             Assert.NotEqual(a, c, BufferComparer.Default);
+            Assert.NotEqual(a, d, BufferComparer.Default);
+        }
+
+        #endregion
+
+        #region Compare
+
+        [Trait("Type", "Unit")]
+        [Fact(DisplayName = "BufferComparer Compare Array")]
+        public static void BufferComparer_Compare_Array()
+        {
+            var a = GenerateArray(16);
+            var b = GenerateArray(16);
+            var c = GenerateArray(16, 1);
+            var d = GenerateArray(15);
+
+            Assert.True(BufferComparer.Default.Compare(a, b) == 0);
+            Assert.True(BufferComparer.Default.Compare(a, c) < 0);
+            Assert.True(BufferComparer.Default.Compare(c, a) > 0);
+            Assert.True(BufferComparer.Default.Compare(d, a) < 0);
+            Assert.True(BufferComparer.Default.Compare(a, d) > 0);
+        }
+
+        [Trait("Type", "Unit")]
+        [Fact(DisplayName = "BufferComparer Compare List")]
+        public static void BufferComparer_Compare_List()
+        {
+            var a = GenerateArray(16).ToList();
+            var b = GenerateArray(16).ToList();
+            var c = GenerateArray(16, 1).ToList();
+            var d = GenerateArray(15).ToList();
+
+            Assert.True(BufferComparer.Default.Compare((IList<byte>)a, b) == 0);
+            Assert.True(BufferComparer.Default.Compare((IList<byte>)a, c) < 0);
+            Assert.True(BufferComparer.Default.Compare((IList<byte>)c, a) > 0);
+            Assert.True(BufferComparer.Default.Compare((IList<byte>)d, a) < 0);
+            Assert.True(BufferComparer.Default.Compare((IList<byte>)a, d) > 0);
+
+            Assert.True(BufferComparer.Default.Compare((IReadOnlyList<byte>)a, b) == 0);
+            Assert.True(BufferComparer.Default.Compare((IReadOnlyList<byte>)a, c) < 0);
+            Assert.True(BufferComparer.Default.Compare((IReadOnlyList<byte>)c, a) > 0);
+            Assert.True(BufferComparer.Default.Compare((IReadOnlyList<byte>)d, a) < 0);
+            Assert.True(BufferComparer.Default.Compare((IReadOnlyList<byte>)a, d) > 0);
+        }
+
+        [Trait("Type", "Unit")]
+        [Fact(DisplayName = "BufferComparer Compare ReadOnlyList")]
+        public static void BufferComparer_Compare_ReadOnlyList()
+        {
+            var a = new ReadOnlyListWrapper<byte>(GenerateArray(16));
+            var b = new ReadOnlyListWrapper<byte>(GenerateArray(16));
+            var c = new ReadOnlyListWrapper<byte>(GenerateArray(16, 1));
+            var d = new ReadOnlyListWrapper<byte>(GenerateArray(15));
+
+            Assert.True(BufferComparer.Default.Compare(a, b) == 0);
+            Assert.True(BufferComparer.Default.Compare(a, c) < 0);
+            Assert.True(BufferComparer.Default.Compare(c, a) > 0);
+            Assert.True(BufferComparer.Default.Compare(d, a) < 0);
+            Assert.True(BufferComparer.Default.Compare(a, d) > 0);
+        }
+
+        [Trait("Type", "Unit")]
+        [Fact(DisplayName = "BufferComparer Compare Enumerable")]
+        public static void BufferComparer_Compare_Enumerable()
+        {
+            var a = GenerateArray(16).Take(16);
+            var b = GenerateArray(16).Take(16);
+            var c = GenerateArray(16, 1).Take(16);
+            var d = GenerateArray(16).Take(15);
+
+            Assert.True(BufferComparer.Default.Compare(a, b) == 0);
+            Assert.True(BufferComparer.Default.Compare(a, c) < 0);
+            Assert.True(BufferComparer.Default.Compare(c, a) > 0);
+            Assert.True(BufferComparer.Default.Compare(d, a) < 0);
+            Assert.True(BufferComparer.Default.Compare(a, d) > 0);
         }
 
         #endregion

--- a/src/SourceCode.Clay.Buffers.Tests/SourceCode.Clay.Buffers.Tests.csproj
+++ b/src/SourceCode.Clay.Buffers.Tests/SourceCode.Clay.Buffers.Tests.csproj
@@ -10,12 +10,7 @@
 
   <PropertyGroup>
     <LangVersion>latest</LangVersion>
-  </PropertyGroup>
-
-  <ItemGroup>
-    <Compile Remove="BufferComparerTests.cs" />
-    <None Include="BufferComparerTests.cs" />
-  </ItemGroup>
+  </PropertyGroup> 
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />

--- a/src/SourceCode.Clay.Buffers.Tests/SourceCode.Clay.Buffers.Tests.csproj
+++ b/src/SourceCode.Clay.Buffers.Tests/SourceCode.Clay.Buffers.Tests.csproj
@@ -1,11 +1,15 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp1.1</TargetFramework>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
     <VersionPrefix>1.0.0</VersionPrefix>
     <Company>SourceCode Technology Holdings Inc.</Company>
     <Product>Clay</Product>
     <Copyright>Copyright © 2017 SourceCode Technology Holdings Inc.</Copyright>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/SourceCode.Clay.Buffers.Tests/SourceCode.Clay.Buffers.Tests.csproj
+++ b/src/SourceCode.Clay.Buffers.Tests/SourceCode.Clay.Buffers.Tests.csproj
@@ -1,8 +1,17 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>    
+  <PropertyGroup>
     <TargetFramework>netcoreapp1.1</TargetFramework>
+    <VersionPrefix>1.0.0</VersionPrefix>
+    <Company>SourceCode Technology Holdings Inc.</Company>
+    <Product>Clay</Product>
+    <Copyright>Copyright © 2017 SourceCode Technology Holdings Inc.</Copyright>
   </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Remove="BufferComparerTests.cs" />
+    <None Include="BufferComparerTests.cs" />
+  </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />

--- a/src/SourceCode.Clay.Buffers.Tests/SourceCode.Clay.Buffers.Tests.csproj
+++ b/src/SourceCode.Clay.Buffers.Tests/SourceCode.Clay.Buffers.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp1.1</TargetFramework>
     <VersionPrefix>1.0.0</VersionPrefix>
     <Company>SourceCode Technology Holdings Inc.</Company>
     <Product>Clay</Product>

--- a/src/SourceCode.Clay.Buffers/BufferSession.cs
+++ b/src/SourceCode.Clay.Buffers/BufferSession.cs
@@ -86,9 +86,7 @@ namespace SourceCode.Clay.Buffers
         /// </summary>
         /// <param name="buffer">The buffer.</param>
         public static void ReturnBuffer(byte[] buffer)
-        {
-            ArrayPool<byte>.Shared.Return(buffer);
-        }
+            => ArrayPool<byte>.Shared.Return(buffer);
 
         #endregion
 

--- a/src/SourceCode.Clay.Buffers/HashCode.Fnv.cs
+++ b/src/SourceCode.Clay.Buffers/HashCode.Fnv.cs
@@ -19,10 +19,11 @@ namespace SourceCode.Clay.Buffers
         /// Calculates a hash code from the specified data using the
         /// Fowler/Noll/Vo 1-a algorithm.
         /// </summary>
-        /// <param name="buffer">A pointer to the initial octet in the data.</param>
-        /// <param name="count">The number of octets to include in the hash code.</param>
-        /// <returns>The hash code.</returns>
-        public static int Fnv(ReadOnlySpan<byte> buffer)
+        /// <param name="buffer">The array containing the range of bytes to include in the hash code.</param>
+        /// <returns>
+        /// The hash code.
+        /// </returns>
+        public static int Fnv(params byte[] buffer)
         {
             var h = FnvOffsetBasis;
 
@@ -46,8 +47,18 @@ namespace SourceCode.Clay.Buffers
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static unsafe int Fnv(byte* buffer, int count)
         {
-            if (buffer == default(byte*)) throw new ArgumentNullException(nameof(buffer));
-            return Fnv(new ReadOnlySpan<byte>(buffer, count));
+            if (buffer == default(byte*))
+                throw new ArgumentNullException(nameof(buffer));
+
+            var h = FnvOffsetBasis;
+
+            for (var i = 0; i < count; i++)
+            {
+                var c = buffer[i];
+                h = unchecked((h ^ c) * FnvPrime);
+            }
+
+            return unchecked((int)h);
         }
 
         /// <summary>
@@ -118,25 +129,7 @@ namespace SourceCode.Clay.Buffers
 
         #region Overloads
 
-        /// <summary>
-        /// Calculates a hash code from the specified data using the
-        /// Fowler/Noll/Vo 1-a algorithm.
-        /// </summary>
-        /// <param name="buffer">The array containing the range of bytes to include in the hash code.</param>
-        /// <returns>
-        /// The hash code.
-        /// </returns>
-        [SecurityCritical]
-        public static unsafe int Fnv(params byte[] buffer)
-        {
-            if (buffer == null) throw new ArgumentNullException(nameof(buffer));
-            if (buffer.Length == 0) return unchecked((int)FnvOffsetBasis);
 
-            fixed (byte* b = &buffer[0])
-            {
-                return Fnv(b, buffer.Length);
-            }
-        }
 
         /// <summary>
         /// Calculates a hash code from the specified data using the

--- a/src/SourceCode.Clay.Buffers/SourceCode.Clay.Buffers.csproj
+++ b/src/SourceCode.Clay.Buffers/SourceCode.Clay.Buffers.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp1.1</TargetFramework>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
     <VersionPrefix>1.0.0</VersionPrefix>
     <Company>SourceCode Technology Holdings Inc.</Company>
     <Product>Clay</Product>
@@ -20,6 +20,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Net.Compilers" Version="2.3.1" />
+    <PackageReference Include="System.ValueTuple" Version="4.4.0" />
     <PackageReference Include="SonarAnalyzer.CSharp" Version="6.3.0.2862">
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>

--- a/src/SourceCode.Clay.Buffers/SourceCode.Clay.Buffers.csproj
+++ b/src/SourceCode.Clay.Buffers/SourceCode.Clay.Buffers.csproj
@@ -10,15 +10,23 @@
 
   <PropertyGroup>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>
+    <Compile Remove="BufferComparer.cs" />
+    <None Include="BufferComparer.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="Microsoft.Net.Compilers" Version="2.3.1" />
-    <PackageReference Include="SonarAnalyzer.CSharp" Version="6.2.0.2536">
+    <PackageReference Include="SonarAnalyzer.CSharp" Version="6.3.0.2862">
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="System.Buffers" Version="4.3.0" />
-    <PackageReference Include="System.Buffers.Primitives" Version="0.1.0-e170809-2" />
-    <PackageReference Include="System.Memory" Version="4.4.0-preview1-25305-02" />
+    <PackageReference Include="System.Buffers" Version="4.4.0" />
+    <!--<PackageReference Include="System.Memory" Version="4.4.0-preview2-25405-01" />
+    <PackageReference Include="System.Numerics.Vectors" Version="4.4.0-preview2-25405-01" />
+    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="4.4.0-preview2-25405-01" />
+    <PackageReference Include="System.Buffers.Primitives" Version="0.1.0-e170810-2" />-->
   </ItemGroup>
 </Project>

--- a/src/SourceCode.Clay.Buffers/SourceCode.Clay.Buffers.csproj
+++ b/src/SourceCode.Clay.Buffers/SourceCode.Clay.Buffers.csproj
@@ -11,12 +11,7 @@
   <PropertyGroup>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
     <LangVersion>latest</LangVersion>
-  </PropertyGroup>
-
-  <ItemGroup>
-    <Compile Remove="BufferComparer.cs" />
-    <None Include="BufferComparer.cs" />
-  </ItemGroup>
+  </PropertyGroup> 
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Net.Compilers" Version="2.3.1" />

--- a/src/SourceCode.Clay.Buffers/SourceCode.Clay.Buffers.csproj
+++ b/src/SourceCode.Clay.Buffers/SourceCode.Clay.Buffers.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp1.1</TargetFramework>
     <VersionPrefix>1.0.0</VersionPrefix>
     <Company>SourceCode Technology Holdings Inc.</Company>
     <Product>Clay</Product>

--- a/src/SourceCode.Clay.Collections.Tests/DictionaryTests.cs
+++ b/src/SourceCode.Clay.Collections.Tests/DictionaryTests.cs
@@ -1,0 +1,25 @@
+﻿using Xunit;
+
+namespace SourceCode.Clay.Collections.Generic.Tests
+{
+    public static class DictionaryTests
+    {
+        [Trait("Type", "Unit")]
+        [Fact(DisplayName = "Dictionary.Empty")]
+        public static void Use_Dictionary_Empty()
+        {
+            var empty = Dictionary.Empty<string, int>();
+
+            Assert.Equal(empty.Count, 0);
+        }
+
+        [Trait("Type", "Unit")]
+        [Fact(DisplayName = "ReadOnlyDictionary.Empty")]
+        public static void Use_ReadOnlyDictionary_Empty()
+        {
+            var empty = ReadOnlyDictionary.Empty<string, int>();
+
+            Assert.Equal(empty.Count, 0);
+        }
+    }
+}

--- a/src/SourceCode.Clay.Collections.Tests/SourceCode.Clay.Collections.Tests.csproj
+++ b/src/SourceCode.Clay.Collections.Tests/SourceCode.Clay.Collections.Tests.csproj
@@ -1,13 +1,21 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>    
-    <TargetFramework>netcoreapp1.1</TargetFramework>
+  <PropertyGroup>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <VersionPrefix>1.0.0</VersionPrefix>
+    <Company>SourceCode Technology Holdings Inc.</Company>
+    <Product>Clay</Product>
+    <Copyright>Copyright © 2017 SourceCode Technology Holdings Inc.</Copyright>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
-    <PackageReference Include="xunit" Version="2.2.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0-preview-20170810-02" />
+    <PackageReference Include="xunit" Version="2.3.0-beta4-build3742" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.0-beta4-build3742" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/SourceCode.Clay.Collections.Tests/SourceCode.Clay.Collections.Tests.csproj
+++ b/src/SourceCode.Clay.Collections.Tests/SourceCode.Clay.Collections.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp1.1</TargetFramework>
     <VersionPrefix>1.0.0</VersionPrefix>
     <Company>SourceCode Technology Holdings Inc.</Company>
     <Product>Clay</Product>

--- a/src/SourceCode.Clay.Collections/Dictionary.cs
+++ b/src/SourceCode.Clay.Collections/Dictionary.cs
@@ -2,7 +2,7 @@
 using System.Collections;
 using System.Collections.Generic;
 
-namespace SourceCode.Clay.Collections
+namespace SourceCode.Clay.Collections.Generic
 {
     /// <summary>
     /// Useful properties and methods for <see cref="IDictionary{TKey, TValue}"/>.
@@ -21,13 +21,13 @@ namespace SourceCode.Clay.Collections
 
         #endregion
 
-        internal sealed class EmptyImpl<TKey, TValue> : IDictionary<TKey, TValue>
+        internal sealed class EmptyImpl<TKey, TValue> : IDictionary<TKey, TValue>, IReadOnlyDictionary<TKey, TValue>
         {
             #region Constants
 
             internal static readonly IDictionary<TKey, TValue> Value = new EmptyImpl<TKey, TValue>();
 
-            internal static readonly IReadOnlyDictionary<TKey, TValue> ReadOnlyValue = (IReadOnlyDictionary<TKey, TValue>)Value;
+            internal static readonly IReadOnlyDictionary<TKey, TValue> ReadOnlyValue = (IReadOnlyDictionary<TKey, TValue>)(Value);
 
             #endregion
 
@@ -45,9 +45,13 @@ namespace SourceCode.Clay.Collections
                 set => throw new InvalidOperationException();
             }
 
-            public ICollection<TKey> Keys => Array.Empty<TKey>();
+            ICollection<TKey> IDictionary<TKey, TValue>.Keys => Array.Empty<TKey>();
 
-            public ICollection<TValue> Values => Array.Empty<TValue>();
+            ICollection<TValue> IDictionary<TKey, TValue>.Values => Array.Empty<TValue>();
+
+            IEnumerable<TKey> IReadOnlyDictionary<TKey, TValue>.Keys => Array.Empty<TKey>();
+
+            IEnumerable<TValue> IReadOnlyDictionary<TKey, TValue>.Values => Array.Empty<TValue>();
 
             public int Count => 0;
 

--- a/src/SourceCode.Clay.Collections/ReadOnlyDictionary.cs
+++ b/src/SourceCode.Clay.Collections/ReadOnlyDictionary.cs
@@ -1,6 +1,6 @@
 ﻿using System.Collections.Generic;
 
-namespace SourceCode.Clay.Collections
+namespace SourceCode.Clay.Collections.Generic
 {
     /// <summary>
     /// Useful properties and methods for <see cref="IReadOnlyDictionary{TKey, TValue}"/>.

--- a/src/SourceCode.Clay.Collections/SourceCode.Clay.Collections.csproj
+++ b/src/SourceCode.Clay.Collections/SourceCode.Clay.Collections.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp1.1</TargetFramework>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
     <VersionPrefix>1.0.0</VersionPrefix>
     <Company>SourceCode Technology Holdings Inc.</Company>
     <Product>Clay</Product>
@@ -10,13 +10,14 @@
 
   <PropertyGroup>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Net.Compilers" Version="2.3.1" />
-    <PackageReference Include="SonarAnalyzer.CSharp" Version="6.2.0.2536">
+    <PackageReference Include="System.ValueTuple" Version="4.4.0" />
+    <PackageReference Include="SonarAnalyzer.CSharp" Version="6.3.0.2862">
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="System.ValueTuple" Version="4.3.1" />
   </ItemGroup>
 </Project>

--- a/src/SourceCode.Clay.Collections/SourceCode.Clay.Collections.csproj
+++ b/src/SourceCode.Clay.Collections/SourceCode.Clay.Collections.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp1.1</TargetFramework>
     <VersionPrefix>1.0.0</VersionPrefix>
     <Company>SourceCode Technology Holdings Inc.</Company>
     <Product>Clay</Product>

--- a/src/SourceCode.Clay.Data.Tests/SourceCode.Clay.Data.Tests.csproj
+++ b/src/SourceCode.Clay.Data.Tests/SourceCode.Clay.Data.Tests.csproj
@@ -1,14 +1,21 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>    
-    <TargetFramework>netcoreapp1.1</TargetFramework>
+  <PropertyGroup>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <VersionPrefix>1.0.0</VersionPrefix>
+    <Company>SourceCode Technology Holdings Inc.</Company>
+    <Product>Clay</Product>
+    <Copyright>Copyright © 2017 SourceCode Technology Holdings Inc.</Copyright>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
-    <PackageReference Include="System.Data.SqlClient" Version="4.3.1" />
-    <PackageReference Include="xunit" Version="2.2.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0-preview-20170810-02" />
+    <PackageReference Include="xunit" Version="2.3.0-beta4-build3742" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.0-beta4-build3742" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/SourceCode.Clay.Data.Tests/SourceCode.Clay.Data.Tests.csproj
+++ b/src/SourceCode.Clay.Data.Tests/SourceCode.Clay.Data.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp1.1</TargetFramework>
     <VersionPrefix>1.0.0</VersionPrefix>
     <Company>SourceCode Technology Holdings Inc.</Company>
     <Product>Clay</Product>

--- a/src/SourceCode.Clay.Data/SourceCode.Clay.Data.csproj
+++ b/src/SourceCode.Clay.Data/SourceCode.Clay.Data.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp1.1</TargetFramework>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
     <VersionPrefix>1.0.0</VersionPrefix>
     <Company>SourceCode Technology Holdings Inc.</Company>
     <Product>Clay</Product>
@@ -10,14 +10,16 @@
 
   <PropertyGroup>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Net.Compilers" Version="2.3.1" />
-    <PackageReference Include="SonarAnalyzer.CSharp" Version="6.2.0.2536">
+    <PackageReference Include="System.ValueTuple" Version="4.4.0" />
+    <PackageReference Include="SonarAnalyzer.CSharp" Version="6.3.0.2862">
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="System.Data.SqlClient" Version="4.3.1" />
+    <PackageReference Include="System.Data.SqlClient" Version="4.4.0" />
     <PackageReference Include="System.Diagnostics.Contracts" Version="4.3.0" />
   </ItemGroup>
 </Project>

--- a/src/SourceCode.Clay.Data/SourceCode.Clay.Data.csproj
+++ b/src/SourceCode.Clay.Data/SourceCode.Clay.Data.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp1.1</TargetFramework>
     <VersionPrefix>1.0.0</VersionPrefix>
     <Company>SourceCode Technology Holdings Inc.</Company>
     <Product>Clay</Product>

--- a/src/SourceCode.Clay.Tests/SourceCode.Clay.Tests.csproj
+++ b/src/SourceCode.Clay.Tests/SourceCode.Clay.Tests.csproj
@@ -1,13 +1,21 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>    
-    <TargetFramework>netcoreapp1.1</TargetFramework>
+  <PropertyGroup>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <VersionPrefix>1.0.0</VersionPrefix>
+    <Company>SourceCode Technology Holdings Inc.</Company>
+    <Product>Clay</Product>
+    <Copyright>Copyright © 2017 SourceCode Technology Holdings Inc.</Copyright>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
-    <PackageReference Include="xunit" Version="2.2.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0-preview-20170810-02" />
+    <PackageReference Include="xunit" Version="2.3.0-beta4-build3742" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.0-beta4-build3742" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/SourceCode.Clay.Tests/SourceCode.Clay.Tests.csproj
+++ b/src/SourceCode.Clay.Tests/SourceCode.Clay.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp1.1</TargetFramework>
     <VersionPrefix>1.0.0</VersionPrefix>
     <Company>SourceCode Technology Holdings Inc.</Company>
     <Product>Clay</Product>

--- a/src/SourceCode.Clay.Text.Tests/SourceCode.Clay.Text.Tests.csproj
+++ b/src/SourceCode.Clay.Text.Tests/SourceCode.Clay.Text.Tests.csproj
@@ -1,13 +1,21 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>    
-    <TargetFramework>netcoreapp1.1</TargetFramework>
+  <PropertyGroup>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <VersionPrefix>1.0.0</VersionPrefix>
+    <Company>SourceCode Technology Holdings Inc.</Company>
+    <Product>Clay</Product>
+    <Copyright>Copyright © 2017 SourceCode Technology Holdings Inc.</Copyright>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
-    <PackageReference Include="xunit" Version="2.2.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0-preview-20170810-02" />
+    <PackageReference Include="xunit" Version="2.3.0-beta4-build3742" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.0-beta4-build3742" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/SourceCode.Clay.Text.Tests/SourceCode.Clay.Text.Tests.csproj
+++ b/src/SourceCode.Clay.Text.Tests/SourceCode.Clay.Text.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp1.1</TargetFramework>
     <VersionPrefix>1.0.0</VersionPrefix>
     <Company>SourceCode Technology Holdings Inc.</Company>
     <Product>Clay</Product>

--- a/src/SourceCode.Clay.Text/SourceCode.Clay.Text.csproj
+++ b/src/SourceCode.Clay.Text/SourceCode.Clay.Text.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp1.1</TargetFramework>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
     <VersionPrefix>1.0.0</VersionPrefix>
     <Company>SourceCode Technology Holdings Inc.</Company>
     <Product>Clay</Product>
@@ -10,11 +10,13 @@
 
   <PropertyGroup>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Net.Compilers" Version="2.3.1" />
-    <PackageReference Include="SonarAnalyzer.CSharp" Version="6.2.0.2536">
+    <PackageReference Include="System.ValueTuple" Version="4.4.0" />
+    <PackageReference Include="SonarAnalyzer.CSharp" Version="6.3.0.2862">
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
   </ItemGroup>

--- a/src/SourceCode.Clay.Text/SourceCode.Clay.Text.csproj
+++ b/src/SourceCode.Clay.Text/SourceCode.Clay.Text.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp1.1</TargetFramework>
     <VersionPrefix>1.0.0</VersionPrefix>
     <Company>SourceCode Technology Holdings Inc.</Company>
     <Product>Clay</Product>

--- a/src/SourceCode.Clay/SourceCode.Clay.csproj
+++ b/src/SourceCode.Clay/SourceCode.Clay.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp1.1</TargetFramework>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
     <VersionPrefix>1.0.0</VersionPrefix>
     <Company>SourceCode Technology Holdings Inc.</Company>
     <Product>Clay</Product>
@@ -10,11 +10,13 @@
 
   <PropertyGroup>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Net.Compilers" Version="2.3.1" />
-    <PackageReference Include="SonarAnalyzer.CSharp" Version="6.2.0.2536">
+    <PackageReference Include="System.ValueTuple" Version="4.4.0" />
+    <PackageReference Include="SonarAnalyzer.CSharp" Version="6.3.0.2862">
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
   </ItemGroup>

--- a/src/SourceCode.Clay/SourceCode.Clay.csproj
+++ b/src/SourceCode.Clay/SourceCode.Clay.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp1.1</TargetFramework>
     <VersionPrefix>1.0.0</VersionPrefix>
     <Company>SourceCode Technology Holdings Inc.</Company>
     <Product>Clay</Product>


### PR DESCRIPTION
- Upgraded all projects to NetCoreApp2.0
- Elided Span<T> and Buffer<T> functionality from BufferComparer, due to build issues at caller
- Use StringComparer.Ordinal.Equals instead of string.Equals(..., StringComparison.Ordinal)
- byte[] is implicitly convertible to Span<byte> so no need for methods to override both signatures
- Normalized project settings and Nugets