### PR TITLE
Fix SqlTokenizer

### DIFF
--- a/src/SourceCode.Clay.Data/SqlParser/SqlTokenInfo.cs
+++ b/src/SourceCode.Clay.Data/SqlParser/SqlTokenInfo.cs
@@ -2,7 +2,7 @@
 
 namespace SourceCode.Clay.Data.SqlParser
 {
-    internal struct SqlTokenInfo
+    public struct SqlTokenInfo
     {
         #region Properties
 


### PR DESCRIPTION
Tokenizer is not parsing comments properly - it breaks when the CLR is on Linux (where the line-endings are `\n` and not `\r\n` like on Windows)