### PR TITLE
BufferComparer

### DIFF
--- a/src/SourceCode.Clay.Buffers.Tests/BlitTests.cs
+++ b/src/SourceCode.Clay.Buffers.Tests/BlitTests.cs
@@ -2,10 +2,10 @@
 
 namespace SourceCode.Clay.Buffers.Tests
 {
-    public class BlitExtensionsTests
+    public static class BlitTests
     {
         [Fact(DisplayName = "BlitExtensions RotateLeft Byte")]
-        public void BlitExtensions_RotateLeft_Byte()
+        public static void Blit_RotateLeft_Byte()
         {
             byte sut = 0b01010101;
             Assert.Equal((byte)0b10101010, Blit.RotateLeft(sut, 1));
@@ -14,7 +14,7 @@ namespace SourceCode.Clay.Buffers.Tests
         }
 
         [Fact(DisplayName = "BlitExtensions RotateLeft UShort")]
-        public void BlitExtensions_RotateLeft_UShort()
+        public static void Blit_RotateLeft_UShort()
         {
             ushort sut = 0b01010101_01010101;
             Assert.Equal((ushort)0b10101010_10101010, Blit.RotateLeft(sut, 1));
@@ -23,7 +23,7 @@ namespace SourceCode.Clay.Buffers.Tests
         }
 
         [Fact(DisplayName = "BlitExtensions RotateLeft UInt")]
-        public void BlitExtensions_RotateLeft_UInt()
+        public static void Blit_RotateLeft_UInt()
         {
             uint sut = 0b01010101_01010101_01010101_01010101;
             Assert.Equal((uint)0b10101010_10101010_10101010_10101010, Blit.RotateLeft(sut, 1));
@@ -32,7 +32,7 @@ namespace SourceCode.Clay.Buffers.Tests
         }
 
         [Fact(DisplayName = "BlitExtensions RotateLeft ULong")]
-        public void BlitExtensions_RotateLeft_ULong()
+        public static void Blit_RotateLeft_ULong()
         {
             ulong sut = 0b01010101_01010101_01010101_01010101_01010101_01010101_01010101_01010101;
             Assert.Equal((ulong)0b10101010_10101010_10101010_10101010_10101010_10101010_10101010_10101010, Blit.RotateLeft(sut, 1));
@@ -41,7 +41,7 @@ namespace SourceCode.Clay.Buffers.Tests
         }
 
         [Fact(DisplayName = "BlitExtensions RotateRight Byte")]
-        public void BlitExtensions_RotateRight_Byte()
+        public static void Blit_RotateRight_Byte()
         {
             byte sut = 0b01010101;
             Assert.Equal((byte)0b10101010, Blit.RotateRight(sut, 1));
@@ -50,7 +50,7 @@ namespace SourceCode.Clay.Buffers.Tests
         }
 
         [Fact(DisplayName = "BlitExtensions RotateRight UShort")]
-        public void BlitExtensions_RotateRight_UShort()
+        public static void Blit_RotateRight_UShort()
         {
             ushort sut = 0b01010101_01010101;
             Assert.Equal((ushort)0b10101010_10101010, Blit.RotateRight(sut, 1));
@@ -59,7 +59,7 @@ namespace SourceCode.Clay.Buffers.Tests
         }
 
         [Fact(DisplayName = "BlitExtensions RotateRight UInt")]
-        public void BlitExtensions_RotateRight_UInt()
+        public static void Blit_RotateRight_UInt()
         {
             uint sut = 0b01010101_01010101_01010101_01010101;
             Assert.Equal((uint)0b10101010_10101010_10101010_10101010, Blit.RotateRight(sut, 1));
@@ -68,7 +68,7 @@ namespace SourceCode.Clay.Buffers.Tests
         }
 
         [Fact(DisplayName = "BlitExtensions RotateRight ULong")]
-        public void BlitExtensions_RotateRight_ULong()
+        public static void Blit_RotateRight_ULong()
         {
             ulong sut = 0b01010101_01010101_01010101_01010101_01010101_01010101_01010101_01010101;
             Assert.Equal((ulong)0b10101010_10101010_10101010_10101010_10101010_10101010_10101010_10101010, Blit.RotateRight(sut, 1));

--- a/src/SourceCode.Clay.Buffers.Tests/BufferComparerTests.cs
+++ b/src/SourceCode.Clay.Buffers.Tests/BufferComparerTests.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using Xunit;
 
 namespace SourceCode.Clay.Buffers.Tests
@@ -442,11 +443,37 @@ namespace SourceCode.Clay.Buffers.Tests
             Assert.True(BufferComparer.Span.Comparison(a, d) > 0);
         }
 
-        #endregion
+        [Trait("Type", "Unit")]
+        [Fact(DisplayName = nameof(BufferComparer_Compare_Array_With_Comparison))]
+        public static void BufferComparer_Compare_Array_With_Comparison()
+        {
+            var expected = new byte[4] { 1, 2, 3, 4 };
 
-        #region Comparison
+            var a1 = new byte[4] { 1, 2, 3, 6 };
+            var a2 = new byte[4] { 1, 2, 3, 7 };
+            var a3 = new byte[4] { 1, 2, 3, 5 };
 
-        //
+            var list = new List<byte[]>(new[] { a1, a2, expected, a3 });
+            list.Sort(BufferComparer.Array.Comparison);
+
+            Assert.Equal(expected, list[0], BufferComparer.Array);
+        }
+
+        [Trait("Type", "Unit")]
+        [Fact(DisplayName = nameof(BufferComparer_Compare_Span_With_Comparison))]
+        public static void BufferComparer_Compare_Span_With_Comparison()
+        {
+            var expected = new byte[4] { 1, 2, 3, 4 }.AsReadOnlySpan();
+
+            var a1 = new byte[4] { 1, 2, 3, 6 }.AsReadOnlySpan();
+            var a2 = new byte[4] { 1, 2, 3, 7 }.AsReadOnlySpan();
+            var a3 = new byte[4] { 1, 2, 3, 5 }.AsReadOnlySpan();
+
+            var list = new List<ReadOnlySpan<byte>>(new[] { a1, a2, expected, a3 });
+            list.Sort(BufferComparer.Span.Comparison);
+
+            Assert.Equal(expected, list[0], BufferComparer.Span);
+        }
 
         #endregion
     }

--- a/src/SourceCode.Clay.Buffers.Tests/BufferComparerTests.cs
+++ b/src/SourceCode.Clay.Buffers.Tests/BufferComparerTests.cs
@@ -299,10 +299,20 @@ namespace SourceCode.Clay.Buffers.Tests
             Assert.True(BufferComparer.Array.Compare(a, b) < 0);
             Assert.True(BufferComparer.Array.Compare(a, c) > 0);
 
+            // Array Comparison
+            Assert.True(BufferComparer.Array.Comparison(a, a1) == 0);
+            Assert.True(BufferComparer.Array.Comparison(a, b) < 0);
+            Assert.True(BufferComparer.Array.Comparison(a, c) > 0);
+
             // ReadOnlySpan
             Assert.True(BufferComparer.Span.Compare((ReadOnlySpan<byte>)a, a1) == 0);
             Assert.True(BufferComparer.Span.Compare((ReadOnlySpan<byte>)a, b) < 0);
             Assert.True(BufferComparer.Span.Compare((ReadOnlySpan<byte>)a, c) > 0);
+
+            // ReadOnlySpan Comparison
+            Assert.True(BufferComparer.Span.Comparison((ReadOnlySpan<byte>)a, a1) == 0);
+            Assert.True(BufferComparer.Span.Comparison((ReadOnlySpan<byte>)a, b) < 0);
+            Assert.True(BufferComparer.Span.Comparison((ReadOnlySpan<byte>)a, c) > 0);
 
             // Span (implicit conversion from Span to ReadOnlySpan)
             Assert.True(BufferComparer.Span.Compare((Span<byte>)a, a1) == 0);
@@ -338,6 +348,13 @@ namespace SourceCode.Clay.Buffers.Tests
             Assert.True(BufferComparer.Array.Compare(d.Array, a.Array) < 0);
             Assert.True(BufferComparer.Array.Compare(a.Array, d.Array) > 0);
 
+            // Array Comparison
+            Assert.True(BufferComparer.Array.Comparison(a.Array, a1.Array) == 0);
+            Assert.True(BufferComparer.Array.Comparison(a.Array, c.Array) < 0);
+            Assert.True(BufferComparer.Array.Comparison(c.Array, a.Array) > 0);
+            Assert.True(BufferComparer.Array.Comparison(d.Array, a.Array) < 0);
+            Assert.True(BufferComparer.Array.Comparison(a.Array, d.Array) > 0);
+
             // ReadOnlySpan
             Assert.True(BufferComparer.Span.Compare((ReadOnlySpan<byte>)a, a1) == 0);
             Assert.True(BufferComparer.Span.Compare((ReadOnlySpan<byte>)a, a2) == 0);
@@ -345,6 +362,14 @@ namespace SourceCode.Clay.Buffers.Tests
             Assert.True(BufferComparer.Span.Compare((ReadOnlySpan<byte>)c, a) > 0);
             Assert.True(BufferComparer.Span.Compare((ReadOnlySpan<byte>)d, a) < 0);
             Assert.True(BufferComparer.Span.Compare((ReadOnlySpan<byte>)a, d) > 0);
+
+            // ReadOnlySpan Comparison
+            Assert.True(BufferComparer.Span.Comparison((ReadOnlySpan<byte>)a, a1) == 0);
+            Assert.True(BufferComparer.Span.Comparison((ReadOnlySpan<byte>)a, a2) == 0);
+            Assert.True(BufferComparer.Span.Comparison((ReadOnlySpan<byte>)a, c) < 0);
+            Assert.True(BufferComparer.Span.Comparison((ReadOnlySpan<byte>)c, a) > 0);
+            Assert.True(BufferComparer.Span.Comparison((ReadOnlySpan<byte>)d, a) < 0);
+            Assert.True(BufferComparer.Span.Comparison((ReadOnlySpan<byte>)a, d) > 0);
 
             // Span (implicit conversion from Span to ReadOnlySpan)
             Assert.True(BufferComparer.Span.Compare((Span<byte>)a, a1) == 0);
@@ -383,6 +408,11 @@ namespace SourceCode.Clay.Buffers.Tests
             Assert.True(BufferComparer.Span.Compare(a, a1) == 0);
             Assert.True(BufferComparer.Span.Compare(a, b) < 0);
             Assert.True(BufferComparer.Span.Compare(a, c) > 0);
+
+            // ArraySegment Comparison (implicit conversion)
+            Assert.True(BufferComparer.Span.Comparison(a, a1) == 0);
+            Assert.True(BufferComparer.Span.Comparison(a, b) < 0);
+            Assert.True(BufferComparer.Span.Comparison(a, c) > 0);
         }
 
         [Trait("Type", "Unit")]
@@ -402,7 +432,21 @@ namespace SourceCode.Clay.Buffers.Tests
             Assert.True(BufferComparer.Span.Compare(c, a) > 0);
             Assert.True(BufferComparer.Span.Compare(d, a) < 0);
             Assert.True(BufferComparer.Span.Compare(a, d) > 0);
+
+            // ArraySegment Comparison (implicit conversion)
+            Assert.True(BufferComparer.Span.Comparison(a, a1) == 0);
+            Assert.True(BufferComparer.Span.Comparison(a, a2) == 0);
+            Assert.True(BufferComparer.Span.Comparison(a, c) < 0);
+            Assert.True(BufferComparer.Span.Comparison(c, a) > 0);
+            Assert.True(BufferComparer.Span.Comparison(d, a) < 0);
+            Assert.True(BufferComparer.Span.Comparison(a, d) > 0);
         }
+
+        #endregion
+
+        #region Comparison
+
+        //
 
         #endregion
     }

--- a/src/SourceCode.Clay.Buffers.Tests/BufferComparerTests.cs
+++ b/src/SourceCode.Clay.Buffers.Tests/BufferComparerTests.cs
@@ -253,6 +253,12 @@ namespace SourceCode.Clay.Buffers.Tests
             var c = GenerateSegment(0, 16, 1).Array;
             var d = GenerateSegment(0, 15).Array;
 
+            // Array
+            Assert.Equal(a, a1, BufferComparer.Array);
+            Assert.NotEqual(a, c, BufferComparer.Array);
+            Assert.NotEqual(a, d, BufferComparer.Array);
+
+            // Span
             Assert.Equal(a, a1, BufferComparer.Span);
             Assert.NotEqual(a, c, BufferComparer.Span);
             Assert.NotEqual(a, d, BufferComparer.Span);
@@ -288,6 +294,11 @@ namespace SourceCode.Clay.Buffers.Tests
             var b = new byte[1] { 2 };
             var c = new byte[1] { 0 };
 
+            // Array
+            Assert.True(BufferComparer.Array.Compare(a, a1) == 0);
+            Assert.True(BufferComparer.Array.Compare(a, b) < 0);
+            Assert.True(BufferComparer.Array.Compare(a, c) > 0);
+
             // ReadOnlySpan
             Assert.True(BufferComparer.Span.Compare((ReadOnlySpan<byte>)a, a1) == 0);
             Assert.True(BufferComparer.Span.Compare((ReadOnlySpan<byte>)a, b) < 0);
@@ -319,6 +330,13 @@ namespace SourceCode.Clay.Buffers.Tests
             var a2 = GenerateSegment(10, 16); // Same
             var c = GenerateSegment(0, 16, 1);
             var d = GenerateSegment(0, 15);
+
+            // Array
+            Assert.True(BufferComparer.Array.Compare(a.Array, a1.Array) == 0);
+            Assert.True(BufferComparer.Array.Compare(a.Array, c.Array) < 0);
+            Assert.True(BufferComparer.Array.Compare(c.Array, a.Array) > 0);
+            Assert.True(BufferComparer.Array.Compare(d.Array, a.Array) < 0);
+            Assert.True(BufferComparer.Array.Compare(a.Array, d.Array) > 0);
 
             // ReadOnlySpan
             Assert.True(BufferComparer.Span.Compare((ReadOnlySpan<byte>)a, a1) == 0);

--- a/src/SourceCode.Clay.Buffers/ArrayBufferComparer.cs
+++ b/src/SourceCode.Clay.Buffers/ArrayBufferComparer.cs
@@ -47,17 +47,6 @@ namespace SourceCode.Clay.Buffers
         #region IEqualityComparer
 
         /// <summary>
-        /// Determines whether the specified objects are equal.
-        /// </summary>
-        /// <param name="x">The first object to compare.</param>
-        /// <param name="y">The second object to compare.</param>
-        /// <returns>
-        /// true if the specified objects are equal; otherwise, false.
-        /// </returns>
-        public override bool Equals(byte[] x, byte[] y)
-            => BufferComparer.CompareArray(x, y) == 0;
-
-        /// <summary>
         /// Returns a hash code for this instance.
         /// </summary>
         /// <param name="obj">The object.</param>

--- a/src/SourceCode.Clay.Buffers/ArrayBufferComparer.cs
+++ b/src/SourceCode.Clay.Buffers/ArrayBufferComparer.cs
@@ -20,8 +20,8 @@ namespace SourceCode.Clay.Buffers
         /// Creates a new instance of the <see cref="ArrayBufferComparer"/> class.
         /// </summary>
         /// <param name="hashCodeFidelity">
-        /// The maximum number of octets that processed when calculating a hashcode. Pass zero or a negative value to
-        /// disable the limit.
+        /// The maximum number of octets processed when calculating a hashcode.
+        /// Pass zero to disable the limit.
         /// </param>
         public ArrayBufferComparer(int hashCodeFidelity)
             : base(hashCodeFidelity)
@@ -60,7 +60,7 @@ namespace SourceCode.Clay.Buffers
                 return HashCode.Fnv(obj);
 
             // Calculate on full length
-            if (HashCodeFidelity <= 0 || obj.Length <= HashCodeFidelity) // Also handles Empty
+            if (HashCodeFidelity == 0 || obj.Length <= HashCodeFidelity) // Also handles Empty
                 return HashCode.Fnv(obj);
 
             // Calculate on prefix

--- a/src/SourceCode.Clay.Buffers/BufferComparer.T.cs
+++ b/src/SourceCode.Clay.Buffers/BufferComparer.T.cs
@@ -63,7 +63,16 @@ namespace SourceCode.Clay.Buffers
 
         #region IEqualityComparer
 
-        public abstract bool Equals(T x, T y);
+        /// <summary>
+        /// Determines whether the specified objects are equal.
+        /// </summary>
+        /// <param name="x">The first object to compare.</param>
+        /// <param name="y">The second object to compare.</param>
+        /// <returns>
+        /// true if the specified objects are equal; otherwise, false.
+        /// </returns>
+        public bool Equals(T x, T y)
+            => Compare(x, y) == 0;
 
         public new bool Equals(object x, object y)
         {
@@ -88,6 +97,16 @@ namespace SourceCode.Clay.Buffers
 
             return obj.GetHashCode();
         }
+
+        #endregion
+
+        #region Comparison
+
+        /// <summary>
+        /// Returns an instance of the <see cref="Comparison{T}"/> delegate for use in methods such as <see cref="Array.Sort{T}(T[], Comparison{T})"/>.
+        /// </summary>
+        public Comparison<T> Comparison
+            => Compare;
 
         #endregion
     }

--- a/src/SourceCode.Clay.Buffers/BufferComparer.T.cs
+++ b/src/SourceCode.Clay.Buffers/BufferComparer.T.cs
@@ -113,7 +113,7 @@ namespace SourceCode.Clay.Buffers
         /// Returns an instance of the <see cref="Comparison{T}"/> delegate for use in methods such as <see cref="Array.Sort{T}(T[], Comparison{T})"/>.
         /// </summary>
         public Comparison<T> Comparison
-            => Compare;
+            => Compare; // Delegate dispatch faster than interface dispatch (https://github.com/dotnet/coreclr/pull/8504)
 
         #endregion
     }

--- a/src/SourceCode.Clay.Buffers/BufferComparer.T.cs
+++ b/src/SourceCode.Clay.Buffers/BufferComparer.T.cs
@@ -26,18 +26,20 @@ namespace SourceCode.Clay.Buffers
         /// </summary>
         protected BufferComparer()
         {
-            HashCodeFidelity = -1;
+            HashCodeFidelity = 0;
         }
 
         /// <summary>
         /// Creates a new instance of the <see cref="BufferComparer"/> class.
         /// </summary>
         /// <param name="hashCodeFidelity">
-        /// The maximum number of octets that processed when calculating a hashcode. Pass zero or a negative value to
-        /// disable the limit.
+        /// The maximum number of octets processed when calculating a hashcode.
+        /// Pass zero to disable the limit.
         /// </param>
         protected BufferComparer(int hashCodeFidelity)
         {
+            if (hashCodeFidelity < 0) throw new ArgumentOutOfRangeException(nameof(hashCodeFidelity));
+
             HashCodeFidelity = hashCodeFidelity;
         }
 
@@ -110,10 +112,10 @@ namespace SourceCode.Clay.Buffers
         #region Comparison
 
         /// <summary>
-        /// Returns an instance of the <see cref="Comparison{T}"/> delegate for use in methods such as <see cref="Array.Sort{T}(T[], Comparison{T})"/>.
+        /// Returns a <see cref="Comparison{T}"/> delegate for use in methods such as <see cref="Array.Sort{T}(T[], Comparison{T})"/>.
         /// </summary>
-        public Comparison<T> Comparison
-            => Compare; // Delegate dispatch faster than interface dispatch (https://github.com/dotnet/coreclr/pull/8504)
+        public int Comparison(T x, T y)
+            => Compare(x, y);
 
         #endregion
     }

--- a/src/SourceCode.Clay.Buffers/BufferComparer.T.cs
+++ b/src/SourceCode.Clay.Buffers/BufferComparer.T.cs
@@ -47,7 +47,7 @@ namespace SourceCode.Clay.Buffers
 
         public abstract int Compare(T x, T y);
 
-        public int Compare(object x, object y)
+        int IComparer.Compare(object x, object y)
         {
             if (ReferenceEquals(x, y)) return 0; // (null, null) or (x, x)
             if (x == null) return -1; // (null, y)
@@ -74,7 +74,16 @@ namespace SourceCode.Clay.Buffers
         public bool Equals(T x, T y)
             => Compare(x, y) == 0;
 
-        public new bool Equals(object x, object y)
+        /// <summary>
+        /// Returns a hash code for this instance.
+        /// </summary>
+        /// <param name="obj">The object.</param>
+        /// <returns>
+        /// A hash code for this instance, suitable for use in hashing algorithms and data structures like a hash table.
+        /// </returns>
+        public abstract int GetHashCode(T obj);
+
+        bool IEqualityComparer.Equals(object x, object y)
         {
             if (ReferenceEquals(x, y)) return true; // (null, null) or (x, x)
             if (x == null) return false; // (null, y)
@@ -86,11 +95,9 @@ namespace SourceCode.Clay.Buffers
             return false;
         }
 
-        public abstract int GetHashCode(T obj);
-
-        public int GetHashCode(object obj)
+        int IEqualityComparer.GetHashCode(object obj)
         {
-            if (obj == null) return 0; ;
+            if (obj == null) return 0;
 
             if (obj is T ot)
                 return GetHashCode(ot);

--- a/src/SourceCode.Clay.Buffers/BufferComparer.cs
+++ b/src/SourceCode.Clay.Buffers/BufferComparer.cs
@@ -66,19 +66,19 @@ namespace SourceCode.Clay.Buffers
             }
             if (y.IsEmpty) return 1; // (x, null)
 
-            var cmp = x.Length.CompareTo(y.Length);
-            if (cmp != 0) return cmp; // (m, n)
+            if (x.Length < y.Length) return -1; // (m, n)
+            if (x.Length > y.Length) return 1;
 
-            switch (x.Length)
+            switch (x.Length) // (n, n)
             {
                 // (0, 0)
-                case 0:
-                    return 0;
+                case 0: return 0;
 
                 // (m[0], n[0])
                 case 1:
-                    cmp = x[0].CompareTo(y[0]);
-                    return cmp;
+                    if (x[0] < y[0]) return -1;
+                    if (x[0] > y[0]) return 1;
+                    return 0;
 
                 // (m[0..N], n[0..N])
                 default:
@@ -88,7 +88,7 @@ namespace SourceCode.Clay.Buffers
                             fixed (byte* xp = &x.DangerousGetPinnableReference())
                             fixed (byte* yp = &y.DangerousGetPinnableReference())
                             {
-                                cmp = NativeMethods.MemCompare(xp, yp, x.Length);
+                                var cmp = NativeMethods.MemCompare(xp, yp, x.Length);
                                 return cmp;
                             }
                         }
@@ -109,19 +109,19 @@ namespace SourceCode.Clay.Buffers
             if (x == null) return -1; // (null, y)
             if (y == null) return 1; // (x, null)
 
-            var cmp = x.Length.CompareTo(y.Length); // (x, y)
-            if (cmp != 0) return cmp; // (m, n)
+            if (x.Length < y.Length) return -1; // (m, n)
+            if (x.Length > y.Length) return 1;
 
-            switch (x.Length)
+            switch (x.Length) // (n, n)
             {
                 // (0, 0)
-                case 0:
-                    return 0;
+                case 0: return 0;
 
                 // (m[0], n[0])
                 case 1:
-                    cmp = x[0].CompareTo(y[0]);
-                    return cmp;
+                    if (x[0] < y[0]) return -1;
+                    if (x[0] > y[0]) return 1;
+                    return 0;
 
                 // (m[0..N], n[0..N])
                 default:
@@ -130,7 +130,7 @@ namespace SourceCode.Clay.Buffers
                         {
                             fixed (byte* xp = x, yp = y)
                             {
-                                cmp = NativeMethods.MemCompare(xp, yp, x.Length);
+                                var cmp = NativeMethods.MemCompare(xp, yp, x.Length);
                                 return cmp;
                             }
                         }

--- a/src/SourceCode.Clay.Buffers/BufferComparer.cs
+++ b/src/SourceCode.Clay.Buffers/BufferComparer.cs
@@ -12,7 +12,7 @@ namespace SourceCode.Clay.Buffers
         #region Constants
 
         /// <summary>
-        /// Gets the number of octets that will be processed when calculating a hashcode.
+        /// The prefix of octets processed when calculating a hashcode.
         /// </summary>
         public const int DefaultHashCodeFidelity = 512;
 

--- a/src/SourceCode.Clay.Buffers/BufferComparer.cs
+++ b/src/SourceCode.Clay.Buffers/BufferComparer.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Runtime.CompilerServices;
 using System.Security;
 
 namespace SourceCode.Clay.Buffers
@@ -42,7 +43,7 @@ namespace SourceCode.Clay.Buffers
 
         #endregion
 
-        #region Methods
+        #region Helpers
 
         /// <summary>
         /// Compare the contexts of two <see cref="ReadOnlySpan{T}"/> buffers.
@@ -51,12 +52,13 @@ namespace SourceCode.Clay.Buffers
         /// <param name="y">Span 2</param>
         /// <returns></returns>
         [SecuritySafeCritical]
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static int CompareSpan(ReadOnlySpan<byte> x, ReadOnlySpan<byte> y)
         {
             // From https://github.com/dotnet/corefx/blob/master/src/System.Memory/src/System/ReadOnlySpan.cs
             // public static bool operator ==
-            // Returns true if left and right point at the same memory and have the same length.  Note that
-            // this does *not* check to see if the *contents* are equal.
+            // Returns true if left and right point at the same memory and have the same length.
+            // Note that this does *not* check to see if the *contents* are equal.
             if (x == y) return 0;
 
             if (x.IsEmpty)
@@ -103,6 +105,7 @@ namespace SourceCode.Clay.Buffers
         /// <param name="y">Buffer 2</param>
         /// <returns></returns>
         [SecuritySafeCritical]
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static int CompareArray(byte[] x, byte[] y)
         {
             if (ReferenceEquals(x, y)) return 0; // (null, null) or (x, x)

--- a/src/SourceCode.Clay.Buffers/BufferSession.cs
+++ b/src/SourceCode.Clay.Buffers/BufferSession.cs
@@ -13,7 +13,7 @@ namespace SourceCode.Clay.Buffers
         #region Properties
 
         /// <summary>
-        /// Gets the result.
+        /// Gets the delineated result (<see cref="BufferSession.Buffer"/> may be overallocated).
         /// </summary>
         /// <value>
         /// The result.

--- a/src/SourceCode.Clay.Buffers/HashCode.Fnv.cs
+++ b/src/SourceCode.Clay.Buffers/HashCode.Fnv.cs
@@ -125,7 +125,7 @@ namespace SourceCode.Clay.Buffers
             if (fields == null) return FnvNull;
             if (fields.Count == 0) return FnvEmpty;
 
-            int* data = stackalloc int[1];
+            Span<int> data = stackalloc int[1]; // TODO: https://github.com/dotnet/corefx/pull/24212
             var bdata = (byte*)data;
 
             var hc = FnvOffsetBasis;
@@ -161,7 +161,7 @@ namespace SourceCode.Clay.Buffers
             if (fields == null) return FnvNull;
             if (!fields.Any()) return FnvEmpty;
 
-            int* data = stackalloc int[1];
+            int* data = stackalloc int[1]; // TODO: https://github.com/dotnet/corefx/pull/24212
             var bdata = (byte*)data;
 
             var hc = FnvOffsetBasis;
@@ -358,7 +358,7 @@ namespace SourceCode.Clay.Buffers
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static unsafe int Fnv(int a, int b)
         {
-            int* data = stackalloc int[2];
+            int* data = stackalloc int[2]; // TODO: https://github.com/dotnet/corefx/pull/24212
             data[0] = a;
             data[1] = b;
 
@@ -380,7 +380,7 @@ namespace SourceCode.Clay.Buffers
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static unsafe int Fnv(int a, int b, int c)
         {
-            int* data = stackalloc int[3];
+            int* data = stackalloc int[3]; // TODO: https://github.com/dotnet/corefx/pull/24212
             data[0] = a;
             data[1] = b;
             data[2] = c;
@@ -404,7 +404,7 @@ namespace SourceCode.Clay.Buffers
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static unsafe int Fnv(int a, int b, int c, int d)
         {
-            int* data = stackalloc int[4];
+            int* data = stackalloc int[4]; // TODO: https://github.com/dotnet/corefx/pull/24212
             data[0] = a;
             data[1] = b;
             data[2] = c;
@@ -430,7 +430,7 @@ namespace SourceCode.Clay.Buffers
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static unsafe int Fnv(int a, int b, int c, int d, int e)
         {
-            int* data = stackalloc int[5];
+            int* data = stackalloc int[5]; // TODO: https://github.com/dotnet/corefx/pull/24212
             data[0] = a;
             data[1] = b;
             data[2] = c;

--- a/src/SourceCode.Clay.Buffers/HashCode.Fnv.cs
+++ b/src/SourceCode.Clay.Buffers/HashCode.Fnv.cs
@@ -125,7 +125,7 @@ namespace SourceCode.Clay.Buffers
             if (fields == null) return FnvNull;
             if (fields.Count == 0) return FnvEmpty;
 
-            Span<int> data = stackalloc int[1]; // TODO: https://github.com/dotnet/corefx/pull/24212
+            int* data = stackalloc int[1]; // TODO: https://github.com/dotnet/corefx/pull/24212
             var bdata = (byte*)data;
 
             var hc = FnvOffsetBasis;

--- a/src/SourceCode.Clay.Buffers/SpanBufferComparer.cs
+++ b/src/SourceCode.Clay.Buffers/SpanBufferComparer.cs
@@ -47,17 +47,6 @@ namespace SourceCode.Clay.Buffers
         #region IEqualityComparer
 
         /// <summary>
-        /// Determines whether the specified objects are equal.
-        /// </summary>
-        /// <param name="x">The first object to compare.</param>
-        /// <param name="y">The second object to compare.</param>
-        /// <returns>
-        /// true if the specified objects are equal; otherwise, false.
-        /// </returns>
-        public override bool Equals(ReadOnlySpan<byte> x, ReadOnlySpan<byte> y)
-            => Compare(x, y) == 0;
-
-        /// <summary>
         /// Returns a hash code for this instance.
         /// </summary>
         /// <param name="obj">The object.</param>

--- a/src/SourceCode.Clay.Buffers/SpanBufferComparer.cs
+++ b/src/SourceCode.Clay.Buffers/SpanBufferComparer.cs
@@ -20,8 +20,8 @@ namespace SourceCode.Clay.Buffers
         /// Creates a new instance of the <see cref="SpanBufferComparer"/> class.
         /// </summary>
         /// <param name="hashCodeFidelity">
-        /// The maximum number of octets that processed when calculating a hashcode. Pass zero or a negative value to
-        /// disable the limit.
+        /// The maximum number of octets processed when calculating a hashcode.
+        /// Pass zero to disable the limit.
         /// </param>
         public SpanBufferComparer(int hashCodeFidelity)
             : base(hashCodeFidelity)
@@ -58,7 +58,7 @@ namespace SourceCode.Clay.Buffers
             // Note ReadOnly/Span is a struct, so cannot pass Null to it
 
             // Calculate on full length
-            if (HashCodeFidelity <= 0 || obj.Length <= HashCodeFidelity) // Also handles Empty
+            if (HashCodeFidelity == 0 || obj.Length <= HashCodeFidelity) // Also handles Empty
                 return HashCode.Fnv(obj);
 
             // Calculate on prefix

--- a/src/SourceCode.Clay/Number.cs
+++ b/src/SourceCode.Clay/Number.cs
@@ -522,6 +522,7 @@ namespace SourceCode.Clay
             var cases = new SwitchCase[types.Length * 2];
             for (var i = 0; i < types.Length; i++)
             {
+                // T
                 var j = i * 2;
                 var type = types[i];
                 var ctor = typeof(Number).GetConstructor(new[] { type });
@@ -529,6 +530,7 @@ namespace SourceCode.Clay
                 var create = Expression.New(ctor, cast);
                 cases[j] = Expression.SwitchCase(create, Expression.Constant(type.TypeHandle));
 
+                // Nullable<T>
                 type = typeof(Nullable<>).MakeGenericType(type);
                 ctor = typeof(Number).GetConstructor(new[] { type });
                 cast = Expression.Convert(objParam, type);


### PR DESCRIPTION
Fixes #46 
- Full HashCodeFidelity is represented by 0 instead of -1
- Add `Comparison` delegate to BufferComparers
- Comments
- Some TODOs that are predicated on C#7.x compiler availability