### PR TITLE
Fix surrogate-pair handling

### DIFF
--- a/src/SourceCode.Clay.Buffers.Tests/SourceCode.Clay.Buffers.Tests.csproj
+++ b/src/SourceCode.Clay.Buffers.Tests/SourceCode.Clay.Buffers.Tests.csproj
@@ -15,7 +15,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0-preview-20170914-09" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0-preview-20170923-02" />
     <PackageReference Include="xunit" Version="2.3.0-beta5-build3769" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.0-beta5-build3769" />
   </ItemGroup>

--- a/src/SourceCode.Clay.Buffers/SourceCode.Clay.Buffers.csproj
+++ b/src/SourceCode.Clay.Buffers/SourceCode.Clay.Buffers.csproj
@@ -10,7 +10,8 @@
 
   <PropertyGroup>
     <Description>Tools and extensions for working with buffers.</Description>
-    <PackageTags>clay utility extension buffer byte</PackageTags>
+    <PackageLicenseUrl>https://github.com/k2workflow/Clay/blob/master/LICENSE</PackageLicenseUrl>
+    <PackageTags>clay utility extension buffer byte array</PackageTags>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/SourceCode.Clay.Collections.Tests/SourceCode.Clay.Collections.Tests.csproj
+++ b/src/SourceCode.Clay.Collections.Tests/SourceCode.Clay.Collections.Tests.csproj
@@ -15,7 +15,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0-preview-20170914-09" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0-preview-20170923-02" />
     <PackageReference Include="xunit" Version="2.3.0-beta5-build3769" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.0-beta5-build3769" />
   </ItemGroup>

--- a/src/SourceCode.Clay.Collections/SourceCode.Clay.Collections.csproj
+++ b/src/SourceCode.Clay.Collections/SourceCode.Clay.Collections.csproj
@@ -10,6 +10,7 @@
 
   <PropertyGroup>
     <Description>Tools and extensions for working with collections.</Description>
+    <PackageLicenseUrl>https://github.com/k2workflow/Clay/blob/master/LICENSE</PackageLicenseUrl>
     <PackageTags>clay utility extension dictionary switch list set</PackageTags>
   </PropertyGroup>
 

--- a/src/SourceCode.Clay.Data.Tests/SourceCode.Clay.Data.Tests.csproj
+++ b/src/SourceCode.Clay.Data.Tests/SourceCode.Clay.Data.Tests.csproj
@@ -15,7 +15,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0-preview-20170914-09" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0-preview-20170923-02" />
     <PackageReference Include="xunit" Version="2.3.0-beta5-build3769" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.0-beta5-build3769" />
   </ItemGroup>

--- a/src/SourceCode.Clay.Data/SourceCode.Clay.Data.csproj
+++ b/src/SourceCode.Clay.Data/SourceCode.Clay.Data.csproj
@@ -10,6 +10,7 @@
 
   <PropertyGroup>
     <Description>Tools and extensions for working with data.</Description>
+    <PackageLicenseUrl>https://github.com/k2workflow/Clay/blob/master/LICENSE</PackageLicenseUrl>
     <PackageTags>clay utility extension sql connection tsql parser</PackageTags>
   </PropertyGroup>
 

--- a/src/SourceCode.Clay.Json.Tests/SourceCode.Clay.Json.Tests.csproj
+++ b/src/SourceCode.Clay.Json.Tests/SourceCode.Clay.Json.Tests.csproj
@@ -15,7 +15,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0-preview-20170914-09" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0-preview-20170923-02" />
     <PackageReference Include="xunit" Version="2.3.0-beta5-build3769" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.0-beta5-build3769" />
   </ItemGroup>

--- a/src/SourceCode.Clay.Json/SourceCode.Clay.Json.csproj
+++ b/src/SourceCode.Clay.Json/SourceCode.Clay.Json.csproj
@@ -10,6 +10,7 @@
 
   <PropertyGroup>
     <Description>Tools and extensions for working with json.</Description>
+    <PackageLicenseUrl>https://github.com/k2workflow/Clay/blob/master/LICENSE</PackageLicenseUrl>
     <PackageTags>clay utility extension json validate</PackageTags>
   </PropertyGroup>
 

--- a/src/SourceCode.Clay.Tests/SourceCode.Clay.Tests.csproj
+++ b/src/SourceCode.Clay.Tests/SourceCode.Clay.Tests.csproj
@@ -15,7 +15,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0-preview-20170914-09" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0-preview-20170923-02" />
     <PackageReference Include="xunit" Version="2.3.0-beta5-build3769" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.0-beta5-build3769" />
   </ItemGroup>

--- a/src/SourceCode.Clay.Tests/StringExtensionsTests.cs
+++ b/src/SourceCode.Clay.Tests/StringExtensionsTests.cs
@@ -1,4 +1,5 @@
-﻿using Xunit;
+﻿using System;
+using Xunit;
 
 namespace SourceCode.Clay.Tests
 {
@@ -203,6 +204,30 @@ namespace SourceCode.Clay.Tests
                     Assert.Equal(expected, actual);
                 }
             }
+        }
+
+        [InlineData(null, null, true)]
+        [InlineData(null, "", false)]
+        [InlineData(null, "a", false)]
+        [InlineData("a", "a", true)]
+        [InlineData(LongStr, LongStr, true)]
+        [Trait("Type", "Unit")]
+        [Theory(DisplayName = nameof(When_String_EqualsOrdinal))]
+        public static void When_String_EqualsOrdinal(string x, string y, bool expected)
+        {
+            // Forward
+            var actual = x.EqualsOrdinal(y);
+            Assert.Equal(expected, actual);
+
+            var exp = StringComparer.Ordinal.Equals(x, y);
+            Assert.Equal(exp, actual);
+
+            // Reverse
+            actual = y.EqualsOrdinal(x);
+            Assert.Equal(expected, actual);
+
+            exp = StringComparer.Ordinal.Equals(y, x);
+            Assert.Equal(exp, actual);
         }
     }
 }

--- a/src/SourceCode.Clay.Tests/StringExtensionsTests.cs
+++ b/src/SourceCode.Clay.Tests/StringExtensionsTests.cs
@@ -6,6 +6,7 @@ namespace SourceCode.Clay.Tests
     public static class StringExtensionsTests
     {
         private const string LongStr = @"From Wikipedia: Astley was born on 6 February 1966 in Newton-le-Willows in Lancashire, the fourth child of his family. His parents divorced when he was five, and Astley was brought up by his father.[9] His musical career started when he was ten, singing in the local church choir.[10] During his schooldays, Astley formed and played the drums in a number of local bands, where he met guitarist David Morris.[2][11] After leaving school at sixteen, Astley was employed during the day as a driver in his father's market-gardening business and played drums on the Northern club circuit at night in bands such as Give Way – specialising in covering Beatles and Shadows songs – and FBI, which won several local talent competitions.[10]";
+        private const string surrogateChar = "\uD869\uDE01";
 
         [Trait("Type", "Unit")]
         [Fact(DisplayName = "StringExtensions Left")]
@@ -159,51 +160,55 @@ namespace SourceCode.Clay.Tests
             }
         }
 
+        // Narrow-1
+        [InlineData("A", -1, 1)]
+        [InlineData("A", 0, 1)]
+        [InlineData("A", 1, 1)]
+        [InlineData("A", 2, 1)]
+        // Wide-1
+        [InlineData(surrogateChar, -1, 2)]
+        [InlineData(surrogateChar, 0, 2)]
+        [InlineData(surrogateChar, 1, 2)]
+        [InlineData(surrogateChar, 2, 2)]
+        [InlineData(surrogateChar, 3, 2)]
+        // Narrow-2
+        [InlineData("AB", -1, 2)]
+        [InlineData("AB", 0, 2)]
+        [InlineData("AB", 1, 2)]
+        [InlineData("AB", 2, 2)]
+        [InlineData("AB", 3, 2)]
+        // Wide-2
+        [InlineData(surrogateChar + surrogateChar, -1, 4)]
+        [InlineData(surrogateChar + surrogateChar, 0, 4)]
+        [InlineData(surrogateChar + surrogateChar, 1, 4)]
+        [InlineData(surrogateChar + surrogateChar, 2, 4)]
+        [InlineData(surrogateChar + surrogateChar, 3, 3)]
+        [InlineData(surrogateChar + surrogateChar, 4, 4)]
+        [InlineData(surrogateChar + surrogateChar, 5, 4)]
+        // Narrow-3
+        [InlineData("ABC", -1, 3)]
+        [InlineData("ABC", 0, 3)]
+        [InlineData("ABC", 1, 3)]
+        [InlineData("ABC", 2, 3)]
+        [InlineData("ABC", 3, 3)]
+        [InlineData("ABC", 4, 3)]
+        // Wide-3
+        [InlineData(surrogateChar + surrogateChar + surrogateChar, -1, 6)]
+        [InlineData(surrogateChar + surrogateChar + surrogateChar, 0, 6)]
+        [InlineData(surrogateChar + surrogateChar + surrogateChar, 1, 6)]
+        [InlineData(surrogateChar + surrogateChar + surrogateChar, 2, 6)]
+        [InlineData(surrogateChar + surrogateChar + surrogateChar, 3, 3)]
+        [InlineData(surrogateChar + surrogateChar + surrogateChar, 4, 3)]
+        [InlineData(surrogateChar + surrogateChar + surrogateChar, 5, 5)]
+        [InlineData(surrogateChar + surrogateChar + surrogateChar, 6, 6)]
+        [InlineData(surrogateChar + surrogateChar + surrogateChar, 7, 6)]
         [Trait("Type", "Unit")]
-        [Fact(DisplayName = "StringExtensions Elide 4-")]
-        public static void When_elide_string_lte_4()
+        [Theory(DisplayName = nameof(When_elide_string_boundary))]
+        public static void When_elide_string_boundary(string str, int totalWidth, int expected)
         {
-            var tests = new[] { "A", "AB", "ABC", "ABCD" };
+            var actual = str.Elide(totalWidth);
 
-            foreach (var test in tests)
-            {
-                for (var totalWidth = -1; totalWidth < 10; totalWidth++)
-                {
-                    var expected = test;
-                    var actual = test.Elide(totalWidth);
-
-                    Assert.Equal(expected.Length, actual.Length);
-                    Assert.Equal(expected, actual);
-                }
-            }
-        }
-
-        [Trait("Type", "Unit")]
-        [Fact(DisplayName = "StringExtensions Elide 5+")]
-        public static void When_elide_string_gte_5()
-        {
-            var tests = new[] { "ABCDE", "ABCDEF", "ABCDEFG", "ABCDEFGHIJKLMNOP", LongStr };
-
-            foreach (var test in tests)
-            {
-                for (var totalWidth = -1; totalWidth <= 4; totalWidth++)
-                {
-                    var expected = test;
-                    var actual = test.Elide(totalWidth);
-
-                    Assert.Equal(expected.Length, actual.Length);
-                    Assert.Equal(expected, actual);
-                }
-
-                for (var totalWidth = 5; totalWidth < test.Length + 10; totalWidth++)
-                {
-                    var expected = test.Length <= totalWidth ? test : test.Left(totalWidth - 3) + @"...";
-                    var actual = test.Elide(totalWidth);
-
-                    Assert.Equal(expected.Length, actual.Length);
-                    Assert.Equal(expected, actual);
-                }
-            }
+            Assert.Equal(expected, actual.Length);
         }
 
         [InlineData(null, null, true)]

--- a/src/SourceCode.Clay.Tests/StringExtensionsTests.cs
+++ b/src/SourceCode.Clay.Tests/StringExtensionsTests.cs
@@ -6,10 +6,10 @@ namespace SourceCode.Clay.Tests
     public static class StringExtensionsTests
     {
         private const string LongStr = @"From Wikipedia: Astley was born on 6 February 1966 in Newton-le-Willows in Lancashire, the fourth child of his family. His parents divorced when he was five, and Astley was brought up by his father.[9] His musical career started when he was ten, singing in the local church choir.[10] During his schooldays, Astley formed and played the drums in a number of local bands, where he met guitarist David Morris.[2][11] After leaving school at sixteen, Astley was employed during the day as a driver in his father's market-gardening business and played drums on the Northern club circuit at night in bands such as Give Way – specialising in covering Beatles and Shadows songs – and FBI, which won several local talent competitions.[10]";
-        private const string surrogateChar = "\uD869\uDE01";
+        private const string _surrogatePair = "\uD869\uDE01";
 
         [Trait("Type", "Unit")]
-        [Fact(DisplayName = "StringExtensions Left")]
+        [Fact(DisplayName = nameof(When_left_string))]
         public static void When_left_string()
         {
             // Null
@@ -61,7 +61,7 @@ namespace SourceCode.Clay.Tests
                 string s = null;
                 for (var i = -1; i < 10; i++)
                 {
-                    var ln = System.Math.Max(0, System.Math.Min(i - 1, len));
+                    var ln = Math.Max(0, Math.Min(i - 1, len));
                     var expected = string.IsNullOrEmpty(s) ? s : s.Substring(0, ln);
 
                     actual = s.Left(len);
@@ -73,7 +73,7 @@ namespace SourceCode.Clay.Tests
         }
 
         [Trait("Type", "Unit")]
-        [Fact(DisplayName = "StringExtensions Right")]
+        [Fact(DisplayName = nameof(When_right_string))]
         public static void When_right_string()
         {
             // Null
@@ -125,7 +125,7 @@ namespace SourceCode.Clay.Tests
                 string s = null;
                 for (var i = -1; i < 10; i++)
                 {
-                    var ln = System.Math.Max(0, System.Math.Min(i - 1, len));
+                    var ln = Math.Max(0, Math.Min(i - 1, len));
                     var expected = string.IsNullOrEmpty(s) ? s : s.Substring(0, ln);
 
                     actual = s.Right(len);
@@ -137,7 +137,7 @@ namespace SourceCode.Clay.Tests
         }
 
         [Trait("Type", "Unit")]
-        [Fact(DisplayName = "StringExtensions Elide Null")]
+        [Fact(DisplayName = nameof(When_elide_string_null))]
         public static void When_elide_string_null()
         {
             for (var totalWidth = -1; totalWidth < 10; totalWidth++)
@@ -149,7 +149,7 @@ namespace SourceCode.Clay.Tests
         }
 
         [Trait("Type", "Unit")]
-        [Fact(DisplayName = "StringExtensions Elide Empty")]
+        [Fact(DisplayName = nameof(When_elide_string_empty))]
         public static void When_elide_string_empty()
         {
             for (var totalWidth = -1; totalWidth < 10; totalWidth++)
@@ -166,11 +166,11 @@ namespace SourceCode.Clay.Tests
         [InlineData("A", 1, 1)]
         [InlineData("A", 2, 1)]
         // Wide-1
-        [InlineData(surrogateChar, -1, 2)]
-        [InlineData(surrogateChar, 0, 2)]
-        [InlineData(surrogateChar, 1, 2)]
-        [InlineData(surrogateChar, 2, 2)]
-        [InlineData(surrogateChar, 3, 2)]
+        [InlineData(_surrogatePair, -1, 2)]
+        [InlineData(_surrogatePair, 0, 2)]
+        [InlineData(_surrogatePair, 1, 2)]
+        [InlineData(_surrogatePair, 2, 2)]
+        [InlineData(_surrogatePair, 3, 2)]
         // Narrow-2
         [InlineData("AB", -1, 2)]
         [InlineData("AB", 0, 2)]
@@ -178,13 +178,13 @@ namespace SourceCode.Clay.Tests
         [InlineData("AB", 2, 2)]
         [InlineData("AB", 3, 2)]
         // Wide-2
-        [InlineData(surrogateChar + surrogateChar, -1, 4)]
-        [InlineData(surrogateChar + surrogateChar, 0, 4)]
-        [InlineData(surrogateChar + surrogateChar, 1, 4)]
-        [InlineData(surrogateChar + surrogateChar, 2, 4)]
-        [InlineData(surrogateChar + surrogateChar, 3, 3)]
-        [InlineData(surrogateChar + surrogateChar, 4, 4)]
-        [InlineData(surrogateChar + surrogateChar, 5, 4)]
+        [InlineData(_surrogatePair + _surrogatePair, -1, 4)]
+        [InlineData(_surrogatePair + _surrogatePair, 0, 4)]
+        [InlineData(_surrogatePair + _surrogatePair, 1, 4)]
+        [InlineData(_surrogatePair + _surrogatePair, 2, 4)]
+        [InlineData(_surrogatePair + _surrogatePair, 3, 3)]
+        [InlineData(_surrogatePair + _surrogatePair, 4, 4)]
+        [InlineData(_surrogatePair + _surrogatePair, 5, 4)]
         // Narrow-3
         [InlineData("ABC", -1, 3)]
         [InlineData("ABC", 0, 3)]
@@ -193,15 +193,15 @@ namespace SourceCode.Clay.Tests
         [InlineData("ABC", 3, 3)]
         [InlineData("ABC", 4, 3)]
         // Wide-3
-        [InlineData(surrogateChar + surrogateChar + surrogateChar, -1, 6)]
-        [InlineData(surrogateChar + surrogateChar + surrogateChar, 0, 6)]
-        [InlineData(surrogateChar + surrogateChar + surrogateChar, 1, 6)]
-        [InlineData(surrogateChar + surrogateChar + surrogateChar, 2, 6)]
-        [InlineData(surrogateChar + surrogateChar + surrogateChar, 3, 3)]
-        [InlineData(surrogateChar + surrogateChar + surrogateChar, 4, 3)]
-        [InlineData(surrogateChar + surrogateChar + surrogateChar, 5, 5)]
-        [InlineData(surrogateChar + surrogateChar + surrogateChar, 6, 6)]
-        [InlineData(surrogateChar + surrogateChar + surrogateChar, 7, 6)]
+        [InlineData(_surrogatePair + _surrogatePair + _surrogatePair, -1, 6)]
+        [InlineData(_surrogatePair + _surrogatePair + _surrogatePair, 0, 6)]
+        [InlineData(_surrogatePair + _surrogatePair + _surrogatePair, 1, 6)]
+        [InlineData(_surrogatePair + _surrogatePair + _surrogatePair, 2, 6)]
+        [InlineData(_surrogatePair + _surrogatePair + _surrogatePair, 3, 3)]
+        [InlineData(_surrogatePair + _surrogatePair + _surrogatePair, 4, 3)]
+        [InlineData(_surrogatePair + _surrogatePair + _surrogatePair, 5, 5)]
+        [InlineData(_surrogatePair + _surrogatePair + _surrogatePair, 6, 6)]
+        [InlineData(_surrogatePair + _surrogatePair + _surrogatePair, 7, 6)]
         [Trait("Type", "Unit")]
         [Theory(DisplayName = nameof(When_elide_string_boundary))]
         public static void When_elide_string_boundary(string str, int totalWidth, int expected)

--- a/src/SourceCode.Clay.Text.Tests/SourceCode.Clay.Text.Tests.csproj
+++ b/src/SourceCode.Clay.Text.Tests/SourceCode.Clay.Text.Tests.csproj
@@ -15,7 +15,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0-preview-20170914-09" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0-preview-20170923-02" />
     <PackageReference Include="xunit" Version="2.3.0-beta5-build3769" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.0-beta5-build3769" />
   </ItemGroup>

--- a/src/SourceCode.Clay.Text/OrdinalIgnoreCaseString.cs
+++ b/src/SourceCode.Clay.Text/OrdinalIgnoreCaseString.cs
@@ -7,28 +7,44 @@ namespace SourceCode.Clay.Text
     /// Uses implicit conversions to/from <see cref="System.String"/>.
     /// </summary>
     /// <seealso cref="IEquatable{T}"/>
-    public struct OrdinalIgnoreCaseString : IEquatable<OrdinalIgnoreCaseString>, IEquatable<string>
+    public struct OrdinalIgnoreCaseString : IEquatable<OrdinalIgnoreCaseString>, IComparable<OrdinalIgnoreCaseString>
     {
+        #region Fields
+
         private readonly string _str;
+
+        #endregion
+
+        #region Constructors
 
         public OrdinalIgnoreCaseString(string str)
         {
             _str = str;
         }
 
-        public static implicit operator OrdinalIgnoreCaseString(string str)
-            => new OrdinalIgnoreCaseString(str);
+        #endregion
 
-        public static explicit operator string(OrdinalIgnoreCaseString str)
-            => str._str;
+        #region Operators
 
-        /// <summary>
-        /// Check equality using <see cref="System.StringComparison.OrdinalIgnoreCase"/>.
-        /// </summary>
-        /// <param name="other">The other string.</param>
-        /// <returns></returns>
-        public bool Equals(string other)
-            => StringComparer.OrdinalIgnoreCase.Equals(_str, other);
+        public static implicit operator OrdinalIgnoreCaseString(string str) => new OrdinalIgnoreCaseString(str);
+
+        public static explicit operator string(OrdinalIgnoreCaseString str) => str._str;
+
+        public static bool operator ==(OrdinalIgnoreCaseString x, OrdinalIgnoreCaseString y) => x.Equals(y);
+
+        public static bool operator !=(OrdinalIgnoreCaseString x, OrdinalIgnoreCaseString y) => !(x == y);
+
+        public static bool operator <(OrdinalIgnoreCaseString x, OrdinalIgnoreCaseString y) => x.CompareTo(y) < 0;
+
+        public static bool operator >(OrdinalIgnoreCaseString x, OrdinalIgnoreCaseString y) => x.CompareTo(y) > 0;
+
+        public static bool operator <=(OrdinalIgnoreCaseString x, OrdinalIgnoreCaseString y) => x.CompareTo(y) <= 0;
+
+        public static bool operator >=(OrdinalIgnoreCaseString x, OrdinalIgnoreCaseString y) => x.CompareTo(y) >= 0;
+
+        #endregion
+
+        #region IEquatable
 
         /// <summary>
         /// Check equality using <see cref="System.StringComparison.OrdinalIgnoreCase"/>.
@@ -58,6 +74,15 @@ namespace SourceCode.Clay.Text
         }
 
         public override int GetHashCode()
-            => _str?.GetHashCode() ?? 0;
+            => StringComparer.OrdinalIgnoreCase.GetHashCode(_str);
+
+        #endregion
+
+        #region IComparable
+
+        public int CompareTo(OrdinalIgnoreCaseString other)
+            => StringComparer.OrdinalIgnoreCase.Compare(_str, other._str);
+
+        #endregion
     }
 }

--- a/src/SourceCode.Clay.Text/OrdinalString.cs
+++ b/src/SourceCode.Clay.Text/OrdinalString.cs
@@ -7,28 +7,44 @@ namespace SourceCode.Clay.Text
     /// Uses implicit conversions to/from <see cref="System.String"/>.
     /// </summary>
     /// <seealso cref="IEquatable{T}"/>
-    public struct OrdinalString : IEquatable<OrdinalString>, IEquatable<string>
+    public struct OrdinalString : IEquatable<OrdinalString>, IComparable<OrdinalString>
     {
+        #region Fields
+
         private readonly string _str;
+
+        #endregion
+
+        #region Constructors
 
         public OrdinalString(string str)
         {
             _str = str;
         }
 
-        public static implicit operator OrdinalString(string str)
-            => new OrdinalString(str);
+        #endregion
 
-        public static explicit operator string(OrdinalString str)
-            => str._str;
+        #region Operators
 
-        /// <summary>
-        /// Check equality using <see cref="System.StringComparison.Ordinal"/>.
-        /// </summary>
-        /// <param name="other">The other string.</param>
-        /// <returns></returns>
-        public bool Equals(string other)
-            => StringComparer.Ordinal.Equals(_str, other);
+        public static implicit operator OrdinalString(string str) => new OrdinalString(str);
+
+        public static explicit operator string(OrdinalString str) => str._str;
+
+        public static bool operator ==(OrdinalString x, OrdinalString y) => x.Equals(y);
+
+        public static bool operator !=(OrdinalString x, OrdinalString y) => !(x == y);
+
+        public static bool operator <(OrdinalString x, OrdinalString y) => x.CompareTo(y) < 0;
+
+        public static bool operator >(OrdinalString x, OrdinalString y) => x.CompareTo(y) > 0;
+
+        public static bool operator <=(OrdinalString x, OrdinalString y) => x.CompareTo(y) <= 0;
+
+        public static bool operator >=(OrdinalString x, OrdinalString y) => x.CompareTo(y) >= 0;
+
+        #endregion
+
+        #region IEquatable
 
         /// <summary>
         /// Check equality using <see cref="System.StringComparison.Ordinal"/>.
@@ -58,6 +74,15 @@ namespace SourceCode.Clay.Text
         }
 
         public override int GetHashCode()
-            => _str?.GetHashCode() ?? 0;
+            => StringComparer.Ordinal.GetHashCode(_str);
+
+        #endregion
+
+        #region IComparable
+
+        public int CompareTo(OrdinalString other)
+            => string.CompareOrdinal(_str, other._str);
+
+        #endregion
     }
 }

--- a/src/SourceCode.Clay.Text/SourceCode.Clay.Text.csproj
+++ b/src/SourceCode.Clay.Text/SourceCode.Clay.Text.csproj
@@ -10,6 +10,7 @@
 
   <PropertyGroup>
     <Description>Tools and extensions for working with text.</Description>
+    <PackageLicenseUrl>https://github.com/k2workflow/Clay/blob/master/LICENSE</PackageLicenseUrl>
     <PackageTags>clay utility extension string stringbuilder</PackageTags>
   </PropertyGroup>
 

--- a/src/SourceCode.Clay/SourceCode.Clay.csproj
+++ b/src/SourceCode.Clay/SourceCode.Clay.csproj
@@ -10,7 +10,8 @@
 
   <PropertyGroup>
     <Description>Tools and extensions to the .Net framework.</Description>
-    <PackageTags>clay utility extension string datetime</PackageTags>
+    <PackageLicenseUrl>https://github.com/k2workflow/Clay/blob/master/LICENSE</PackageLicenseUrl>
+    <PackageTags>clay utility extension string datetime number</PackageTags>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/SourceCode.Clay/StringExtensions.cs
+++ b/src/SourceCode.Clay/StringExtensions.cs
@@ -21,6 +21,8 @@ namespace SourceCode.Clay
             var len = length <= 0 ? 0 : length;
 
             if (str == null || str.Length <= len) return str;
+
+            // Per Substring behavior, we don't respect surrogate pairs
             return str.Substring(0, len);
         }
 
@@ -37,6 +39,8 @@ namespace SourceCode.Clay
             var len = length <= 0 ? 0 : length;
 
             if (str == null || str.Length <= len) return str;
+
+            // Per Substring behavior, we don't respect surrogate pairs
             return str.Substring(str.Length - len, len);
         }
 
@@ -51,10 +55,14 @@ namespace SourceCode.Clay
         /// <param name="str">The string.</param>
         /// <param name="totalWidth">The total width.</param>
         /// <returns>The elided string.</returns>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static string Elide(this string str, int totalWidth)
         {
             if (str == null || totalWidth <= 2 || str.Length <= totalWidth) return str;
+
+            // Since Elide is expected to be used primarily for display purposes, it needs to respect
+            // surrogate pairs and not blindly split them in half.
+            // https://stackoverflow.com/questions/2241348/what-is-unicode-utf-8-utf-16
+            // https://stackoverflow.com/questions/14347799/how-do-i-create-a-string-with-a-surrogate-pair-inside-of-it
 
             var ca = str.ToCharArray();
 
@@ -67,6 +75,8 @@ namespace SourceCode.Clay
                 // If target is the LOW surrogate, replace both (returning a shorter-by-1-than-expected result)
                 if (char.IsLowSurrogate(ca[totalWidth - 1]))
                     n = 1;
+
+                // It it's the HIGH surrogate, we're replacing it regardless
             }
             // Low|High
             else
@@ -74,6 +84,8 @@ namespace SourceCode.Clay
                 // If target is the HIGH surrogate, replace both (returning a shorter-by-1-than-expected result)
                 if (char.IsHighSurrogate(ca[totalWidth - 1]))
                     n = 1;
+
+                // It it's the LOW surrogate, we're replacing it regardless
             }
 
             ca[totalWidth - n - 1] = '…';

--- a/src/SourceCode.Clay/StringExtensions.cs
+++ b/src/SourceCode.Clay/StringExtensions.cs
@@ -63,5 +63,21 @@ namespace SourceCode.Clay
 
             return new string(ca);
         }
+
+        /// <summary>
+        /// Compares two strings using ordinal rules, with checks for null and reference equality.
+        /// A partner for the framework-provided <see cref="string.CompareOrdinal(string, string)"/> method.
+        /// </summary>
+        /// <param name="x"></param>
+        /// <param name="y"></param>
+        /// <returns></returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool EqualsOrdinal(this string x, string y)
+        {
+            if (x == y) return true; // (null, null) or (s, s)
+            if (x == null || y == null) return false; // (s, null) or (null, t)
+
+            return x.Equals(y); // (s, t)
+        }
     }
 }


### PR DESCRIPTION
Fixes #52 (surrogate-pair)
Fixes #50 (Nuget License)

- `OrdinalString` should implement `IComparable<T>`