### PR TITLE
Missing Defaults and CodeMaid

### DIFF
--- a/CodeMaid.config
+++ b/CodeMaid.config
@@ -1,118 +1,180 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
-    <configSections>
-        <sectionGroup name="userSettings" type="System.Configuration.UserSettingsGroup, System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" >
-            <section name="SteveCadwallader.CodeMaid.Properties.Settings" type="System.Configuration.ClientSettingsSection, System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
-        </sectionGroup>
-    </configSections>
-    <userSettings>
-        <SteveCadwallader.CodeMaid.Properties.Settings>
-            <setting name="Cleaning_InsertExplicitAccessModifiersOnStructs"
-                serializeAs="String">
-                <value>False</value>
-            </setting>
-            <setting name="Cleaning_SkipRemoveUnusedUsingStatementsDuringAutoCleanupOnSave"
-                serializeAs="String">
-                <value>False</value>
-            </setting>
-            <setting name="Cleaning_InsertEndOfFileTrailingNewLine" serializeAs="String">
-                <value>True</value>
-            </setting>
-            <setting name="Collapsing_CollapseSolutionWhenOpened" serializeAs="String">
-                <value>False</value>
-            </setting>
-            <setting name="Cleaning_AutoCleanupOnFileSave" serializeAs="String">
-                <value>True</value>
-            </setting>
-            <setting name="Cleaning_InsertExplicitAccessModifiersOnFields"
-                serializeAs="String">
-                <value>False</value>
-            </setting>
-            <setting name="Digging_SynchronizeOutlining" serializeAs="String">
-                <value>False</value>
-            </setting>
-            <setting name="Cleaning_InsertExplicitAccessModifiersOnMethods"
-                serializeAs="String">
-                <value>False</value>
-            </setting>
-            <setting name="Digging_ShowItemComplexity" serializeAs="String">
-                <value>False</value>
-            </setting>
-            <setting name="Cleaning_InsertExplicitAccessModifiersOnProperties"
-                serializeAs="String">
-                <value>False</value>
-            </setting>
-            <setting name="Digging_ShowItemMetadata" serializeAs="String">
-                <value>False</value>
-            </setting>
-            <setting name="Cleaning_InsertExplicitAccessModifiersOnClasses"
-                serializeAs="String">
-                <value>False</value>
-            </setting>
-            <setting name="Cleaning_RemoveEndOfFileTrailingNewLine" serializeAs="String">
-                <value>False</value>
-            </setting>
-            <setting name="Cleaning_InsertExplicitAccessModifiersOnDelegates"
-                serializeAs="String">
-                <value>False</value>
-            </setting>
-            <setting name="Cleaning_InsertExplicitAccessModifiersOnEnumerations"
-                serializeAs="String">
-                <value>False</value>
-            </setting>
-            <setting name="Cleaning_InsertExplicitAccessModifiersOnEvents"
-                serializeAs="String">
-                <value>False</value>
-            </setting>
-            <setting name="Cleaning_UpdateEndRegionDirectives" serializeAs="String">
-                <value>False</value>
-            </setting>
-            <setting name="Cleaning_InsertExplicitAccessModifiersOnInterfaces"
-                serializeAs="String">
-                <value>False</value>
-            </setting>
-            <setting name="Digging_ShowMethodParameters" serializeAs="String">
-                <value>False</value>
-            </setting>
-            <setting name="Progressing_ShowBuildProgressOnBuildStart" serializeAs="String">
-                <value>False</value>
-            </setting>
-            <setting name="Progressing_ShowProgressOnWindowsTaskbar" serializeAs="String">
-                <value>False</value>
-            </setting>
-            <setting name="Progressing_HideBuildProgressOnBuildStop" serializeAs="String">
-                <value>False</value>
-            </setting>
-            <setting name="Finding_TemporarilyOpenSolutionFolders" serializeAs="String">
-                <value>False</value>
-            </setting>
-            <setting name="Reorganizing_RegionsInsertKeepEvenIfEmpty" serializeAs="String">
-                <value>False</value>
-            </setting>
-            <setting name="Cleaning_PerformPartialCleanupOnExternal" serializeAs="String">
-                <value>1</value>
-            </setting>
-            <setting name="General_IconSet" serializeAs="String">
-                <value>3</value>
-            </setting>
-            <setting name="General_Theme" serializeAs="String">
-                <value>1</value>
-            </setting>
-            <setting name="General_UseUndoTransactions" serializeAs="String">
-                <value>False</value>
-            </setting>
-            <setting name="General_CacheFiles" serializeAs="String">
-                <value>False</value>
-            </setting>
-            <setting name="General_LoadModelsAsynchronously" serializeAs="String">
-                <value>False</value>
-            </setting>
-            <setting name="Reorganizing_ExplicitMembersAtEnd" serializeAs="String">
-                <value>True</value>
-            </setting>
-            <setting name="General_Font" serializeAs="String">
-                <value>Segoe UI</value>
-            </setting>
-        </SteveCadwallader.CodeMaid.Properties.Settings>
-    </userSettings>
+  <configSections>
+    <sectionGroup name="userSettings" type="System.Configuration.UserSettingsGroup, System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+      <section name="SteveCadwallader.CodeMaid.Properties.Settings" type="System.Configuration.ClientSettingsSection, System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+    </sectionGroup>
+  </configSections>
+  <userSettings>
+    <SteveCadwallader.CodeMaid.Properties.Settings>
+      <setting name="Cleaning_InsertExplicitAccessModifiersOnStructs"
+        serializeAs="String">
+        <value>True</value>
+      </setting>
+      <setting name="Cleaning_SkipRemoveUnusedUsingStatementsDuringAutoCleanupOnSave"
+        serializeAs="String">
+        <value>False</value>
+      </setting>
+      <setting name="Cleaning_InsertEndOfFileTrailingNewLine" serializeAs="String">
+        <value>True</value>
+      </setting>
+      <setting name="Collapsing_CollapseSolutionWhenOpened" serializeAs="String">
+        <value>False</value>
+      </setting>
+      <setting name="Cleaning_AutoCleanupOnFileSave" serializeAs="String">
+        <value>True</value>
+      </setting>
+      <setting name="Cleaning_InsertExplicitAccessModifiersOnFields"
+        serializeAs="String">
+        <value>True</value>
+      </setting>
+      <setting name="Digging_SynchronizeOutlining" serializeAs="String">
+        <value>False</value>
+      </setting>
+      <setting name="Cleaning_InsertExplicitAccessModifiersOnMethods"
+        serializeAs="String">
+        <value>True</value>
+      </setting>
+      <setting name="Digging_ShowItemComplexity" serializeAs="String">
+        <value>False</value>
+      </setting>
+      <setting name="Cleaning_InsertExplicitAccessModifiersOnProperties"
+        serializeAs="String">
+        <value>True</value>
+      </setting>
+      <setting name="Digging_ShowItemMetadata" serializeAs="String">
+        <value>False</value>
+      </setting>
+      <setting name="Cleaning_InsertExplicitAccessModifiersOnClasses"
+        serializeAs="String">
+        <value>True</value>
+      </setting>
+      <setting name="Cleaning_RemoveEndOfFileTrailingNewLine" serializeAs="String">
+        <value>False</value>
+      </setting>
+      <setting name="Cleaning_InsertExplicitAccessModifiersOnDelegates"
+        serializeAs="String">
+        <value>True</value>
+      </setting>
+      <setting name="Cleaning_InsertExplicitAccessModifiersOnEnumerations"
+        serializeAs="String">
+        <value>True</value>
+      </setting>
+      <setting name="Cleaning_InsertExplicitAccessModifiersOnEvents"
+        serializeAs="String">
+        <value>True</value>
+      </setting>
+      <setting name="Cleaning_UpdateEndRegionDirectives" serializeAs="String">
+        <value>False</value>
+      </setting>
+      <setting name="Cleaning_InsertExplicitAccessModifiersOnInterfaces"
+        serializeAs="String">
+        <value>True</value>
+      </setting>
+      <setting name="Digging_ShowMethodParameters" serializeAs="String">
+        <value>False</value>
+      </setting>
+      <setting name="Progressing_ShowBuildProgressOnBuildStart" serializeAs="String">
+        <value>False</value>
+      </setting>
+      <setting name="Progressing_ShowProgressOnWindowsTaskbar" serializeAs="String">
+        <value>False</value>
+      </setting>
+      <setting name="Progressing_HideBuildProgressOnBuildStop" serializeAs="String">
+        <value>False</value>
+      </setting>
+      <setting name="Finding_TemporarilyOpenSolutionFolders" serializeAs="String">
+        <value>False</value>
+      </setting>
+      <setting name="Reorganizing_RegionsInsertKeepEvenIfEmpty" serializeAs="String">
+        <value>False</value>
+      </setting>
+      <setting name="Cleaning_PerformPartialCleanupOnExternal" serializeAs="String">
+        <value>1</value>
+      </setting>
+      <setting name="General_IconSet" serializeAs="String">
+        <value>3</value>
+      </setting>
+      <setting name="General_Theme" serializeAs="String">
+        <value>1</value>
+      </setting>
+      <setting name="General_UseUndoTransactions" serializeAs="String">
+        <value>False</value>
+      </setting>
+      <setting name="General_CacheFiles" serializeAs="String">
+        <value>False</value>
+      </setting>
+      <setting name="General_LoadModelsAsynchronously" serializeAs="String">
+        <value>False</value>
+      </setting>
+      <setting name="Reorganizing_ExplicitMembersAtEnd" serializeAs="String">
+        <value>True</value>
+      </setting>
+      <setting name="General_Font" serializeAs="String">
+        <value>Segoe UI</value>
+      </setting>
+      <setting name="Reorganizing_AlphabetizeMembersOfTheSameGroup"
+        serializeAs="String">
+        <value>False</value>
+      </setting>
+      <setting name="Reorganizing_ReverseOrderByAccessLevel" serializeAs="String">
+        <value>True</value>
+      </setting>
+      <setting name="Reorganizing_MemberTypeConstructors" serializeAs="String">
+        <value>Constructors||5||Constructors</value>
+      </setting>
+      <setting name="Reorganizing_MemberTypeMethods" serializeAs="String">
+        <value>Methods||7||Methods</value>
+      </setting>
+      <setting name="Reorganizing_MemberTypeProperties" serializeAs="String">
+        <value>Properties||2||Properties</value>
+      </setting>
+      <setting name="Reorganizing_MemberTypeEnums" serializeAs="String">
+        <value>Enums||9||Enums</value>
+      </setting>
+      <setting name="Reorganizing_MemberTypeDestructors" serializeAs="String">
+        <value>Destructors||6||Destructors</value>
+      </setting>
+      <setting name="Reorganizing_RegionsInsertNewRegions" serializeAs="String">
+        <value>True</value>
+      </setting>
+      <setting name="Reorganizing_MemberTypeDelegates" serializeAs="String">
+        <value>Delegates||8||Delegates</value>
+      </setting>
+      <setting name="Reorganizing_MemberTypeIndexers" serializeAs="String">
+        <value>Indexers||3||Indexers</value>
+      </setting>
+      <setting name="Reorganizing_MemberTypeEvents" serializeAs="String">
+        <value>Events||4||Events</value>
+      </setting>
+      <setting name="Reorganizing_MemberTypeInterfaces" serializeAs="String">
+        <value>Interfaces||10||Interfaces</value>
+      </setting>
+      <setting name="Formatting_CommentRunDuringCleanup" serializeAs="String">
+        <value>False</value>
+      </setting>
+      <setting name="Formatting_CommentXmlValueIndent" serializeAs="String">
+        <value>2</value>
+      </setting>
+      <setting name="Reorganizing_PerformWhenPreprocessorConditionals"
+        serializeAs="String">
+        <value>2</value>
+      </setting>
+      <setting name="Reorganizing_RunAtStartOfCleanup" serializeAs="String">
+        <value>True</value>
+      </setting>
+      <setting name="Reorganizing_PrimaryOrderByAccessLevel" serializeAs="String">
+        <value>True</value>
+      </setting>
+      <setting name="Cleaning_UpdateFileHeaderCSharp" serializeAs="String">
+        <value>#region License
+
+// Copyright (c) K2 Workflow (SourceCode Technology Holdings Inc.). All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+#endregion
+</value>
+      </setting>
+    </SteveCadwallader.CodeMaid.Properties.Settings>
+  </userSettings>
 </configuration>

--- a/SourceCode.Clay.sln
+++ b/SourceCode.Clay.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
-VisualStudioVersion = 15.0.26929.2
+VisualStudioVersion = 15.0.26730.16
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SourceCode.Clay", "src\SourceCode.Clay\SourceCode.Clay.csproj", "{D029C294-B983-4173-9220-550175041CC0}"
 EndProject
@@ -38,6 +38,11 @@ EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SourceCode.Clay.Threading", "src\SourceCode.Clay.Threading\SourceCode.Clay.Threading.csproj", "{EC96B9A0-9244-4AA3-B6FA-366C1226ACCD}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SourceCode.Clay.Threading.Tests", "src\SourceCode.Clay.Threading.Tests\SourceCode.Clay.Threading.Tests.csproj", "{E23B716F-DAF6-42EF-A5A8-DDEFAD26D916}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "files", "files", "{B2F708DF-EF63-4F62-A95D-9A148D01421E}"
+	ProjectSection(SolutionItems) = preProject
+		LICENSE = LICENSE
+	EndProjectSection
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/src/SourceCode.Clay.Buffers.Tests/Blit16Tests.cs
+++ b/src/SourceCode.Clay.Buffers.Tests/Blit16Tests.cs
@@ -1,10 +1,19 @@
-﻿using System;
+#region License
+
+// Copyright (c) K2 Workflow (SourceCode Technology Holdings Inc.). All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+#endregion
+
+using System;
 using Xunit;
 
 namespace SourceCode.Clay.Buffers.Tests
 {
     public static class Blit16Tests
     {
+        #region Methods
+
         [Trait("Type", "Unit")]
         [Fact(DisplayName = nameof(When_blitting_UInt16_to_Int16))]
         public static void When_blitting_UInt16_to_Int16()
@@ -48,5 +57,7 @@ namespace SourceCode.Clay.Buffers.Tests
                 Assert.Equal(actual.Byte1, actual.Blit1.Byte);
             }
         }
+
+        #endregion
     }
 }

--- a/src/SourceCode.Clay.Buffers.Tests/Blit32Tests.cs
+++ b/src/SourceCode.Clay.Buffers.Tests/Blit32Tests.cs
@@ -1,10 +1,19 @@
-﻿using System;
+#region License
+
+// Copyright (c) K2 Workflow (SourceCode Technology Holdings Inc.). All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+#endregion
+
+using System;
 using Xunit;
 
 namespace SourceCode.Clay.Buffers.Tests
 {
     public static class Blit32Tests
     {
+        #region Methods
+
         [Trait("Type", "Unit")]
         [Fact(DisplayName = nameof(When_blitting_UInt32_to_Int32))]
         public static void When_blitting_UInt32_to_Int32()
@@ -56,5 +65,7 @@ namespace SourceCode.Clay.Buffers.Tests
                 Assert.Equal(actual.Byte3, actual.Blit1.Byte1);
             }
         }
+
+        #endregion
     }
 }

--- a/src/SourceCode.Clay.Buffers.Tests/Blit64Tests.cs
+++ b/src/SourceCode.Clay.Buffers.Tests/Blit64Tests.cs
@@ -1,10 +1,19 @@
-﻿using System;
+#region License
+
+// Copyright (c) K2 Workflow (SourceCode Technology Holdings Inc.). All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+#endregion
+
+using System;
 using Xunit;
 
 namespace SourceCode.Clay.Buffers.Tests
 {
     public static class Blit64Tests
     {
+        #region Methods
+
         [Trait("Type", "Unit")]
         [Fact(DisplayName = nameof(When_blitting_UInt64_to_Int64))]
         public static void When_blitting_UInt64_to_Int64()
@@ -74,5 +83,7 @@ namespace SourceCode.Clay.Buffers.Tests
                 Assert.Equal(actual.Byte7, actual.Blit1.Byte3);
             }
         }
+
+        #endregion
     }
 }

--- a/src/SourceCode.Clay.Buffers.Tests/Blit8Tests.cs
+++ b/src/SourceCode.Clay.Buffers.Tests/Blit8Tests.cs
@@ -1,9 +1,18 @@
-﻿using Xunit;
+#region License
+
+// Copyright (c) K2 Workflow (SourceCode Technology Holdings Inc.). All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+#endregion
+
+using Xunit;
 
 namespace SourceCode.Clay.Buffers.Tests
 {
     public static class Blit8Tests
     {
+        #region Methods
+
         [Trait("Type", "Unit")]
         [Fact(DisplayName = nameof(When_blitting_byte_to_sbyte))]
         public static void When_blitting_byte_to_sbyte()
@@ -39,5 +48,7 @@ namespace SourceCode.Clay.Buffers.Tests
                 Assert.Equal(expected, bytes[0]);
             }
         }
+
+        #endregion
     }
 }

--- a/src/SourceCode.Clay.Buffers.Tests/BlitTests.cs
+++ b/src/SourceCode.Clay.Buffers.Tests/BlitTests.cs
@@ -1,9 +1,18 @@
-﻿using Xunit;
+#region License
+
+// Copyright (c) K2 Workflow (SourceCode Technology Holdings Inc.). All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+#endregion
+
+using Xunit;
 
 namespace SourceCode.Clay.Buffers.Tests
 {
     public static class BlitTests
     {
+        #region Methods
+
         [Fact(DisplayName = nameof(Blit_RotateLeft_Byte))]
         public static void Blit_RotateLeft_Byte()
         {
@@ -75,5 +84,7 @@ namespace SourceCode.Clay.Buffers.Tests
             Assert.Equal((ulong)0b01010101_01010101_01010101_01010101_01010101_01010101_01010101_01010101, Blit.RotateRight(sut, 2));
             Assert.Equal((ulong)0b10101010_10101010_10101010_10101010_10101010_10101010_10101010_10101010, Blit.RotateRight(sut, 3));
         }
+
+        #endregion
     }
 }

--- a/src/SourceCode.Clay.Buffers.Tests/BufferComparerTests.cs
+++ b/src/SourceCode.Clay.Buffers.Tests/BufferComparerTests.cs
@@ -1,4 +1,11 @@
-﻿using System;
+#region License
+
+// Copyright (c) K2 Workflow (SourceCode Technology Holdings Inc.). All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+#endregion
+
+using System;
 using System.Collections.Generic;
 using Xunit;
 

--- a/src/SourceCode.Clay.Buffers.Tests/BufferSessionTests.cs
+++ b/src/SourceCode.Clay.Buffers.Tests/BufferSessionTests.cs
@@ -1,10 +1,19 @@
-﻿using System;
+#region License
+
+// Copyright (c) K2 Workflow (SourceCode Technology Holdings Inc.). All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+#endregion
+
+using System;
 using Xunit;
 
 namespace SourceCode.Clay.Buffers.Tests
 {
     public static class BufferSessionTests
     {
+        #region Methods
+
         [Trait("Type", "Unit")]
         [Fact(DisplayName = nameof(BufferSession_Full_Lifecycle))]
         public static void BufferSession_Full_Lifecycle()
@@ -24,5 +33,7 @@ namespace SourceCode.Clay.Buffers.Tests
 
             Assert.Null(session.Buffer);
         }
+
+        #endregion
     }
 }

--- a/src/SourceCode.Clay.Buffers.Tests/ReadOnlyListWrapper.cs
+++ b/src/SourceCode.Clay.Buffers.Tests/ReadOnlyListWrapper.cs
@@ -1,23 +1,50 @@
-﻿using System.Collections;
+#region License
+
+// Copyright (c) K2 Workflow (SourceCode Technology Holdings Inc.). All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+#endregion
+
+using System.Collections;
 using System.Collections.Generic;
 
 namespace SourceCode.Clay.Buffers.Tests
 {
     internal sealed class ReadOnlyListWrapper<T> : IReadOnlyList<T>
     {
-        public T this[int index] => _list[index];
+        #region Fields
+
+        private readonly IReadOnlyList<T> _list;
+
+        #endregion
+
+        #region Properties
 
         public int Count => _list.Count;
 
-        private readonly IReadOnlyList<T> _list;
+        #endregion
+
+        #region Indexers
+
+        public T this[int index] => _list[index];
+
+        #endregion
+
+        #region Constructors
 
         public ReadOnlyListWrapper(IReadOnlyList<T> list)
         {
             _list = list;
         }
 
+        #endregion
+
+        #region Methods
+
         public IEnumerator<T> GetEnumerator() => _list.GetEnumerator();
 
         IEnumerator IEnumerable.GetEnumerator() => _list.GetEnumerator();
+
+        #endregion
     }
 }

--- a/src/SourceCode.Clay.Buffers/ArrayBufferComparer.cs
+++ b/src/SourceCode.Clay.Buffers/ArrayBufferComparer.cs
@@ -1,4 +1,11 @@
-﻿using System;
+#region License
+
+// Copyright (c) K2 Workflow (SourceCode Technology Holdings Inc.). All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+#endregion
+
+using System;
 
 namespace SourceCode.Clay.Buffers
 {

--- a/src/SourceCode.Clay.Buffers/Blit.cs
+++ b/src/SourceCode.Clay.Buffers/Blit.cs
@@ -1,4 +1,11 @@
-﻿using System.Runtime.CompilerServices;
+#region License
+
+// Copyright (c) K2 Workflow (SourceCode Technology Holdings Inc.). All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+#endregion
+
+using System.Runtime.CompilerServices;
 
 namespace SourceCode.Clay.Buffers
 {
@@ -7,6 +14,8 @@ namespace SourceCode.Clay.Buffers
     /// </summary>
     public static class Blit
     {
+        #region Methods
+
         /// <summary>
         /// Rotates the specified <see cref="byte"/> value left by the specified number of bits.
         /// </summary>
@@ -118,5 +127,7 @@ namespace SourceCode.Clay.Buffers
 
             return unchecked((value >> b) | (value << (64 - b)));
         }
+
+        #endregion
     }
 }

--- a/src/SourceCode.Clay.Buffers/Blit16.cs
+++ b/src/SourceCode.Clay.Buffers/Blit16.cs
@@ -1,4 +1,11 @@
-﻿using System.Diagnostics;
+#region License
+
+// Copyright (c) K2 Workflow (SourceCode Technology Holdings Inc.). All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+#endregion
+
+using System.Diagnostics;
 using System.Runtime.InteropServices;
 
 namespace SourceCode.Clay.Buffers

--- a/src/SourceCode.Clay.Buffers/Blit32.cs
+++ b/src/SourceCode.Clay.Buffers/Blit32.cs
@@ -1,4 +1,11 @@
-﻿using System.Diagnostics;
+#region License
+
+// Copyright (c) K2 Workflow (SourceCode Technology Holdings Inc.). All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+#endregion
+
+using System.Diagnostics;
 using System.Runtime.InteropServices;
 
 namespace SourceCode.Clay.Buffers

--- a/src/SourceCode.Clay.Buffers/Blit64.cs
+++ b/src/SourceCode.Clay.Buffers/Blit64.cs
@@ -1,4 +1,11 @@
-﻿using System.Diagnostics;
+#region License
+
+// Copyright (c) K2 Workflow (SourceCode Technology Holdings Inc.). All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+#endregion
+
+using System.Diagnostics;
 using System.Runtime.InteropServices;
 
 namespace SourceCode.Clay.Buffers

--- a/src/SourceCode.Clay.Buffers/Blit8.cs
+++ b/src/SourceCode.Clay.Buffers/Blit8.cs
@@ -1,4 +1,11 @@
-﻿using System.Diagnostics;
+#region License
+
+// Copyright (c) K2 Workflow (SourceCode Technology Holdings Inc.). All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+#endregion
+
+using System.Diagnostics;
 using System.Runtime.InteropServices;
 
 namespace SourceCode.Clay.Buffers

--- a/src/SourceCode.Clay.Buffers/BufferComparer.T.cs
+++ b/src/SourceCode.Clay.Buffers/BufferComparer.T.cs
@@ -1,4 +1,11 @@
-﻿using System;
+#region License
+
+// Copyright (c) K2 Workflow (SourceCode Technology Holdings Inc.). All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+#endregion
+
+using System;
 using System.Collections.Generic;
 
 namespace SourceCode.Clay.Buffers

--- a/src/SourceCode.Clay.Buffers/BufferComparer.cs
+++ b/src/SourceCode.Clay.Buffers/BufferComparer.cs
@@ -1,4 +1,11 @@
-﻿using System;
+#region License
+
+// Copyright (c) K2 Workflow (SourceCode Technology Holdings Inc.). All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+#endregion
+
+using System;
 using System.Runtime.CompilerServices;
 using System.Security;
 

--- a/src/SourceCode.Clay.Buffers/BufferSession.cs
+++ b/src/SourceCode.Clay.Buffers/BufferSession.cs
@@ -1,4 +1,11 @@
-﻿using System;
+#region License
+
+// Copyright (c) K2 Workflow (SourceCode Technology Holdings Inc.). All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+#endregion
+
+using System;
 
 namespace SourceCode.Clay.Buffers
 {

--- a/src/SourceCode.Clay.Buffers/HashCode.Fnv.cs
+++ b/src/SourceCode.Clay.Buffers/HashCode.Fnv.cs
@@ -1,4 +1,11 @@
-﻿using System;
+#region License
+
+// Copyright (c) K2 Workflow (SourceCode Technology Holdings Inc.). All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+#endregion
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.CompilerServices;

--- a/src/SourceCode.Clay.Buffers/NativeMethods.cs
+++ b/src/SourceCode.Clay.Buffers/NativeMethods.cs
@@ -1,12 +1,23 @@
-﻿using System.Runtime.InteropServices;
+#region License
+
+// Copyright (c) K2 Workflow (SourceCode Technology Holdings Inc.). All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+#endregion
+
+using System.Runtime.InteropServices;
 using System.Security;
 
 namespace SourceCode.Clay.Buffers
 {
     internal static unsafe class NativeMethods
     {
+        #region Methods
+
         [DllImport("msvcrt.dll", EntryPoint = "memcmp", CallingConvention = CallingConvention.Cdecl, SetLastError = false)]
         [SecurityCritical]
         public static extern int MemCompare(byte* x, byte* y, int count);
+
+        #endregion
     }
 }

--- a/src/SourceCode.Clay.Buffers/Properties/AssemblyInfo.cs
+++ b/src/SourceCode.Clay.Buffers/Properties/AssemblyInfo.cs
@@ -1,1 +1,8 @@
-﻿[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("SourceCode.Clay.Buffers.Tests")]
+#region License
+
+// Copyright (c) K2 Workflow (SourceCode Technology Holdings Inc.). All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+#endregion
+
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("SourceCode.Clay.Buffers.Tests")]

--- a/src/SourceCode.Clay.Buffers/SpanBufferComparer.cs
+++ b/src/SourceCode.Clay.Buffers/SpanBufferComparer.cs
@@ -1,4 +1,11 @@
-﻿using System;
+#region License
+
+// Copyright (c) K2 Workflow (SourceCode Technology Holdings Inc.). All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+#endregion
+
+using System;
 
 namespace SourceCode.Clay.Buffers
 {

--- a/src/SourceCode.Clay.Collections.Bench/Int32SwitchVsDictionaryBench.cs
+++ b/src/SourceCode.Clay.Collections.Bench/Int32SwitchVsDictionaryBench.cs
@@ -1,4 +1,11 @@
-﻿using BenchmarkDotNet.Attributes;
+#region License
+
+// Copyright (c) K2 Workflow (SourceCode Technology Holdings Inc.). All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+#endregion
+
+using BenchmarkDotNet.Attributes;
 using BenchmarkDotNet.Running;
 using SourceCode.Clay.Collections.Generic;
 using System.Collections.Generic;
@@ -7,11 +14,17 @@ namespace SourceCode.Clay.Collections.Bench
 {
     public class Int32SwitchVsDictionaryBench
     {
+        #region Fields
+
         private const int ItemCount = 50;
         private const int InvokeCount = 1000;
 
         private readonly Dictionary<int, int> dict;
         private readonly IDynamicSwitch<int, int> @switch;
+
+        #endregion
+
+        #region Constructors
 
         public Int32SwitchVsDictionaryBench()
         {
@@ -23,6 +36,10 @@ namespace SourceCode.Clay.Collections.Bench
             // Build switch
             @switch = dict.ToDynamicSwitch();
         }
+
+        #endregion
+
+        #region Methods
 
         [Benchmark(Baseline = true, OperationsPerInvoke = ItemCount * InvokeCount)]
         public int Lookup()
@@ -59,5 +76,7 @@ namespace SourceCode.Clay.Collections.Bench
 
             return total;
         }
+
+        #endregion
     }
 }

--- a/src/SourceCode.Clay.Collections.Bench/Program.cs
+++ b/src/SourceCode.Clay.Collections.Bench/Program.cs
@@ -1,9 +1,18 @@
-﻿using BenchmarkDotNet.Running;
+#region License
+
+// Copyright (c) K2 Workflow (SourceCode Technology Holdings Inc.). All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+#endregion
+
+using BenchmarkDotNet.Running;
 
 namespace SourceCode.Clay.Collections.Bench
 {
     public static class Program
     {
+        #region Methods
+
         public static void Main(string[] args)
         {
             var test1 = new Int32SwitchVsDictionaryBench();
@@ -12,5 +21,7 @@ namespace SourceCode.Clay.Collections.Bench
 
             var summary1 = BenchmarkRunner.Run<Int32SwitchVsDictionaryBench>();
         }
+
+        #endregion
     }
 }

--- a/src/SourceCode.Clay.Collections.Tests/DictionaryExtensionsTests.cs
+++ b/src/SourceCode.Clay.Collections.Tests/DictionaryExtensionsTests.cs
@@ -1,3 +1,10 @@
+#region License
+
+// Copyright (c) K2 Workflow (SourceCode Technology Holdings Inc.). All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+#endregion
+
 using SourceCode.Clay.Collections.Generic;
 using System;
 using System.Collections.Generic;
@@ -7,6 +14,8 @@ namespace SourceCode.Clay.Collections.Tests
 {
     public static class DictionaryExtensionsTests
     {
+        #region Fields
+
         private static readonly Dictionary<string, string> _dict = new Dictionary<string, string>()
         {
             ["foo"] = "foo1",
@@ -14,6 +23,10 @@ namespace SourceCode.Clay.Collections.Tests
             ["baz"] = "baz1",
             ["nin"] = "nin1"
         };
+
+        #endregion
+
+        #region Methods
 
         [Trait("Type", "Unit")]
         [Fact(DisplayName = nameof(DictionaryEquals_both_null))]
@@ -93,5 +106,7 @@ namespace SourceCode.Clay.Collections.Tests
             var equal = _dict.DictionaryEquals(dict2);
             Assert.False(equal);
         }
+
+        #endregion
     }
 }

--- a/src/SourceCode.Clay.Collections.Tests/DictionaryTests.cs
+++ b/src/SourceCode.Clay.Collections.Tests/DictionaryTests.cs
@@ -1,9 +1,18 @@
+#region License
+
+// Copyright (c) K2 Workflow (SourceCode Technology Holdings Inc.). All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+#endregion
+
 using Xunit;
 
 namespace SourceCode.Clay.Collections.Generic.Tests
 {
     public static class DictionaryTests
     {
+        #region Methods
+
         [Trait("Type", "Unit")]
         [Fact(DisplayName = nameof(Dictionary_Empty))]
         public static void Dictionary_Empty()
@@ -21,5 +30,7 @@ namespace SourceCode.Clay.Collections.Generic.Tests
 
             Assert.Equal(0, empty.Count);
         }
+
+        #endregion
     }
 }

--- a/src/SourceCode.Clay.Collections.Tests/KeyedLookupTests.cs
+++ b/src/SourceCode.Clay.Collections.Tests/KeyedLookupTests.cs
@@ -1,4 +1,11 @@
-﻿using SourceCode.Clay.Collections.Generic;
+#region License
+
+// Copyright (c) K2 Workflow (SourceCode Technology Holdings Inc.). All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+#endregion
+
+using SourceCode.Clay.Collections.Generic;
 using System;
 using System.Collections.Generic;
 using Xunit;
@@ -7,6 +14,8 @@ namespace SourceCode.Clay.Collections.Tests
 {
     public static class KeyedLookupTests
     {
+        #region Methods
+
         [Fact(DisplayName = nameof(KeyedLookup_KeyExtractor))]
         public static void KeyedLookup_KeyExtractor()
         {
@@ -69,5 +78,7 @@ namespace SourceCode.Clay.Collections.Tests
             Assert.Equal(AttributeTargets.Delegate, lookup["c"].Value);
             Assert.Throws<KeyNotFoundException>(() => lookup["C"]);
         }
+
+        #endregion
     }
 }

--- a/src/SourceCode.Clay.Collections.Tests/ListExtensionsTests.cs
+++ b/src/SourceCode.Clay.Collections.Tests/ListExtensionsTests.cs
@@ -1,3 +1,10 @@
+#region License
+
+// Copyright (c) K2 Workflow (SourceCode Technology Holdings Inc.). All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+#endregion
+
 using SourceCode.Clay.Collections.Generic;
 using System;
 using System.Collections.Generic;
@@ -7,6 +14,8 @@ namespace SourceCode.Clay.Collections.Tests
 {
     public static class ListExtensionsTests
     {
+        #region Fields
+
         private static readonly string[] _null = null;
 
         private static readonly string[] _list =
@@ -16,6 +25,10 @@ namespace SourceCode.Clay.Collections.Tests
             "baz",
             "nin"
         };
+
+        #endregion
+
+        #region Methods
 
         [Trait("Type", "Unit")]
         [Fact(DisplayName = nameof(ListEquals_both_null))]
@@ -240,5 +253,7 @@ namespace SourceCode.Clay.Collections.Tests
             equal = listA.ListEquals(listB, n => n.Value, StringComparer.Ordinal, false);
             Assert.False(equal);
         }
+
+        #endregion
     }
 }

--- a/src/SourceCode.Clay.Collections.Tests/MemoryExtensionsTests.cs
+++ b/src/SourceCode.Clay.Collections.Tests/MemoryExtensionsTests.cs
@@ -1,4 +1,11 @@
-﻿using SourceCode.Clay.Collections.Generic;
+#region License
+
+// Copyright (c) K2 Workflow (SourceCode Technology Holdings Inc.). All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+#endregion
+
+using SourceCode.Clay.Collections.Generic;
 using System;
 using Xunit;
 
@@ -6,6 +13,8 @@ namespace SourceCode.Clay.Collections.Tests
 {
     public static class MemoryExtensionsTests
     {
+        #region Fields
+
         private static readonly ReadOnlyMemory<string> _null = new ReadOnlyMemory<string>();
 
         private static readonly string[] _list = new[]
@@ -15,6 +24,10 @@ namespace SourceCode.Clay.Collections.Tests
             "baz",
             "nin"
         };
+
+        #endregion
+
+        #region Methods
 
         [Trait("Type", "Unit")]
         [Fact(DisplayName = nameof(MemoryEquals_both_null))]
@@ -192,5 +205,7 @@ namespace SourceCode.Clay.Collections.Tests
             equal = list.MemoryEquals(list2, false);
             Assert.False(equal);
         }
+
+        #endregion
     }
 }

--- a/src/SourceCode.Clay.Collections.Tests/SetExtensionsTests.cs
+++ b/src/SourceCode.Clay.Collections.Tests/SetExtensionsTests.cs
@@ -1,3 +1,10 @@
+#region License
+
+// Copyright (c) K2 Workflow (SourceCode Technology Holdings Inc.). All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+#endregion
+
 using SourceCode.Clay.Collections.Generic;
 using System;
 using System.Collections.Generic;
@@ -7,6 +14,8 @@ namespace SourceCode.Clay.Collections.Tests
 {
     public static class SetExtensionsTests
     {
+        #region Fields
+
         private static readonly HashSet<string> _set = new HashSet<string>
         {
             "foo",
@@ -14,6 +23,10 @@ namespace SourceCode.Clay.Collections.Tests
             "baz",
             "nin"
         };
+
+        #endregion
+
+        #region Methods
 
         [Trait("Type", "Unit")]
         [Fact(DisplayName = nameof(SetEquals_both_null))]
@@ -88,5 +101,7 @@ namespace SourceCode.Clay.Collections.Tests
             var equal = _set.NullableSetEquals(set2);
             Assert.False(equal);
         }
+
+        #endregion
     }
 }

--- a/src/SourceCode.Clay.Collections.Tests/SwitchExtensionsTests.cs
+++ b/src/SourceCode.Clay.Collections.Tests/SwitchExtensionsTests.cs
@@ -1,3 +1,10 @@
+#region License
+
+// Copyright (c) K2 Workflow (SourceCode Technology Holdings Inc.). All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+#endregion
+
 using SourceCode.Clay.Collections.Generic;
 using System;
 using System.Collections.Generic;
@@ -7,6 +14,8 @@ namespace SourceCode.Clay.Collections.Tests
 {
     public static class SwitchExtensionsTests
     {
+        #region Methods
+
         [Trait("Type", "Unit")]
         [Fact(DisplayName = nameof(ToDynamicSwitch_Bool))]
         public static void ToDynamicSwitch_Bool()
@@ -90,5 +99,7 @@ namespace SourceCode.Clay.Collections.Tests
             Assert.Equal(AttributeTargets.Constructor, @switch[2]);
             Assert.Equal(AttributeTargets.Delegate, @switch[3]);
         }
+
+        #endregion
     }
 }

--- a/src/SourceCode.Clay.Collections/BaseSwitchBuilder.cs
+++ b/src/SourceCode.Clay.Collections/BaseSwitchBuilder.cs
@@ -1,4 +1,11 @@
-﻿using System;
+#region License
+
+// Copyright (c) K2 Workflow (SourceCode Technology Holdings Inc.). All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+#endregion
+
+using System;
 using System.Collections.Generic;
 using System.Linq.Expressions;
 using System.Reflection;
@@ -38,6 +45,11 @@ namespace SourceCode.Clay.Collections.Generic
         #region IDynamicSwitch
 
         /// <summary>
+        /// The number of items in the switch.
+        /// </summary>
+        public int Count => _values.Count;
+
+        /// <summary>
         /// Gets the value with the specified key.
         /// </summary>
         /// <value>
@@ -46,11 +58,6 @@ namespace SourceCode.Clay.Collections.Generic
         /// <param name="key">The key.</param>
         /// <returns></returns>
         public TValue this[TKey key] => _values[_indexer(key)];
-
-        /// <summary>
-        /// The number of items in the switch.
-        /// </summary>
-        public int Count => _values.Count;
 
         /// <summary>
         /// Checks whether the specified key is present in the switch.
@@ -79,14 +86,6 @@ namespace SourceCode.Clay.Collections.Generic
         #endregion
 
         #region Helpers
-
-        /// <summary>
-        /// Override this method if the keys need to be transformed in some manner before
-        /// being compared. For example, changing string keys to their lowercase equivalent.
-        /// </summary>
-        /// <param name="key">The key value to be transformed.</param>
-        /// <returns>The transformed key value.</returns>
-        protected virtual TKey NormalizeKey(TKey key) => key;
 
         /// <summary>
         /// A persistent pointer to the <see cref="NormalizeKey(TKey)"/> method.
@@ -163,6 +162,14 @@ namespace SourceCode.Clay.Collections.Generic
             var func = expr.Compile();
             return (values, func);
         }
+
+        /// <summary>
+        /// Override this method if the keys need to be transformed in some manner before
+        /// being compared. For example, changing string keys to their lowercase equivalent.
+        /// </summary>
+        /// <param name="key">The key value to be transformed.</param>
+        /// <returns>The transformed key value.</returns>
+        protected virtual TKey NormalizeKey(TKey key) => key;
 
         #endregion
     }

--- a/src/SourceCode.Clay.Collections/CaseInsensitiveSwitchBuilder.cs
+++ b/src/SourceCode.Clay.Collections/CaseInsensitiveSwitchBuilder.cs
@@ -25,7 +25,7 @@ namespace SourceCode.Clay.Collections.Generic
         /// <returns>
         /// The transformed key value.
         /// </returns>
-        protected override string NormalizeKey(string key) => key.ToUpperInvariant();
+        protected override string NormalizeKey(string key) => key.ToUpperInvariant(); // Apparently UC (vs LC) is optimized in CLR
 
         #endregion
 
@@ -40,7 +40,5 @@ namespace SourceCode.Clay.Collections.Generic
         { }
 
         #endregion
-
-        // Apparently UC (vs LC) is optimized in CLR
     }
 }

--- a/src/SourceCode.Clay.Collections/CaseInsensitiveSwitchBuilder.cs
+++ b/src/SourceCode.Clay.Collections/CaseInsensitiveSwitchBuilder.cs
@@ -1,4 +1,11 @@
-﻿using System.Collections.Generic;
+#region License
+
+// Copyright (c) K2 Workflow (SourceCode Technology Holdings Inc.). All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+#endregion
+
+using System.Collections.Generic;
 
 namespace SourceCode.Clay.Collections.Generic
 {
@@ -9,13 +16,7 @@ namespace SourceCode.Clay.Collections.Generic
     /// <typeparam name="TValue">The type of values.</typeparam>
     internal sealed class CaseInsensitiveSwitchBuilder<TValue> : BaseSwitchBuilder<string, TValue>
     {
-        /// <summary>
-        /// Initializes a new instance of the <see cref="CaseInsensitiveSwitchBuilder{TValue}"/> class.
-        /// </summary>
-        /// <param name="cases">The cases.</param>
-        public CaseInsensitiveSwitchBuilder(IReadOnlyDictionary<string, TValue> cases)
-            : base(cases)
-        { }
+        #region Methods
 
         /// <summary>
         /// Normalizes each switch key, so that comparisons are case-insensitive.
@@ -24,6 +25,22 @@ namespace SourceCode.Clay.Collections.Generic
         /// <returns>
         /// The transformed key value.
         /// </returns>
-        protected override string NormalizeKey(string key) => key.ToUpperInvariant(); // Apparently UC (vs LC) is optimized in CLR
+        protected override string NormalizeKey(string key) => key.ToUpperInvariant();
+
+        #endregion
+
+        #region Constructors
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CaseInsensitiveSwitchBuilder{TValue}"/> class.
+        /// </summary>
+        /// <param name="cases">The cases.</param>
+        public CaseInsensitiveSwitchBuilder(IReadOnlyDictionary<string, TValue> cases)
+            : base(cases)
+        { }
+
+        #endregion
+
+        // Apparently UC (vs LC) is optimized in CLR
     }
 }

--- a/src/SourceCode.Clay.Collections/CaseSensitiveSwitchBuilder.cs
+++ b/src/SourceCode.Clay.Collections/CaseSensitiveSwitchBuilder.cs
@@ -1,4 +1,11 @@
-﻿using System.Collections.Generic;
+#region License
+
+// Copyright (c) K2 Workflow (SourceCode Technology Holdings Inc.). All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+#endregion
+
+using System.Collections.Generic;
 
 namespace SourceCode.Clay.Collections.Generic
 {
@@ -9,6 +16,8 @@ namespace SourceCode.Clay.Collections.Generic
     /// <typeparam name="TValue">The type of values.</typeparam>
     internal sealed class CaseSensitiveSwitchBuilder<TValue> : BaseSwitchBuilder<string, TValue>
     {
+        #region Constructors
+
         /// <summary>
         /// Initializes a new instance of the <see cref="CaseSensitiveSwitchBuilder{TValue}"/> class.
         /// </summary>
@@ -16,5 +25,7 @@ namespace SourceCode.Clay.Collections.Generic
         public CaseSensitiveSwitchBuilder(IReadOnlyDictionary<string, TValue> cases)
             : base(cases)
         { }
+
+        #endregion
     }
 }

--- a/src/SourceCode.Clay.Collections/Dictionary.cs
+++ b/src/SourceCode.Clay.Collections/Dictionary.cs
@@ -1,4 +1,11 @@
-﻿using System.Collections.Generic;
+#region License
+
+// Copyright (c) K2 Workflow (SourceCode Technology Holdings Inc.). All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+#endregion
+
+using System.Collections.Generic;
 
 namespace SourceCode.Clay.Collections.Generic
 {

--- a/src/SourceCode.Clay.Collections/DictionaryExtensions.cs
+++ b/src/SourceCode.Clay.Collections/DictionaryExtensions.cs
@@ -1,3 +1,10 @@
+#region License
+
+// Copyright (c) K2 Workflow (SourceCode Technology Holdings Inc.). All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+#endregion
+
 using System;
 using System.Collections.Generic;
 
@@ -8,6 +15,8 @@ namespace SourceCode.Clay.Collections.Generic
     /// </summary>
     public static class DictionaryExtensions
     {
+        #region Methods
+
         /// <summary>
         /// Performs an efficient item-by-item comparison
         /// using the <see cref="IEqualityComparer{T}"/> from the first dictionary for Key comparisons
@@ -59,5 +68,7 @@ namespace SourceCode.Clay.Collections.Generic
         /// <returns></returns>
         public static bool DictionaryEquals<TKey, TValue>(this IReadOnlyDictionary<TKey, TValue> x, IReadOnlyDictionary<TKey, TValue> y)
             => x.DictionaryEquals(y, EqualityComparer<TValue>.Default);
+
+        #endregion
     }
 }

--- a/src/SourceCode.Clay.Collections/EmptyDictionaryImpl.cs
+++ b/src/SourceCode.Clay.Collections/EmptyDictionaryImpl.cs
@@ -1,4 +1,11 @@
-﻿using System;
+#region License
+
+// Copyright (c) K2 Workflow (SourceCode Technology Holdings Inc.). All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+#endregion
+
+using System;
 using System.Collections;
 using System.Collections.Generic;
 
@@ -29,11 +36,9 @@ namespace SourceCode.Clay.Collections.Generic
 
         #region Properties
 
-        public TValue this[TKey key]
-        {
-            get => _dict[key]; // Leverage the underlying exception
-            set => throw new InvalidOperationException();
-        }
+        public int Count => 0;
+
+        public bool IsReadOnly => true;
 
         ICollection<TKey> IDictionary<TKey, TValue>.Keys => Array.Empty<TKey>();
 
@@ -43,9 +48,11 @@ namespace SourceCode.Clay.Collections.Generic
 
         IEnumerable<TValue> IReadOnlyDictionary<TKey, TValue>.Values => Array.Empty<TValue>();
 
-        public int Count => 0;
-
-        public bool IsReadOnly => true;
+        public TValue this[TKey key]
+        {
+            get => _dict[key]; // Leverage the underlying exception
+            set => throw new InvalidOperationException();
+        }
 
         #endregion
 

--- a/src/SourceCode.Clay.Collections/IDynamicSwitch.cs
+++ b/src/SourceCode.Clay.Collections/IDynamicSwitch.cs
@@ -1,4 +1,11 @@
-﻿namespace SourceCode.Clay.Collections.Generic
+#region License
+
+// Copyright (c) K2 Workflow (SourceCode Technology Holdings Inc.). All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+#endregion
+
+namespace SourceCode.Clay.Collections.Generic
 {
     /// <summary>
     /// Interface used for exposing dynamic switch statements.
@@ -9,6 +16,17 @@
     /// <seealso cref="Expression.Switch"/>
     public interface IDynamicSwitch<in TKey, TValue>
     {
+        #region Properties
+
+        /// <summary>
+        /// The number of items in the switch.
+        /// </summary>
+        int Count { get; }
+
+        #endregion
+
+        #region Indexers
+
         /// <summary>
         /// Gets the value with the specified key.
         /// </summary>
@@ -16,10 +34,9 @@
         /// <returns></returns>
         TValue this[TKey key] { get; }
 
-        /// <summary>
-        /// The number of items in the switch.
-        /// </summary>
-        int Count { get; }
+        #endregion
+
+        #region Methods
 
         /// <summary>
         /// Checks whether the specified key is present in the switch.
@@ -35,5 +52,7 @@
         /// <param name="value">The value.</param>
         /// <returns></returns>
         bool TryGetValue(TKey key, out TValue value);
+
+        #endregion
     }
 }

--- a/src/SourceCode.Clay.Collections/KeyedCollectionFactory.cs
+++ b/src/SourceCode.Clay.Collections/KeyedCollectionFactory.cs
@@ -1,3 +1,10 @@
+#region License
+
+// Copyright (c) K2 Workflow (SourceCode Technology Holdings Inc.). All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+#endregion
+
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
@@ -9,6 +16,8 @@ namespace SourceCode.Clay.Collections.Generic
     /// </summary>
     public static class KeyedCollectionFactory
     {
+        #region Methods
+
         /// <summary>
         /// Creates a Dictionary that stores values containing embedded keys.
         /// </summary>
@@ -136,14 +145,28 @@ namespace SourceCode.Clay.Collections.Generic
             return impl;
         }
 
+        #endregion
+
         #region Implementation
 
         private sealed class KeyedCollectionImpl<TKey, TValue> : KeyedCollection<TKey, TValue>
         {
+            #region Fields
+
             private readonly Func<TValue, TKey> _keyExtractor;
 
+            #endregion
+
+            #region Methods
+
+            protected sealed override TKey GetKeyForItem(TValue item) => _keyExtractor(item);
+
+            #endregion
+
+            #region Constructors
+
             public KeyedCollectionImpl(Func<TValue, TKey> keyExtractor, IEqualityComparer<TKey> comparer, int dictionaryCreationThreshold)
-                : base(comparer, dictionaryCreationThreshold)
+                            : base(comparer, dictionaryCreationThreshold)
             {
                 if (comparer == null) throw new ArgumentNullException(nameof(comparer));
                 if (dictionaryCreationThreshold < -1) throw new ArgumentOutOfRangeException(nameof(dictionaryCreationThreshold));
@@ -164,7 +187,7 @@ namespace SourceCode.Clay.Collections.Generic
                 _keyExtractor = keyExtractor ?? throw new ArgumentNullException(nameof(keyExtractor));
             }
 
-            protected sealed override TKey GetKeyForItem(TValue item) => _keyExtractor(item);
+            #endregion
         }
 
         #endregion

--- a/src/SourceCode.Clay.Collections/ListExtensions.cs
+++ b/src/SourceCode.Clay.Collections/ListExtensions.cs
@@ -1,3 +1,10 @@
+#region License
+
+// Copyright (c) K2 Workflow (SourceCode Technology Holdings Inc.). All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+#endregion
+
 using System;
 using System.Collections;
 using System.Collections.Generic;
@@ -9,6 +16,8 @@ namespace SourceCode.Clay.Collections.Generic
     /// </summary>
     public static class ListExtensions
     {
+        #region Methods
+
         /// <summary>
         /// Performs an optimized item-by-item comparison, using a custom <see cref="IEqualityComparer{T}"/>.
         /// </summary>
@@ -220,5 +229,7 @@ namespace SourceCode.Clay.Collections.Generic
         /// <returns></returns>
         public static bool ListEquals<T>(this IReadOnlyList<T> x, IReadOnlyList<T> y, bool sequential)
             => x.ListEquals(y, EqualityComparer<T>.Default, sequential);
+
+        #endregion
     }
 }

--- a/src/SourceCode.Clay.Collections/MemoryExtensions.cs
+++ b/src/SourceCode.Clay.Collections/MemoryExtensions.cs
@@ -1,4 +1,11 @@
-﻿using System;
+#region License
+
+// Copyright (c) K2 Workflow (SourceCode Technology Holdings Inc.). All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+#endregion
+
+using System;
 using System.Collections;
 using System.Collections.Generic;
 
@@ -9,6 +16,8 @@ namespace SourceCode.Clay.Collections.Generic
     /// </summary>
     public static class MemoryExtensions
     {
+        #region Methods
+
         /// <summary>
         /// Performs an optimized item-by-item comparison, using a custom <see cref="IEqualityComparer{T}"/>.
         /// </summary>
@@ -109,5 +118,7 @@ namespace SourceCode.Clay.Collections.Generic
         /// <returns></returns>
         public static bool MemoryEquals<T>(this ReadOnlyMemory<T> x, ReadOnlyMemory<T> y, bool sequential)
             => x.MemoryEquals(y, EqualityComparer<T>.Default, sequential);
+
+        #endregion
     }
 }

--- a/src/SourceCode.Clay.Collections/ReadOnlyDictionary.cs
+++ b/src/SourceCode.Clay.Collections/ReadOnlyDictionary.cs
@@ -1,4 +1,11 @@
-﻿using System.Collections.Generic;
+#region License
+
+// Copyright (c) K2 Workflow (SourceCode Technology Holdings Inc.). All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+#endregion
+
+using System.Collections.Generic;
 
 namespace SourceCode.Clay.Collections.Generic
 {

--- a/src/SourceCode.Clay.Collections/SetExtensions.cs
+++ b/src/SourceCode.Clay.Collections/SetExtensions.cs
@@ -1,3 +1,10 @@
+#region License
+
+// Copyright (c) K2 Workflow (SourceCode Technology Holdings Inc.). All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+#endregion
+
 using System;
 using System.Collections.Generic;
 
@@ -8,6 +15,8 @@ namespace SourceCode.Clay.Collections.Generic
     /// </summary>
     public static class SetExtensions
     {
+        #region Methods
+
         /// <summary>
         /// Performs an efficient item-by-item comparison, using a custom <see cref="IEqualityComparer{T}"/>.
         /// </summary>
@@ -67,5 +76,7 @@ namespace SourceCode.Clay.Collections.Generic
             // Use native checks
             return x.SetEquals(y); // Uses the equality comparer from the first set
         }
+
+        #endregion
     }
 }

--- a/src/SourceCode.Clay.Collections/StructSwitchBuilderImpl.cs
+++ b/src/SourceCode.Clay.Collections/StructSwitchBuilderImpl.cs
@@ -1,4 +1,11 @@
-﻿using System;
+#region License
+
+// Copyright (c) K2 Workflow (SourceCode Technology Holdings Inc.). All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+#endregion
+
+using System;
 using System.Collections.Generic;
 
 namespace SourceCode.Clay.Collections.Generic
@@ -12,6 +19,8 @@ namespace SourceCode.Clay.Collections.Generic
     internal sealed class StructSwitchBuilderImpl<TKey, TValue> : BaseSwitchBuilder<TKey, TValue>
         where TKey : struct, IEquatable<TKey>
     {
+        #region Constructors
+
         /// <summary>
         /// Initializes a new instance of the <see cref="StructSwitchBuilderImpl{TKey, TValue}"/> class.
         /// </summary>
@@ -19,5 +28,7 @@ namespace SourceCode.Clay.Collections.Generic
         public StructSwitchBuilderImpl(IReadOnlyDictionary<TKey, TValue> cases)
             : base(cases)
         { }
+
+        #endregion
     }
 }

--- a/src/SourceCode.Clay.Collections/SwitchExtensions.cs
+++ b/src/SourceCode.Clay.Collections/SwitchExtensions.cs
@@ -1,4 +1,11 @@
-﻿using System;
+#region License
+
+// Copyright (c) K2 Workflow (SourceCode Technology Holdings Inc.). All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+#endregion
+
+using System;
 using System.Collections.Generic;
 
 namespace SourceCode.Clay.Collections.Generic
@@ -9,6 +16,8 @@ namespace SourceCode.Clay.Collections.Generic
     /// <seealso cref="Expression.Switch"/>
     public static class SwitchExtensions
     {
+        #region Methods
+
         /// <summary>
         /// Builds a dynamic switch with <see cref="System.Boolean"/> keys.
         /// </summary>
@@ -135,5 +144,7 @@ namespace SourceCode.Clay.Collections.Generic
             var impl = cases.ToDynamicSwitch(keyExtractor, v => v);
             return impl;
         }
+
+        #endregion
     }
 }

--- a/src/SourceCode.Clay.Data.Tests/SqlConnectionStringBuilderTests.cs
+++ b/src/SourceCode.Clay.Data.Tests/SqlConnectionStringBuilderTests.cs
@@ -1,4 +1,11 @@
-﻿using SourceCode.Clay.Data.SqlClient.Azure;
+#region License
+
+// Copyright (c) K2 Workflow (SourceCode Technology Holdings Inc.). All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+#endregion
+
+using SourceCode.Clay.Data.SqlClient.Azure;
 using System;
 using System.Data.SqlClient;
 using Xunit;
@@ -7,8 +14,14 @@ namespace SourceCode.Clay.Data.SqlClient.Tests
 {
     public static class SqlConnectionStringBuilderTests
     {
+        #region Fields
+
         private const string dbToken = "database";
         private static readonly string[] serverTokens = { "DATA SOURCE", "data source", "SERVER", "server" };
+
+        #endregion
+
+        #region Methods
 
         [Trait("Type", "Unit")]
         [Fact(DisplayName = "SqlConnectionStringBuilderExtensions MakeRobust Local")]
@@ -120,5 +133,7 @@ namespace SourceCode.Clay.Data.SqlClient.Tests
                 }
             }
         }
+
+        #endregion
     }
 }

--- a/src/SourceCode.Clay.Data.Tests/SqlParamBlockParserTests.cs
+++ b/src/SourceCode.Clay.Data.Tests/SqlParamBlockParserTests.cs
@@ -1,10 +1,19 @@
-﻿using System.Data;
+#region License
+
+// Copyright (c) K2 Workflow (SourceCode Technology Holdings Inc.). All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+#endregion
+
+using System.Data;
 using Xunit;
 
 namespace SourceCode.Clay.Data.SqlParser.Tests
 {
     public static class SqlParamBlockParserTests
     {
+        #region Fields
+
         // Block comment is not closed
         private const string sqlBadComment = @"
 			CReaTE /*blah
@@ -13,15 +22,6 @@ namespace SourceCode.Clay.Data.SqlParser.Tests
 			BEGIN
                 RETURN 1;
 			END;";
-
-        [Trait("Type", "Unit")]
-        [Fact(DisplayName = nameof(Tokenize_bad_comment))]
-        public static void Tokenize_bad_comment()
-        {
-            var @params = SqlParamBlockParser.ParseFunction(sqlBadComment);
-
-            Assert.True(@params.Count == 0);
-        }
 
         // [abc]]def]
         // [abc[]]def]
@@ -34,15 +34,6 @@ namespace SourceCode.Clay.Data.SqlParser.Tests
 			    inT
 			BEGIN RETURN 1;
 			END; /**/";
-
-        [Trait("Type", "Unit")]
-        [Fact(DisplayName = nameof(Tokenize_escaped_names))]
-        public static void Tokenize_escaped_names()
-        {
-            var @params = SqlParamBlockParser.ParseFunction(sqlEscapedNames);
-
-            Assert.True(@params.Count == 0);
-        }
 
         private const string sqlMessyProcWithParen = @"
 			CReaTE /*blah*/
@@ -63,33 +54,6 @@ namespace SourceCode.Clay.Data.SqlParser.Tests
 			--blah */ etc
 				/* ok -- */
 			END;";
-
-        [Trait("Type", "Unit")]
-        [Fact(DisplayName = nameof(Tokenize_messy_proc_2_params))]
-        public static void Tokenize_messy_proc_2_params()
-        {
-            var @params = SqlParamBlockParser.ParseProcedure(sqlMessyProcWithParen);
-
-            Assert.Equal(2, @params.Count);
-
-            // @p1
-            var found = @params.TryGetValue("@p1", out var param);
-            Assert.True(found);
-
-            Assert.Equal(ParameterDirection.InputOutput, param.Direction);
-            Assert.True(param.HasDefault);
-            Assert.False(param.IsNullable);
-            Assert.False(param.IsReadOnly);
-
-            // @p_2
-            found = @params.TryGetValue("@p_2", out param);
-            Assert.True(found);
-
-            Assert.Equal(ParameterDirection.Input, param.Direction);
-            Assert.False(param.HasDefault);
-            Assert.False(param.IsNullable);
-            Assert.True(param.IsReadOnly);
-        }
 
         private const string sqlRealFunction = @"
 /*
@@ -122,6 +86,75 @@ AS RETURN
 );
 		";
 
+        private const string sqlMessyProcNoParen = @"
+			CReaTE /*blah*/
+				PROCedure            --etc
+			abc.[def]
+					/*
+						xyz -- /*
+					*/
+			@p  --test--
+			/* yada
+			*/
+			NVARCHAR(MAX) = 3 OUT -- /* -- */ -- */
+			WITH ( OPTION -- opt
+               /* AS */ RECOMPILE) AS
+			/**/
+			BEGIN --
+			--
+			--blah */ etc
+				/* ok -- */
+			END;";
+
+        #endregion
+
+        #region Methods
+
+        [Trait("Type", "Unit")]
+        [Fact(DisplayName = nameof(Tokenize_bad_comment))]
+        public static void Tokenize_bad_comment()
+        {
+            var @params = SqlParamBlockParser.ParseFunction(sqlBadComment);
+
+            Assert.True(@params.Count == 0);
+        }
+
+        [Trait("Type", "Unit")]
+        [Fact(DisplayName = nameof(Tokenize_escaped_names))]
+        public static void Tokenize_escaped_names()
+        {
+            var @params = SqlParamBlockParser.ParseFunction(sqlEscapedNames);
+
+            Assert.True(@params.Count == 0);
+        }
+
+        [Trait("Type", "Unit")]
+        [Fact(DisplayName = nameof(Tokenize_messy_proc_2_params))]
+        public static void Tokenize_messy_proc_2_params()
+        {
+            var @params = SqlParamBlockParser.ParseProcedure(sqlMessyProcWithParen);
+
+            Assert.Equal(2, @params.Count);
+
+            // @p1
+            var found = @params.TryGetValue("@p1", out var param);
+            Assert.True(found);
+
+            Assert.Equal(ParameterDirection.InputOutput, param.Direction);
+            Assert.True(param.HasDefault);
+            Assert.False(param.IsNullable);
+            Assert.False(param.IsReadOnly);
+
+            // @p_2
+            found = @params.TryGetValue("@p_2", out param);
+            Assert.True(found);
+
+            Assert.Equal(ParameterDirection.Input, param.Direction);
+            Assert.False(param.HasDefault);
+            Assert.False(param.IsNullable);
+            Assert.True(param.IsReadOnly);
+        }
+
         [Trait("Type", "Unit")]
         [Fact(DisplayName = nameof(Tokenize_real_function_2_params))]
         public static void Tokenize_real_function_2_params()
@@ -149,26 +182,6 @@ AS RETURN
             Assert.False(param.IsReadOnly);
         }
 
-        private const string sqlMessyProcNoParen = @"
-			CReaTE /*blah*/
-				PROCedure            --etc
-			abc.[def]
-					/*
-						xyz -- /*
-					*/
-			@p  --test--
-			/* yada
-			*/
-			NVARCHAR(MAX) = 3 OUT -- /* -- */ -- */
-			WITH ( OPTION -- opt
-               /* AS */ RECOMPILE) AS
-			/**/
-			BEGIN --
-			--
-			--blah */ etc
-				/* ok -- */
-			END;";
-
         [Trait("Type", "Unit")]
         [Fact(DisplayName = nameof(Tokenize_messy_proc_2_no_parenthesis))]
         public static void Tokenize_messy_proc_2_no_parenthesis()
@@ -186,5 +199,7 @@ AS RETURN
             Assert.False(param.IsNullable);
             Assert.False(param.IsReadOnly);
         }
+
+        #endregion
     }
 }

--- a/src/SourceCode.Clay.Data/SqlClient/Azure/SqlConnectionStringBuilderExtensions.cs
+++ b/src/SourceCode.Clay.Data/SqlClient/Azure/SqlConnectionStringBuilderExtensions.cs
@@ -1,4 +1,11 @@
-﻿using System;
+#region License
+
+// Copyright (c) K2 Workflow (SourceCode Technology Holdings Inc.). All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+#endregion
+
+using System;
 using System.Data.SqlClient;
 
 namespace SourceCode.Clay.Data.SqlClient.Azure
@@ -10,6 +17,8 @@ namespace SourceCode.Clay.Data.SqlClient.Azure
     /// <seealso cref="System.Data.SqlClient.SqlConnectionStringBuilder"/>
     public static class SqlConnectionStringBuilderAzureExtensions
     {
+        #region Methods
+
         /// <summary>
         /// Add retry and timeout settings according to AzureDb best practices.
         /// </summary>
@@ -71,5 +80,7 @@ namespace SourceCode.Clay.Data.SqlClient.Azure
 
             return sqlCsb;
         }
+
+        #endregion
     }
 }

--- a/src/SourceCode.Clay.Data/SqlClient/SqlCommandExtensions.cs
+++ b/src/SourceCode.Clay.Data/SqlClient/SqlCommandExtensions.cs
@@ -1,4 +1,11 @@
-﻿using System;
+#region License
+
+// Copyright (c) K2 Workflow (SourceCode Technology Holdings Inc.). All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+#endregion
+
+using System;
 using System.Data;
 using System.Data.SqlClient;
 

--- a/src/SourceCode.Clay.Data/SqlClient/SqlConnectionExtensions.cs
+++ b/src/SourceCode.Clay.Data/SqlClient/SqlConnectionExtensions.cs
@@ -1,4 +1,11 @@
-﻿using System;
+#region License
+
+// Copyright (c) K2 Workflow (SourceCode Technology Holdings Inc.). All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+#endregion
+
+using System;
 using System.Data;
 using System.Data.SqlClient;
 using System.Diagnostics.CodeAnalysis;

--- a/src/SourceCode.Clay.Data/SqlClient/SqlConnectionRetryOptions.cs
+++ b/src/SourceCode.Clay.Data/SqlClient/SqlConnectionRetryOptions.cs
@@ -1,4 +1,11 @@
-﻿namespace SourceCode.Clay.Data.SqlClient
+#region License
+
+// Copyright (c) K2 Workflow (SourceCode Technology Holdings Inc.). All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+#endregion
+
+namespace SourceCode.Clay.Data.SqlClient
 {
     /// <summary>
     /// A property bag to hold various connection retry options.
@@ -15,6 +22,10 @@
 
         private byte? _connectRetryCount;
 
+        private byte? _connectRetryInterval;
+
+        private ushort? _connectTimeout;
+
         /// <summary>
         /// The number of reconnections attempted after identifying that there was an
         /// idle connection failure. This must be an integer between 0 and 255. Default is 5.
@@ -26,8 +37,6 @@
             set => _connectRetryCount = value;
         }
 
-        private byte? _connectRetryInterval;
-
         /// <summary>
         /// Amount of time (in seconds) between each reconnection attempt after identifying that there was an
         /// idle connection failure. This must be an integer between 1 and 60. The default is 10 seconds.
@@ -37,8 +46,6 @@
             get => _connectRetryInterval.GetValueOrDefault(10);
             set => _connectRetryInterval = value;
         }
-
-        private ushort? _connectTimeout;
 
         /// <summary>
         /// Gets or sets the length of time (in seconds) to wait for a connection to the

--- a/src/SourceCode.Clay.Data/SqlClient/SqlConnectionStringBuilderExtensions.cs
+++ b/src/SourceCode.Clay.Data/SqlClient/SqlConnectionStringBuilderExtensions.cs
@@ -1,4 +1,11 @@
-﻿using System;
+#region License
+
+// Copyright (c) K2 Workflow (SourceCode Technology Holdings Inc.). All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+#endregion
+
+using System;
 using System.Data.SqlClient;
 
 namespace SourceCode.Clay.Data.SqlClient
@@ -10,6 +17,8 @@ namespace SourceCode.Clay.Data.SqlClient
     /// <seealso cref="System.Data.SqlClient.SqlConnectionStringBuilder"/>
     public static class SqlConnectionStringBuilderExtensions
     {
+        #region Methods
+
         /// <summary>
         /// Clear any inline credentials store in the builder. This is useful for logging.
         /// </summary>
@@ -24,5 +33,7 @@ namespace SourceCode.Clay.Data.SqlClient
 
             return sqlCsb;
         }
+
+        #endregion
     }
 }

--- a/src/SourceCode.Clay.Data/SqlClient/SqlDataReaderExtensions.cs
+++ b/src/SourceCode.Clay.Data/SqlClient/SqlDataReaderExtensions.cs
@@ -1,4 +1,11 @@
-﻿using System;
+#region License
+
+// Copyright (c) K2 Workflow (SourceCode Technology Holdings Inc.). All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+#endregion
+
+using System;
 using System.Data.SqlClient;
 using System.Xml.Linq;
 

--- a/src/SourceCode.Clay.Data/SqlParser/SqlCharReader.cs
+++ b/src/SourceCode.Clay.Data/SqlParser/SqlCharReader.cs
@@ -1,4 +1,11 @@
-﻿using System;
+#region License
+
+// Copyright (c) K2 Workflow (SourceCode Technology Holdings Inc.). All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+#endregion
+
+using System;
 using System.Buffers;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -140,7 +147,7 @@ namespace SourceCode.Clay.Data.SqlParser
 
         private bool _disposed;
 
-        void Dispose(bool disposing)
+        private void Dispose(bool disposing)
         {
             if (!_disposed)
             {

--- a/src/SourceCode.Clay.Data/SqlParser/SqlParamBlockParser.cs
+++ b/src/SourceCode.Clay.Data/SqlParser/SqlParamBlockParser.cs
@@ -1,4 +1,11 @@
-﻿using SourceCode.Clay.Collections.Generic;
+#region License
+
+// Copyright (c) K2 Workflow (SourceCode Technology Holdings Inc.). All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+#endregion
+
+using SourceCode.Clay.Collections.Generic;
 using System;
 using System.Collections.Generic;
 using System.Data;

--- a/src/SourceCode.Clay.Data/SqlParser/SqlParamInfo.cs
+++ b/src/SourceCode.Clay.Data/SqlParser/SqlParamInfo.cs
@@ -1,3 +1,10 @@
+#region License
+
+// Copyright (c) K2 Workflow (SourceCode Technology Holdings Inc.). All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+#endregion
+
 using System;
 using System.Data;
 

--- a/src/SourceCode.Clay.Data/SqlParser/SqlTokenInfo.cs
+++ b/src/SourceCode.Clay.Data/SqlParser/SqlTokenInfo.cs
@@ -1,4 +1,11 @@
-﻿using System.Text;
+#region License
+
+// Copyright (c) K2 Workflow (SourceCode Technology Holdings Inc.). All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+#endregion
+
+using System.Text;
 
 namespace SourceCode.Clay.Data.SqlParser
 {

--- a/src/SourceCode.Clay.Data/SqlParser/SqlTokenKind.cs
+++ b/src/SourceCode.Clay.Data/SqlParser/SqlTokenKind.cs
@@ -1,4 +1,11 @@
-﻿namespace SourceCode.Clay.Data.SqlParser
+#region License
+
+// Copyright (c) K2 Workflow (SourceCode Technology Holdings Inc.). All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+#endregion
+
+namespace SourceCode.Clay.Data.SqlParser
 {
     public enum SqlTokenKind : byte
     {

--- a/src/SourceCode.Clay.Data/SqlParser/SqlTokenizer.cs
+++ b/src/SourceCode.Clay.Data/SqlParser/SqlTokenizer.cs
@@ -1,4 +1,11 @@
-﻿using System;
+#region License
+
+// Copyright (c) K2 Workflow (SourceCode Technology Holdings Inc.). All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+#endregion
+
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;

--- a/src/SourceCode.Clay.Json.Tests/DecimalValidatorTests.cs
+++ b/src/SourceCode.Clay.Json.Tests/DecimalValidatorTests.cs
@@ -1,3 +1,10 @@
+#region License
+
+// Copyright (c) K2 Workflow (SourceCode Technology Holdings Inc.). All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+#endregion
+
 using SourceCode.Clay.Json.Validation;
 using Xunit;
 
@@ -5,6 +12,8 @@ namespace SourceCode.Clay.Json.Units
 {
     public static class DecimalValidatorTests
     {
+        #region Methods
+
         [Trait("Type", "Unit")]
         [Theory(DisplayName = nameof(Test_Empty_DecimalValidator))]
         [InlineData(0.49, true)]
@@ -129,5 +138,7 @@ namespace SourceCode.Clay.Json.Units
 
             Assert.True(range.IsValid(dec) == valid);
         }
+
+        #endregion
     }
 }

--- a/src/SourceCode.Clay.Json.Tests/DoubleValidatorTests.cs
+++ b/src/SourceCode.Clay.Json.Tests/DoubleValidatorTests.cs
@@ -1,10 +1,19 @@
-﻿using SourceCode.Clay.Json.Validation;
+#region License
+
+// Copyright (c) K2 Workflow (SourceCode Technology Holdings Inc.). All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+#endregion
+
+using SourceCode.Clay.Json.Validation;
 using Xunit;
 
 namespace SourceCode.Clay.Json.Units
 {
     public static class DoubleValidatorTests
     {
+        #region Methods
+
         [Trait("Type", "Unit")]
         [Theory(DisplayName = nameof(Test_Empty_DoubleValidator))]
         [InlineData(0.49, true)]
@@ -108,5 +117,7 @@ namespace SourceCode.Clay.Json.Units
 
             Assert.True(range.IsValid(value) == valid);
         }
+
+        #endregion
     }
 }

--- a/src/SourceCode.Clay.Json.Tests/JsonExtensionsTests.cs
+++ b/src/SourceCode.Clay.Json.Tests/JsonExtensionsTests.cs
@@ -1,10 +1,19 @@
-﻿using System.Json;
+#region License
+
+// Copyright (c) K2 Workflow (SourceCode Technology Holdings Inc.). All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+#endregion
+
+using System.Json;
 using Xunit;
 
 namespace SourceCode.Clay.Json.Tests
 {
     public static class JsonExtensionTests
     {
+        #region Methods
+
         [Trait("Type", "Unit")]
         [Fact(DisplayName = nameof(When_TryGetValue))]
         public static void When_TryGetValue()
@@ -24,5 +33,7 @@ namespace SourceCode.Clay.Json.Tests
             Assert.True(json.TryGetObject("object", out JsonObject jo));
             Assert.True(json.TryGetArray("array", out JsonArray ja));
         }
+
+        #endregion
     }
 }

--- a/src/SourceCode.Clay.Json.Tests/JsonPointerTests.cs
+++ b/src/SourceCode.Clay.Json.Tests/JsonPointerTests.cs
@@ -1,4 +1,11 @@
-﻿using SourceCode.Clay.Json.Pointers;
+#region License
+
+// Copyright (c) K2 Workflow (SourceCode Technology Holdings Inc.). All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+#endregion
+
+using SourceCode.Clay.Json.Pointers;
 using System;
 using System.Json;
 using System.Linq;
@@ -8,6 +15,8 @@ namespace SourceCode.Clay.Json.Tests
 {
     public static class JsonPointerTests
     {
+        #region Methods
+
         [Fact(DisplayName = nameof(JsonPointer_ToString))]
         public static void JsonPointer_ToString()
         {
@@ -179,5 +188,7 @@ namespace SourceCode.Clay.Json.Tests
             JsonPointer.Parse("/foo6/2").Evaluate(json, JsonPointerEvaluationOptions.InvalidIndiciesAreNull);
             JsonPointer.Parse("/foo6/-").Evaluate(json, JsonPointerEvaluationOptions.InvalidIndiciesAreNull);
         }
+
+        #endregion
     }
 }

--- a/src/SourceCode.Clay.Json.Tests/LengthValidatorTests.cs
+++ b/src/SourceCode.Clay.Json.Tests/LengthValidatorTests.cs
@@ -1,10 +1,19 @@
-﻿using SourceCode.Clay.Json.Validation;
+#region License
+
+// Copyright (c) K2 Workflow (SourceCode Technology Holdings Inc.). All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+#endregion
+
+using SourceCode.Clay.Json.Validation;
 using Xunit;
 
 namespace SourceCode.Clay.Json.Units
 {
     public static class LengthValidatorTests
     {
+        #region Methods
+
         [Trait("Type", "Unit")]
         [Theory(DisplayName = nameof(Test_Empty_LengthValidator))]
         [InlineData(-1, true)]
@@ -57,5 +66,7 @@ namespace SourceCode.Clay.Json.Units
 
             Assert.True(range.IsValid(value) == valid);
         }
+
+        #endregion
     }
 }

--- a/src/SourceCode.Clay.Json.Tests/LongValidatorTests.cs
+++ b/src/SourceCode.Clay.Json.Tests/LongValidatorTests.cs
@@ -1,10 +1,19 @@
-﻿using SourceCode.Clay.Json.Validation;
+#region License
+
+// Copyright (c) K2 Workflow (SourceCode Technology Holdings Inc.). All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+#endregion
+
+using SourceCode.Clay.Json.Validation;
 using Xunit;
 
 namespace SourceCode.Clay.Json.Units
 {
     public static class LongValidatorTests
     {
+        #region Methods
+
         [Trait("Type", "Unit")]
         [Theory(DisplayName = nameof(Test_Empty_LongValidator))]
         [InlineData(-15, true)]
@@ -108,5 +117,7 @@ namespace SourceCode.Clay.Json.Units
 
             Assert.True(range.IsValid(value) == valid);
         }
+
+        #endregion
     }
 }

--- a/src/SourceCode.Clay.Json.Tests/NumberValidatorTests.cs
+++ b/src/SourceCode.Clay.Json.Tests/NumberValidatorTests.cs
@@ -1,3 +1,10 @@
+#region License
+
+// Copyright (c) K2 Workflow (SourceCode Technology Holdings Inc.). All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+#endregion
+
 using SourceCode.Clay.Json.Validation;
 using Xunit;
 
@@ -5,6 +12,8 @@ namespace SourceCode.Clay.Json.Units
 {
     public static class NumberValidatorTests
     {
+        #region Methods
+
         [Trait("Type", "Unit")]
         [Theory(DisplayName = nameof(OpenApi_Test_Empty_DoubleValidator))]
         [InlineData(0.49, true)]
@@ -108,5 +117,7 @@ namespace SourceCode.Clay.Json.Units
 
             Assert.True(range.IsValid(value) == valid);
         }
+
+        #endregion
     }
 }

--- a/src/SourceCode.Clay.Json.Tests/PatternValidatorTests.cs
+++ b/src/SourceCode.Clay.Json.Tests/PatternValidatorTests.cs
@@ -1,10 +1,19 @@
-﻿using SourceCode.Clay.Json.Validation;
+#region License
+
+// Copyright (c) K2 Workflow (SourceCode Technology Holdings Inc.). All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+#endregion
+
+using SourceCode.Clay.Json.Validation;
 using Xunit;
 
 namespace SourceCode.Clay.Json.Units
 {
     public static class PatternValidatorTests
     {
+        #region Methods
+
         [Trait("Type", "Unit")]
         [Theory(DisplayName = nameof(Test_Simple_Optional_PatternValidator))]
         [InlineData("a", true)]
@@ -32,5 +41,7 @@ namespace SourceCode.Clay.Json.Units
 
             Assert.True(range.IsValid(value) == valid);
         }
+
+        #endregion
     }
 }

--- a/src/SourceCode.Clay.Json/JsonExtensions.cs
+++ b/src/SourceCode.Clay.Json/JsonExtensions.cs
@@ -1,3 +1,10 @@
+#region License
+
+// Copyright (c) K2 Workflow (SourceCode Technology Holdings Inc.). All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+#endregion
+
 using System;
 using System.Json;
 

--- a/src/SourceCode.Clay.Json/Pointers/JsonPointer.cs
+++ b/src/SourceCode.Clay.Json/Pointers/JsonPointer.cs
@@ -1,3 +1,10 @@
+#region License
+
+// Copyright (c) K2 Workflow (SourceCode Technology Holdings Inc.). All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+#endregion
+
 using System;
 using System.Collections;
 using System.Collections.Generic;
@@ -21,14 +28,14 @@ namespace SourceCode.Clay.Json.Pointers
 
         private readonly JsonPointerToken[] _tokens;
 
+        /// <summary>Gets the number of elements in the collection.</summary>
+        /// <returns>The number of elements in the collection.</returns>
+        public int Count => _tokens?.Length ?? 0;
+
         /// <summary>Gets the element at the specified index in the read-only list.</summary>
         /// <param name="index">The zero-based index of the element to get.</param>
         /// <returns>The element at the specified index in the read-only list.</returns>
         public JsonPointerToken this[int index] => (_tokens ?? Array.Empty<JsonPointerToken>())[index];
-
-        /// <summary>Gets the number of elements in the collection.</summary>
-        /// <returns>The number of elements in the collection.</returns>
-        public int Count => _tokens?.Length ?? 0;
 
         #endregion
 

--- a/src/SourceCode.Clay.Json/Pointers/JsonPointerEvaluationOptions.cs
+++ b/src/SourceCode.Clay.Json/Pointers/JsonPointerEvaluationOptions.cs
@@ -1,3 +1,10 @@
+#region License
+
+// Copyright (c) K2 Workflow (SourceCode Technology Holdings Inc.). All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+#endregion
+
 using System;
 
 namespace SourceCode.Clay.Json.Pointers

--- a/src/SourceCode.Clay.Json/Pointers/JsonPointerToken.cs
+++ b/src/SourceCode.Clay.Json/Pointers/JsonPointerToken.cs
@@ -1,3 +1,10 @@
+#region License
+
+// Copyright (c) K2 Workflow (SourceCode Technology Holdings Inc.). All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+#endregion
+
 using System;
 using System.Globalization;
 
@@ -86,11 +93,11 @@ namespace SourceCode.Clay.Json.Pointers
 
         public static bool operator !=(JsonPointerToken x, JsonPointerToken y) => !x.Equals(y);
 
+        public static implicit operator JsonPointerToken(string value) => new JsonPointerToken(value);
+
         /// <summary>Returns the fully qualified type name of this instance.</summary>
         /// <returns>The fully qualified type name.</returns>
         public override string ToString() => Value;
-
-        public static implicit operator JsonPointerToken(string value) => new JsonPointerToken(value);
 
         #endregion
     }

--- a/src/SourceCode.Clay.Json/Validation/DecimalValidator.cs
+++ b/src/SourceCode.Clay.Json/Validation/DecimalValidator.cs
@@ -1,3 +1,10 @@
+#region License
+
+// Copyright (c) K2 Workflow (SourceCode Technology Holdings Inc.). All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+#endregion
+
 namespace SourceCode.Clay.Json.Validation
 {
     public sealed class DecimalValidator

--- a/src/SourceCode.Clay.Json/Validation/DoubleValidator.cs
+++ b/src/SourceCode.Clay.Json/Validation/DoubleValidator.cs
@@ -1,4 +1,11 @@
-﻿namespace SourceCode.Clay.Json.Validation
+#region License
+
+// Copyright (c) K2 Workflow (SourceCode Technology Holdings Inc.). All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+#endregion
+
+namespace SourceCode.Clay.Json.Validation
 {
     public sealed class DoubleValidator
     {

--- a/src/SourceCode.Clay.Json/Validation/Int64Validator.cs
+++ b/src/SourceCode.Clay.Json/Validation/Int64Validator.cs
@@ -1,3 +1,10 @@
+#region License
+
+// Copyright (c) K2 Workflow (SourceCode Technology Holdings Inc.). All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+#endregion
+
 namespace SourceCode.Clay.Json.Validation
 {
     public sealed class Int64Validator

--- a/src/SourceCode.Clay.Json/Validation/LengthValidator.cs
+++ b/src/SourceCode.Clay.Json/Validation/LengthValidator.cs
@@ -1,4 +1,11 @@
-﻿namespace SourceCode.Clay.Json.Validation
+#region License
+
+// Copyright (c) K2 Workflow (SourceCode Technology Holdings Inc.). All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+#endregion
+
+namespace SourceCode.Clay.Json.Validation
 {
     public sealed class LengthValidator
     {

--- a/src/SourceCode.Clay.Json/Validation/NumberValidator.cs
+++ b/src/SourceCode.Clay.Json/Validation/NumberValidator.cs
@@ -1,4 +1,11 @@
-﻿using System;
+#region License
+
+// Copyright (c) K2 Workflow (SourceCode Technology Holdings Inc.). All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+#endregion
+
+using System;
 
 namespace SourceCode.Clay.Json.Validation
 {

--- a/src/SourceCode.Clay.Json/Validation/PatternValidator.cs
+++ b/src/SourceCode.Clay.Json/Validation/PatternValidator.cs
@@ -1,4 +1,11 @@
-﻿using System;
+#region License
+
+// Copyright (c) K2 Workflow (SourceCode Technology Holdings Inc.). All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+#endregion
+
+using System;
 using System.Runtime.CompilerServices;
 using System.Text.RegularExpressions;
 using System.Threading;
@@ -48,6 +55,13 @@ namespace SourceCode.Clay.Json.Validation
 
         #region Methods
 
+        // Heap analysis shows Regex permanently holds onto last input string, which may be large
+        [MethodImpl(MethodImplOptions.NoOptimization)]
+        private static void Clear(Regex regex)
+        {
+            regex.IsMatch(string.Empty);
+        }
+
         public bool IsValid(string value)
         {
             if (string.IsNullOrEmpty(value))
@@ -58,13 +72,6 @@ namespace SourceCode.Clay.Json.Validation
             Clear(_regex.Value);
 
             return isMatch;
-        }
-
-        // Heap analysis shows Regex permanently holds onto last input string, which may be large
-        [MethodImpl(MethodImplOptions.NoOptimization)]
-        private static void Clear(Regex regex)
-        {
-            regex.IsMatch(string.Empty);
         }
 
         public override string ToString()

--- a/src/SourceCode.Clay.OpenApi.Tests/Expressions/CompoundExpressionTests.cs
+++ b/src/SourceCode.Clay.OpenApi.Tests/Expressions/CompoundExpressionTests.cs
@@ -1,3 +1,10 @@
+#region License
+
+// Copyright (c) K2 Workflow (SourceCode Technology Holdings Inc.). All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+#endregion
+
 using SourceCode.Clay.OpenApi.Expressions;
 using Xunit;
 
@@ -5,6 +12,8 @@ namespace SourceCode.Clay.OpenApi.Tests.Expressions
 {
     public static class CompoundExpressionTests
     {
+        #region Methods
+
         [Fact(DisplayName = nameof(CompoundExpression_Parse))]
         public static void CompoundExpression_Parse()
         {
@@ -27,5 +36,7 @@ namespace SourceCode.Clay.OpenApi.Tests.Expressions
             Assert.Equal("$method", sut[5].ToString());
             Assert.Equal("$statusCode", sut[6].ToString());
         }
+
+        #endregion
     }
 }

--- a/src/SourceCode.Clay.OpenApi.Tests/Expressions/FieldExpressionTests.cs
+++ b/src/SourceCode.Clay.OpenApi.Tests/Expressions/FieldExpressionTests.cs
@@ -1,14 +1,20 @@
+#region License
+
+// Copyright (c) K2 Workflow (SourceCode Technology Holdings Inc.). All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+#endregion
+
 using SourceCode.Clay.Json.Pointers;
 using SourceCode.Clay.OpenApi.Expressions;
-using System;
-using System.Collections.Generic;
-using System.Text;
 using Xunit;
 
 namespace SourceCode.Clay.OpenApi.Tests.Expressions
 {
     public static class FieldExpressionTests
     {
+        #region Methods
+
         [Fact(DisplayName = nameof(FieldExpression_Parse_Url))]
         public static void FieldExpression_Parse_Url()
         {
@@ -72,7 +78,7 @@ namespace SourceCode.Clay.OpenApi.Tests.Expressions
             Assert.Equal(JsonPointer.Parse("/foo/bar"), sut.Pointer);
             Assert.Equal("$request.body#/foo/bar", sut.ToString());
         }
-        
+
         [Fact(DisplayName = nameof(FieldExpression_Parse_ResponseHeader))]
         public static void FieldExpression_Parse_ResponseHeader()
         {
@@ -112,5 +118,7 @@ namespace SourceCode.Clay.OpenApi.Tests.Expressions
             Assert.Equal(JsonPointer.Parse("/foo/bar"), sut.Pointer);
             Assert.Equal("$response.body#/foo/bar", sut.ToString());
         }
+
+        #endregion
     }
 }

--- a/src/SourceCode.Clay.OpenApi.Tests/ReferenceTests.cs
+++ b/src/SourceCode.Clay.OpenApi.Tests/ReferenceTests.cs
@@ -1,3 +1,10 @@
+#region License
+
+// Copyright (c) K2 Workflow (SourceCode Technology Holdings Inc.). All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+#endregion
+
 using SourceCode.Clay.Json.Pointers;
 using System;
 using Xunit;
@@ -6,6 +13,8 @@ namespace SourceCode.Clay.OpenApi.Tests
 {
     public static class ReferenceTests
     {
+        #region Methods
+
         [Fact(DisplayName = nameof(Reference_ParseUrl_Absolute))]
         public static void Reference_ParseUrl_Absolute()
         {
@@ -41,5 +50,7 @@ namespace SourceCode.Clay.OpenApi.Tests
             Assert.Equal(JsonPointer.Parse("/test/path"), sut.Pointer);
             Assert.Equal("/openapi.json#/test/path", sut.ToString());
         }
+
+        #endregion
     }
 }

--- a/src/SourceCode.Clay.OpenApi/ApiKeySecurityScheme.cs
+++ b/src/SourceCode.Clay.OpenApi/ApiKeySecurityScheme.cs
@@ -1,3 +1,10 @@
+#region License
+
+// Copyright (c) K2 Workflow (SourceCode Technology Holdings Inc.). All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+#endregion
+
 using System;
 
 namespace SourceCode.Clay.OpenApi
@@ -7,6 +14,8 @@ namespace SourceCode.Clay.OpenApi
     /// </summary>
     public class ApiKeySecurityScheme : SecurityScheme, IEquatable<ApiKeySecurityScheme>
     {
+        #region Properties
+
         /// <summary>Gets the type of the security scheme.</summary>
         public override SecuritySchemeType Type => SecuritySchemeType.ApiKey;
 
@@ -19,6 +28,10 @@ namespace SourceCode.Clay.OpenApi
         /// Gets the location of the API key.
         /// </summary>
         public ParameterLocation Location { get; }
+
+        #endregion
+
+        #region Constructors
 
         /// <summary>
         /// Creates a new instance of the <see cref="ApiKeySecurityScheme"/> class.
@@ -36,7 +49,19 @@ namespace SourceCode.Clay.OpenApi
             Location = location;
         }
 
+        #endregion
+
         #region Equatable
+
+        public static bool operator ==(ApiKeySecurityScheme scheme1, ApiKeySecurityScheme scheme2)
+        {
+            if (ReferenceEquals(scheme1, null) && ReferenceEquals(scheme2, null)) return true;
+            if (ReferenceEquals(scheme1, null) || ReferenceEquals(scheme2, null)) return false;
+            return scheme1.Equals((object)scheme2);
+        }
+
+        public static bool operator !=(ApiKeySecurityScheme scheme1, ApiKeySecurityScheme scheme2)
+                    => !(scheme1 == scheme2);
 
         /// <summary>Determines whether the specified object is equal to the current object.</summary>
         /// <param name="obj">The object to compare with the current object.</param>
@@ -70,16 +95,6 @@ namespace SourceCode.Clay.OpenApi
                 return ((int)(hc >> 32)) ^ (int)hc;
             }
         }
-
-        public static bool operator ==(ApiKeySecurityScheme scheme1, ApiKeySecurityScheme scheme2)
-        {
-            if (ReferenceEquals(scheme1, null) && ReferenceEquals(scheme2, null)) return true;
-            if (ReferenceEquals(scheme1, null) || ReferenceEquals(scheme2, null)) return false;
-            return scheme1.Equals((object)scheme2);
-        }
-
-        public static bool operator !=(ApiKeySecurityScheme scheme1, ApiKeySecurityScheme scheme2)
-            => !(scheme1 == scheme2);
 
         #endregion
     }

--- a/src/SourceCode.Clay.OpenApi/Callback.cs
+++ b/src/SourceCode.Clay.OpenApi/Callback.cs
@@ -1,3 +1,10 @@
+#region License
+
+// Copyright (c) K2 Workflow (SourceCode Technology Holdings Inc.). All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+#endregion
+
 using SourceCode.Clay.Collections.Generic;
 using SourceCode.Clay.OpenApi.Expressions;
 using System;
@@ -82,6 +89,15 @@ namespace SourceCode.Clay.OpenApi
 
         #region IEquatable
 
+        public static bool operator ==(Callback callback1, Callback callback2)
+        {
+            if (ReferenceEquals(callback1, null) && ReferenceEquals(callback2, null)) return true;
+            if (ReferenceEquals(callback1, null) || ReferenceEquals(callback2, null)) return false;
+            return callback1.Equals((object)callback2);
+        }
+
+        public static bool operator !=(Callback callback1, Callback callback2) => !(callback1 == callback2);
+
         /// <summary>Determines whether the specified object is equal to the current object.</summary>
         /// <param name="obj">The object to compare with the current object.</param>
         /// <returns>true if the specified object  is equal to the current object; otherwise, false.</returns>
@@ -113,15 +129,6 @@ namespace SourceCode.Clay.OpenApi
                 return ((int)(hc >> 32)) ^ (int)hc;
             }
         }
-
-        public static bool operator ==(Callback callback1, Callback callback2)
-        {
-            if (ReferenceEquals(callback1, null) && ReferenceEquals(callback2, null)) return true;
-            if (ReferenceEquals(callback1, null) || ReferenceEquals(callback2, null)) return false;
-            return callback1.Equals((object)callback2);
-        }
-
-        public static bool operator !=(Callback callback1, Callback callback2) => !(callback1 == callback2);
 
         #endregion
     }

--- a/src/SourceCode.Clay.OpenApi/Components.cs
+++ b/src/SourceCode.Clay.OpenApi/Components.cs
@@ -1,3 +1,10 @@
+#region License
+
+// Copyright (c) K2 Workflow (SourceCode Technology Holdings Inc.). All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+#endregion
+
 using SourceCode.Clay.Collections.Generic;
 using System;
 using System.Collections.Generic;
@@ -100,6 +107,15 @@ namespace SourceCode.Clay.OpenApi
 
         #region IEquatable
 
+        public static bool operator ==(Components components1, Components components2)
+        {
+            if (ReferenceEquals(components1, null) && ReferenceEquals(components2, null)) return true;
+            if (ReferenceEquals(components1, null) || ReferenceEquals(components2, null)) return false;
+            return components1.Equals((object)components2);
+        }
+
+        public static bool operator !=(Components components1, Components components2) => !(components1 == components2);
+
         /// <summary>Determines whether the specified object is equal to the current object.</summary>
         /// <param name="obj">The object to compare with the current object.</param>
         /// <returns>true if the specified object  is equal to the current object; otherwise, false.</returns>
@@ -147,15 +163,6 @@ namespace SourceCode.Clay.OpenApi
                 return ((int)(hc >> 32)) ^ (int)hc;
             }
         }
-
-        public static bool operator ==(Components components1, Components components2)
-        {
-            if (ReferenceEquals(components1, null) && ReferenceEquals(components2, null)) return true;
-            if (ReferenceEquals(components1, null) || ReferenceEquals(components2, null)) return false;
-            return components1.Equals((object)components2);
-        }
-
-        public static bool operator !=(Components components1, Components components2) => !(components1 == components2);
 
         #endregion
     }

--- a/src/SourceCode.Clay.OpenApi/Contact.cs
+++ b/src/SourceCode.Clay.OpenApi/Contact.cs
@@ -1,3 +1,10 @@
+#region License
+
+// Copyright (c) K2 Workflow (SourceCode Technology Holdings Inc.). All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+#endregion
+
 using System;
 using System.Net.Mail;
 
@@ -27,6 +34,8 @@ namespace SourceCode.Clay.OpenApi
 
         #endregion
 
+        #region Constructors
+
         /// <summary>
         /// Creates a new instance of the <see cref="Contact"/> class.
         /// </summary>
@@ -43,7 +52,18 @@ namespace SourceCode.Clay.OpenApi
             Email = email;
         }
 
+        #endregion
+
         #region IEquatable
+
+        public static bool operator ==(Contact contact1, Contact contact2)
+        {
+            if (ReferenceEquals(contact1, null) && ReferenceEquals(contact2, null)) return true;
+            if (ReferenceEquals(contact1, null) || ReferenceEquals(contact2, null)) return false;
+            return contact1.Equals((object)contact2);
+        }
+
+        public static bool operator !=(Contact contact1, Contact contact2) => !(contact1 == contact2);
 
         /// <summary>Determines whether the specified object is equal to the current object.</summary>
         /// <param name="obj">The object to compare with the current object.</param>
@@ -84,15 +104,6 @@ namespace SourceCode.Clay.OpenApi
                 return ((int)(hc >> 32)) ^ (int)hc;
             }
         }
-
-        public static bool operator ==(Contact contact1, Contact contact2)
-        {
-            if (ReferenceEquals(contact1, null) && ReferenceEquals(contact2, null)) return true;
-            if (ReferenceEquals(contact1, null) || ReferenceEquals(contact2, null)) return false;
-            return contact1.Equals((object)contact2);
-        }
-
-        public static bool operator !=(Contact contact1, Contact contact2) => !(contact1 == contact2);
 
         #endregion
     }

--- a/src/SourceCode.Clay.OpenApi/CountRange.cs
+++ b/src/SourceCode.Clay.OpenApi/CountRange.cs
@@ -1,3 +1,10 @@
+#region License
+
+// Copyright (c) K2 Workflow (SourceCode Technology Holdings Inc.). All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+#endregion
+
 using System;
 using System.Collections.Generic;
 using System.Globalization;
@@ -10,6 +17,8 @@ namespace SourceCode.Clay.OpenApi
     /// </summary>
     public struct CountRange : IEquatable<CountRange>
     {
+        #region Properties
+
         /// <summary>
         /// Gets the minimum value.
         /// </summary>
@@ -30,6 +39,10 @@ namespace SourceCode.Clay.OpenApi
         /// has a value.
         /// </summary>
         public bool HasValue => Minimum.HasValue || Maximum.HasValue;
+
+        #endregion
+
+        #region Constructors
 
         /// <summary>
         /// Creates a new inclusive <see cref="NumberRange"/> value.
@@ -57,6 +70,10 @@ namespace SourceCode.Clay.OpenApi
             Maximum = maximum;
             RangeOptions = rangeOptions;
         }
+
+        #endregion
+
+        #region Methods
 
         /// <summary>Indicates whether this instance and a specified object are equal.</summary>
         /// <param name="obj">The object to compare with the current instance.</param>
@@ -111,5 +128,7 @@ namespace SourceCode.Clay.OpenApi
 
             return sb.ToString();
         }
+
+        #endregion
     }
 }

--- a/src/SourceCode.Clay.OpenApi/DataTypeFormat.cs
+++ b/src/SourceCode.Clay.OpenApi/DataTypeFormat.cs
@@ -1,18 +1,31 @@
-﻿namespace SourceCode.Clay.OpenApi
+#region License
+
+// Copyright (c) K2 Workflow (SourceCode Technology Holdings Inc.). All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+#endregion
+
+namespace SourceCode.Clay.OpenApi
 {
     /// <summary>
     /// Well-known data type formats.
     /// </summary>
     public static class DataTypeFormat
     {
+        #region Classes
+
         /// <summary>
         /// Standard formats as defined by the specification
         /// https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.0.md#data-types
         /// </summary>
         public static class Standard
         {
+            #region Classes
+
             public static class Integer
             {
+                #region Fields
+
                 /// <summary>
                 /// Signed 32 bits.
                 /// </summary>
@@ -22,10 +35,14 @@
                 /// Signed 64 bits.
                 /// </summary>
                 public const string Int64 = "int64";
+
+                #endregion
             }
 
             public static class Number
             {
+                #region Fields
+
                 /// <summary>
                 /// Real 32 bits.
                 /// </summary>
@@ -35,10 +52,14 @@
                 /// Real 64 bits.
                 /// </summary>
                 public const string Double = "double";
+
+                #endregion
             }
 
             public static class String
             {
+                #region Fields
+
                 /// <summary>
                 /// Base64 encoded characters.
                 /// </summary>
@@ -65,8 +86,14 @@
                 /// <summary>
                 /// A hint to UIs to obscured input.
                 /// </summary>
-                public const string Password = "pass" + "word"; // FxCop complains
+                public const string Password = "pass" + "word";
+
+                #endregion
+
+                // FxCop complains
             }
+
+            #endregion
         }
 
         /// <summary>
@@ -74,8 +101,12 @@
         /// </summary>
         public static class Extended
         {
+            #region Classes
+
             public static class String
             {
+                #region Fields
+
                 /// <summary>
                 /// A timestamp.
                 /// </summary>
@@ -85,7 +116,13 @@
                 /// A GUID.
                 /// </summary>
                 public const string Guid = "uuid";
+
+                #endregion
             }
+
+            #endregion
         }
+
+        #endregion
     }
 }

--- a/src/SourceCode.Clay.OpenApi/Document.cs
+++ b/src/SourceCode.Clay.OpenApi/Document.cs
@@ -1,3 +1,10 @@
+#region License
+
+// Copyright (c) K2 Workflow (SourceCode Technology Holdings Inc.). All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+#endregion
+
 using SourceCode.Clay.Collections.Generic;
 using System;
 using System.Collections.Generic;
@@ -90,6 +97,15 @@ namespace SourceCode.Clay.OpenApi
 
         #region IEquatable
 
+        public static bool operator ==(Document document1, Document document2)
+        {
+            if (ReferenceEquals(document1, null) && ReferenceEquals(document2, null)) return true;
+            if (ReferenceEquals(document1, null) || ReferenceEquals(document2, null)) return false;
+            return document1.Equals((object)document2);
+        }
+
+        public static bool operator !=(Document document1, Document document2) => !(document1 == document2);
+
         /// <summary>Determines whether the specified object is equal to the current object.</summary>
         /// <param name="obj">The object to compare with the current object.</param>
         /// <returns>true if the specified object  is equal to the current object; otherwise, false.</returns>
@@ -135,15 +151,6 @@ namespace SourceCode.Clay.OpenApi
                 return ((int)(hc >> 32)) ^ (int)hc;
             }
         }
-
-        public static bool operator ==(Document document1, Document document2)
-        {
-            if (ReferenceEquals(document1, null) && ReferenceEquals(document2, null)) return true;
-            if (ReferenceEquals(document1, null) || ReferenceEquals(document2, null)) return false;
-            return document1.Equals((object)document2);
-        }
-
-        public static bool operator !=(Document document1, Document document2) => !(document1 == document2);
 
         #endregion
     }

--- a/src/SourceCode.Clay.OpenApi/Example.cs
+++ b/src/SourceCode.Clay.OpenApi/Example.cs
@@ -1,3 +1,10 @@
+#region License
+
+// Copyright (c) K2 Workflow (SourceCode Technology Holdings Inc.). All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+#endregion
+
 using System;
 
 namespace SourceCode.Clay.OpenApi
@@ -53,6 +60,15 @@ namespace SourceCode.Clay.OpenApi
 
         #region IEquatable
 
+        public static bool operator ==(Example example1, Example example2)
+        {
+            if (ReferenceEquals(example1, null) && ReferenceEquals(example2, null)) return true;
+            if (ReferenceEquals(example1, null) || ReferenceEquals(example2, null)) return false;
+            return example1.Equals((object)example2);
+        }
+
+        public static bool operator !=(Example example1, Example example2) => !(example1 == example2);
+
         /// <summary>Determines whether the specified object is equal to the current object.</summary>
         /// <param name="obj">The object to compare with the current object.</param>
         /// <returns>true if the specified object  is equal to the current object; otherwise, false.</returns>
@@ -88,15 +104,6 @@ namespace SourceCode.Clay.OpenApi
                 return ((int)(hc >> 32)) ^ (int)hc;
             }
         }
-
-        public static bool operator ==(Example example1, Example example2)
-        {
-            if (ReferenceEquals(example1, null) && ReferenceEquals(example2, null)) return true;
-            if (ReferenceEquals(example1, null) || ReferenceEquals(example2, null)) return false;
-            return example1.Equals((object)example2);
-        }
-
-        public static bool operator !=(Example example1, Example example2) => !(example1 == example2);
 
         #endregion
     }

--- a/src/SourceCode.Clay.OpenApi/Expressions/CompoundExpression.cs
+++ b/src/SourceCode.Clay.OpenApi/Expressions/CompoundExpression.cs
@@ -1,3 +1,10 @@
+#region License
+
+// Copyright (c) K2 Workflow (SourceCode Technology Holdings Inc.). All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+#endregion
+
 using System;
 using System.Collections;
 using System.Collections.Generic;
@@ -14,14 +21,14 @@ namespace SourceCode.Clay.OpenApi.Expressions
 
         private readonly ExpressionComponent[] _components;
 
+        /// <summary>Gets the number of elements in the collection.</summary>
+        /// <returns>The number of elements in the collection.</returns>
+        public int Count => _components?.Length ?? 0;
+
         /// <summary>Gets the element at the specified index in the read-only list.</summary>
         /// <param name="index">The zero-based index of the element to get.</param>
         /// <returns>The element at the specified index in the read-only list.</returns>
         public ExpressionComponent this[int index] => (_components ?? Array.Empty<ExpressionComponent>())[index];
-
-        /// <summary>Gets the number of elements in the collection.</summary>
-        /// <returns>The number of elements in the collection.</returns>
-        public int Count => _components?.Length ?? 0;
 
         #endregion
 
@@ -94,37 +101,6 @@ namespace SourceCode.Clay.OpenApi.Expressions
         #endregion
 
         #region String
-
-        /// <summary>Returns the string format of the expression.</summary>
-        /// <returns>The string format of the expression.</returns>
-        public override string ToString()
-        {
-            if (_components == null) return string.Empty;
-
-            var sb = new StringBuilder();
-            for (var i = 0; i < _components.Length; i++)
-            {
-                var component = _components[i];
-
-                if (component is LiteralExpression literal)
-                {
-                    for (var j = 0; j < literal.Value.Length; j++)
-                    {
-                        var c = literal.Value[j];
-                        sb.Append(c);
-                        if (c == '{' || c == '}') sb.Append(c);
-                    }
-                }
-                else if (component is FieldExpression field)
-                {
-                    sb.Append("{");
-                    field.ToString(sb);
-                    sb.Append("}");
-                }
-            }
-
-            return sb.ToString();
-        }
 
         /// <summary>
         /// Converts the string representation of an expression to its structured equivalent.
@@ -210,6 +186,37 @@ namespace SourceCode.Clay.OpenApi.Expressions
 
             result = new CompoundExpression(components.ToArray());
             return true;
+        }
+
+        /// <summary>Returns the string format of the expression.</summary>
+        /// <returns>The string format of the expression.</returns>
+        public override string ToString()
+        {
+            if (_components == null) return string.Empty;
+
+            var sb = new StringBuilder();
+            for (var i = 0; i < _components.Length; i++)
+            {
+                var component = _components[i];
+
+                if (component is LiteralExpression literal)
+                {
+                    for (var j = 0; j < literal.Value.Length; j++)
+                    {
+                        var c = literal.Value[j];
+                        sb.Append(c);
+                        if (c == '{' || c == '}') sb.Append(c);
+                    }
+                }
+                else if (component is FieldExpression field)
+                {
+                    sb.Append("{");
+                    field.ToString(sb);
+                    sb.Append("}");
+                }
+            }
+
+            return sb.ToString();
         }
 
         #endregion

--- a/src/SourceCode.Clay.OpenApi/Expressions/ExpressionComponent.cs
+++ b/src/SourceCode.Clay.OpenApi/Expressions/ExpressionComponent.cs
@@ -1,3 +1,10 @@
+#region License
+
+// Copyright (c) K2 Workflow (SourceCode Technology Holdings Inc.). All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+#endregion
+
 using System;
 
 namespace SourceCode.Clay.OpenApi.Expressions
@@ -7,14 +14,18 @@ namespace SourceCode.Clay.OpenApi.Expressions
     /// </summary>
     public abstract class ExpressionComponent : IEquatable<ExpressionComponent>
     {
+        #region Properties
+
         /// <summary>
         /// Gets the component type.
         /// </summary>
         public abstract ExpressionComponentType ComponentType { get; }
 
+        #endregion
+
         #region Ctor
 
-#       pragma warning disable S3442 // "abstract" classes should not have "public" constructors
+#pragma warning disable S3442 // "abstract" classes should not have "public" constructors
         // Reasoning: external inheritance not supported.
 
         /// <summary>
@@ -24,11 +35,21 @@ namespace SourceCode.Clay.OpenApi.Expressions
         {
         }
 
-#       pragma warning restore S3442 // "abstract" classes should not have "public" constructors
+#pragma warning restore S3442 // "abstract" classes should not have "public" constructors
 
         #endregion
 
         #region Equality
+
+        public static bool operator ==(ExpressionComponent expression1, ExpressionComponent expression2)
+        {
+            if (ReferenceEquals(expression1, expression2)) return true;
+            if (ReferenceEquals(expression1, null) || ReferenceEquals(expression2, null)) return false;
+
+            return expression1.Equals(expression2);
+        }
+
+        public static bool operator !=(ExpressionComponent expression1, ExpressionComponent expression2) => !(expression1 == expression2);
 
         /// <summary>Determines whether the specified object is equal to the current object.</summary>
         /// <param name="obj">The object to compare with the current object.</param>
@@ -56,16 +77,6 @@ namespace SourceCode.Clay.OpenApi.Expressions
             if (ComponentType != other.ComponentType) return false;
             return Equals(other);
         }
-
-        public static bool operator ==(ExpressionComponent expression1, ExpressionComponent expression2)
-        {
-            if (ReferenceEquals(expression1, expression2)) return true;
-            if (ReferenceEquals(expression1, null) || ReferenceEquals(expression2, null)) return false;
-
-            return expression1.Equals(expression2);
-        }
-
-        public static bool operator !=(ExpressionComponent expression1, ExpressionComponent expression2) => !(expression1 == expression2);
 
         #endregion
     }

--- a/src/SourceCode.Clay.OpenApi/Expressions/ExpressionComponentType.cs
+++ b/src/SourceCode.Clay.OpenApi/Expressions/ExpressionComponentType.cs
@@ -1,3 +1,10 @@
+#region License
+
+// Copyright (c) K2 Workflow (SourceCode Technology Holdings Inc.). All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+#endregion
+
 namespace SourceCode.Clay.OpenApi.Expressions
 {
     /// <summary>

--- a/src/SourceCode.Clay.OpenApi/Expressions/FieldExpression.cs
+++ b/src/SourceCode.Clay.OpenApi/Expressions/FieldExpression.cs
@@ -1,3 +1,10 @@
+#region License
+
+// Copyright (c) K2 Workflow (SourceCode Technology Holdings Inc.). All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+#endregion
+
 using SourceCode.Clay.Json.Pointers;
 using System;
 using System.Collections.Generic;
@@ -278,64 +285,15 @@ namespace SourceCode.Clay.OpenApi.Expressions
 
         #region String
 
-        /// <summary>Returns a string that represents the current object.</summary>
-        /// <returns>A string that represents the current object.</returns>
-        public override string ToString()
+        private static bool StartsWith(string s, string cmp, int index)
         {
-            var sb = new StringBuilder();
-            ToString(sb);
-            return sb.ToString();
-        }
-
-        internal void ToString(StringBuilder sb)
-        {
-            switch (ExpressionType)
+            for (var i = 0; i < cmp.Length; i++)
             {
-                case FieldExpressionType.Url: sb.Append("$url"); return;
-                case FieldExpressionType.Method: sb.Append("$method"); return;
-                case FieldExpressionType.StatusCode: sb.Append("$statusCode"); return;
-                case FieldExpressionType.Request: sb.Append("$request."); break;
-                case FieldExpressionType.Response: sb.Append("$response."); break;
+                if (index >= s.Length) return false;
+                if (s[index] != cmp[i]) return false;
+                index++;
             }
-
-            switch (ExpressionSource)
-            {
-                case FieldExpressionSource.Header: sb.Append("header.").Append(Name); break;
-                case FieldExpressionSource.Query: sb.Append("query.").Append(Name); break;
-                case FieldExpressionSource.Path: sb.Append("path.").Append(Name); break;
-                case FieldExpressionSource.Body: sb.Append("body#").Append(Pointer.ToString()); break;
-            }
-        }
-
-        /// <summary>
-        /// Converts the string representation of a field expression to its structured equivalent.
-        /// </summary>
-        /// <param name="s">A string containing a field expression to convert.</param>
-        /// <returns>The structured equivalent of the field expression contained in <paramref name="s"/>.</returns>
-        /// <exception cref="ArgumentNullException"><paramref name="s"/> is null.</exception>
-        /// <exception cref="FormatException"><paramref name="s"/> is not in a format compliant with the Open API specification.</exception>
-        public static FieldExpression Parse(string s)
-        {
-            if (!TryParse(s, out var result)) throw new FormatException("The expression is not a valid field expression.");
-            return result;
-        }
-
-        /// <summary>
-        /// Converts the string representation of a field expression to its structured equivalent.
-        /// A return value indicates whether the conversion succeeded.
-        /// </summary>
-        /// <param name="s">A string containing a field expression to convert.</param>
-        /// <param name="result">
-        /// When this method returns, contains the structured equivalent of the field expression contained in <paramref name="s"/>,
-        /// if the conversion succeeded, or default if the conversion failed. The conversion fails if the <paramref name="s"/> parameter
-        /// is not in a format compliant with the Open API field expression specification. This parameter is passed uninitialized;
-        /// any value originally supplied in result will be overwritten.
-        /// </param>
-        /// <returns><c>true</c> if s was converted successfully; otherwise, <c>false</c>.</returns>
-        public static bool TryParse(string s, out FieldExpression result)
-        {
-            var i = 0;
-            return TryParse(s, out result, ref i, false);
+            return true;
         }
 
         internal static bool TryParse(string s, out FieldExpression result, ref int index, bool respectDelimiter)
@@ -493,15 +451,64 @@ namespace SourceCode.Clay.OpenApi.Expressions
             return true;
         }
 
-        private static bool StartsWith(string s, string cmp, int index)
+        internal void ToString(StringBuilder sb)
         {
-            for (var i = 0; i < cmp.Length; i++)
+            switch (ExpressionType)
             {
-                if (index >= s.Length) return false;
-                if (s[index] != cmp[i]) return false;
-                index++;
+                case FieldExpressionType.Url: sb.Append("$url"); return;
+                case FieldExpressionType.Method: sb.Append("$method"); return;
+                case FieldExpressionType.StatusCode: sb.Append("$statusCode"); return;
+                case FieldExpressionType.Request: sb.Append("$request."); break;
+                case FieldExpressionType.Response: sb.Append("$response."); break;
             }
-            return true;
+
+            switch (ExpressionSource)
+            {
+                case FieldExpressionSource.Header: sb.Append("header.").Append(Name); break;
+                case FieldExpressionSource.Query: sb.Append("query.").Append(Name); break;
+                case FieldExpressionSource.Path: sb.Append("path.").Append(Name); break;
+                case FieldExpressionSource.Body: sb.Append("body#").Append(Pointer.ToString()); break;
+            }
+        }
+
+        /// <summary>
+        /// Converts the string representation of a field expression to its structured equivalent.
+        /// </summary>
+        /// <param name="s">A string containing a field expression to convert.</param>
+        /// <returns>The structured equivalent of the field expression contained in <paramref name="s"/>.</returns>
+        /// <exception cref="ArgumentNullException"><paramref name="s"/> is null.</exception>
+        /// <exception cref="FormatException"><paramref name="s"/> is not in a format compliant with the Open API specification.</exception>
+        public static FieldExpression Parse(string s)
+        {
+            if (!TryParse(s, out var result)) throw new FormatException("The expression is not a valid field expression.");
+            return result;
+        }
+
+        /// <summary>
+        /// Converts the string representation of a field expression to its structured equivalent.
+        /// A return value indicates whether the conversion succeeded.
+        /// </summary>
+        /// <param name="s">A string containing a field expression to convert.</param>
+        /// <param name="result">
+        /// When this method returns, contains the structured equivalent of the field expression contained in <paramref name="s"/>,
+        /// if the conversion succeeded, or default if the conversion failed. The conversion fails if the <paramref name="s"/> parameter
+        /// is not in a format compliant with the Open API field expression specification. This parameter is passed uninitialized;
+        /// any value originally supplied in result will be overwritten.
+        /// </param>
+        /// <returns><c>true</c> if s was converted successfully; otherwise, <c>false</c>.</returns>
+        public static bool TryParse(string s, out FieldExpression result)
+        {
+            var i = 0;
+            return TryParse(s, out result, ref i, false);
+        }
+
+        /// <summary>Returns a string that represents the current object.</summary>
+        /// <returns>A string that represents the current object.</returns>
+        public override string ToString()
+        {
+            var sb = new StringBuilder();
+            ToString(sb);
+            return sb.ToString();
         }
 
         #endregion

--- a/src/SourceCode.Clay.OpenApi/Expressions/FieldExpressionSource.cs
+++ b/src/SourceCode.Clay.OpenApi/Expressions/FieldExpressionSource.cs
@@ -1,3 +1,10 @@
+#region License
+
+// Copyright (c) K2 Workflow (SourceCode Technology Holdings Inc.). All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+#endregion
+
 namespace SourceCode.Clay.OpenApi.Expressions
 {
     /// <summary>

--- a/src/SourceCode.Clay.OpenApi/Expressions/FieldExpressionType.cs
+++ b/src/SourceCode.Clay.OpenApi/Expressions/FieldExpressionType.cs
@@ -1,3 +1,10 @@
+#region License
+
+// Copyright (c) K2 Workflow (SourceCode Technology Holdings Inc.). All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+#endregion
+
 namespace SourceCode.Clay.OpenApi.Expressions
 {
     /// <summary>

--- a/src/SourceCode.Clay.OpenApi/Expressions/LiteralExpression.cs
+++ b/src/SourceCode.Clay.OpenApi/Expressions/LiteralExpression.cs
@@ -1,3 +1,10 @@
+#region License
+
+// Copyright (c) K2 Workflow (SourceCode Technology Holdings Inc.). All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+#endregion
+
 using System;
 
 namespace SourceCode.Clay.OpenApi.Expressions
@@ -7,6 +14,8 @@ namespace SourceCode.Clay.OpenApi.Expressions
     /// </summary>
     public sealed class LiteralExpression : ExpressionComponent, IEquatable<LiteralExpression>
     {
+        #region Properties
+
         /// <summary>
         /// Gets the literal value.
         /// </summary>
@@ -14,6 +23,10 @@ namespace SourceCode.Clay.OpenApi.Expressions
 
         /// <summary>Gets the component type.</summary>
         public override ExpressionComponentType ComponentType => ExpressionComponentType.Literal;
+
+        #endregion
+
+        #region Constructors
 
         /// <summary>
         /// Creates a new instance of the <see cref="LiteralExpression"/> class.
@@ -23,6 +36,10 @@ namespace SourceCode.Clay.OpenApi.Expressions
         {
             Value = value ?? throw new ArgumentNullException(nameof(value));
         }
+
+        #endregion
+
+        #region Methods
 
         /// <summary>Determines whether the specified object is equal to the current object.</summary>
         /// <param name="obj">The object to compare with the current object.</param>
@@ -55,5 +72,7 @@ namespace SourceCode.Clay.OpenApi.Expressions
         /// <summary>Returns a string that represents the current object.</summary>
         /// <returns>A string that represents the current object.</returns>
         public override string ToString() => Value;
+
+        #endregion
     }
 }

--- a/src/SourceCode.Clay.OpenApi/ExternalDocumentation.cs
+++ b/src/SourceCode.Clay.OpenApi/ExternalDocumentation.cs
@@ -1,3 +1,10 @@
+#region License
+
+// Copyright (c) K2 Workflow (SourceCode Technology Holdings Inc.). All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+#endregion
+
 using System;
 
 namespace SourceCode.Clay.OpenApi
@@ -24,6 +31,8 @@ namespace SourceCode.Clay.OpenApi
 
         #endregion
 
+        #region Constructors
+
         /// <summary>
         /// Creates a new instance of the <see cref="ExternalDocumentation"/> class.
         /// </summary>
@@ -37,7 +46,19 @@ namespace SourceCode.Clay.OpenApi
             Url = url;
         }
 
+        #endregion
+
         #region IEquatable
+
+        public static bool operator ==(ExternalDocumentation externalDocumentation1, ExternalDocumentation externalDocumentation2)
+        {
+            if (ReferenceEquals(externalDocumentation1, null) && ReferenceEquals(externalDocumentation2, null)) return true;
+            if (ReferenceEquals(externalDocumentation1, null) || ReferenceEquals(externalDocumentation2, null)) return false;
+            return externalDocumentation1.Equals((object)externalDocumentation2);
+        }
+
+        public static bool operator !=(ExternalDocumentation externalDocumentation1, ExternalDocumentation externalDocumentation2)
+                    => !(externalDocumentation1 == externalDocumentation2);
 
         /// <summary>Indicates whether this instance and a specified object are equal.</summary>
         /// <param name="obj">The object to compare with the current instance.</param>
@@ -72,16 +93,6 @@ namespace SourceCode.Clay.OpenApi
                 return ((int)(hc >> 32)) ^ (int)hc;
             }
         }
-
-        public static bool operator ==(ExternalDocumentation externalDocumentation1, ExternalDocumentation externalDocumentation2)
-        {
-            if (ReferenceEquals(externalDocumentation1, null) && ReferenceEquals(externalDocumentation2, null)) return true;
-            if (ReferenceEquals(externalDocumentation1, null) || ReferenceEquals(externalDocumentation2, null)) return false;
-            return externalDocumentation1.Equals((object)externalDocumentation2);
-        }
-
-        public static bool operator !=(ExternalDocumentation externalDocumentation1, ExternalDocumentation externalDocumentation2)
-            => !(externalDocumentation1 == externalDocumentation2);
 
         #endregion
     }

--- a/src/SourceCode.Clay.OpenApi/HttpSecurityScheme.cs
+++ b/src/SourceCode.Clay.OpenApi/HttpSecurityScheme.cs
@@ -26,9 +26,9 @@ namespace SourceCode.Clay.OpenApi
         /// <param name="description">The short description for security scheme.</param>
         /// <param name="scheme">The name of the HTTP Authorization scheme to be used in the Authorization header.</param>
         protected HttpSecurityScheme(
-            string description = null,
-            string scheme = null,
-            string bearerFormat = null)
+            string description = default,
+            string scheme = default,
+            string bearerFormat = default)
             : base(description)
         {
             Scheme = scheme;

--- a/src/SourceCode.Clay.OpenApi/HttpSecurityScheme.cs
+++ b/src/SourceCode.Clay.OpenApi/HttpSecurityScheme.cs
@@ -1,3 +1,10 @@
+#region License
+
+// Copyright (c) K2 Workflow (SourceCode Technology Holdings Inc.). All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+#endregion
+
 using System;
 
 namespace SourceCode.Clay.OpenApi
@@ -7,18 +14,7 @@ namespace SourceCode.Clay.OpenApi
     /// </summary>
     public class HttpSecurityScheme : SecurityScheme, IEquatable<HttpSecurityScheme>
     {
-        /// <summary>Gets the type of the security scheme.</summary>
-        public override SecuritySchemeType Type => SecuritySchemeType.Http;
-
-        /// <summary>
-        /// Gets the name of the HTTP Authorization scheme to be used in the Authorization header.
-        /// </summary>
-        public string Scheme { get; }
-
-        /// <summary>
-        /// Gets the hint to the client to identify how the bearer token is formatted.
-        /// </summary>
-        public string BearerFormat { get; }
+        #region Constructors
 
         /// <summary>
         /// Creates a new instance of the <see cref="HttpSecurityScheme"/> class.
@@ -35,7 +31,36 @@ namespace SourceCode.Clay.OpenApi
             BearerFormat = bearerFormat;
         }
 
+        #endregion
+
+        #region Properties
+
+        /// <summary>Gets the type of the security scheme.</summary>
+        public override SecuritySchemeType Type => SecuritySchemeType.Http;
+
+        /// <summary>
+        /// Gets the name of the HTTP Authorization scheme to be used in the Authorization header.
+        /// </summary>
+        public string Scheme { get; }
+
+        /// <summary>
+        /// Gets the hint to the client to identify how the bearer token is formatted.
+        /// </summary>
+        public string BearerFormat { get; }
+
+        #endregion
+
         #region Equatable
+
+        public static bool operator ==(HttpSecurityScheme scheme1, HttpSecurityScheme scheme2)
+        {
+            if (ReferenceEquals(scheme1, null) && ReferenceEquals(scheme2, null)) return true;
+            if (ReferenceEquals(scheme1, null) || ReferenceEquals(scheme2, null)) return false;
+            return scheme1.Equals((object)scheme2);
+        }
+
+        public static bool operator !=(HttpSecurityScheme scheme1, HttpSecurityScheme scheme2)
+                    => !(scheme1 == scheme2);
 
         /// <summary>Determines whether the specified object is equal to the current object.</summary>
         /// <param name="obj">The object to compare with the current object.</param>
@@ -69,16 +94,6 @@ namespace SourceCode.Clay.OpenApi
                 return ((int)(hc >> 32)) ^ (int)hc;
             }
         }
-
-        public static bool operator ==(HttpSecurityScheme scheme1, HttpSecurityScheme scheme2)
-        {
-            if (ReferenceEquals(scheme1, null) && ReferenceEquals(scheme2, null)) return true;
-            if (ReferenceEquals(scheme1, null) || ReferenceEquals(scheme2, null)) return false;
-            return scheme1.Equals((object)scheme2);
-        }
-
-        public static bool operator !=(HttpSecurityScheme scheme1, HttpSecurityScheme scheme2)
-            => !(scheme1 == scheme2);
 
         #endregion
     }

--- a/src/SourceCode.Clay.OpenApi/Information.cs
+++ b/src/SourceCode.Clay.OpenApi/Information.cs
@@ -1,3 +1,10 @@
+#region License
+
+// Copyright (c) K2 Workflow (SourceCode Technology Holdings Inc.). All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+#endregion
+
 using System;
 
 namespace SourceCode.Clay.OpenApi
@@ -77,6 +84,16 @@ namespace SourceCode.Clay.OpenApi
 
         #region IEquatable
 
+        public static bool operator ==(Information information1, Information information2)
+        {
+            if (ReferenceEquals(information1, null) && ReferenceEquals(information2, null)) return true;
+            if (ReferenceEquals(information1, null) || ReferenceEquals(information2, null)) return false;
+            return information1.Equals((object)information2);
+        }
+
+        public static bool operator !=(Information information1, Information information2)
+                    => !(information1 == information2);
+
         /// <summary>Determines whether the specified object is equal to the current object.</summary>
         /// <param name="obj">The object to compare with the current object.</param>
         /// <returns>true if the specified object  is equal to the current object; otherwise, false.</returns>
@@ -114,16 +131,6 @@ namespace SourceCode.Clay.OpenApi
 
             return hc;
         }
-
-        public static bool operator ==(Information information1, Information information2)
-        {
-            if (ReferenceEquals(information1, null) && ReferenceEquals(information2, null)) return true;
-            if (ReferenceEquals(information1, null) || ReferenceEquals(information2, null)) return false;
-            return information1.Equals((object)information2);
-        }
-
-        public static bool operator !=(Information information1, Information information2)
-            => !(information1 == information2);
 
         #endregion
     }

--- a/src/SourceCode.Clay.OpenApi/License.cs
+++ b/src/SourceCode.Clay.OpenApi/License.cs
@@ -29,8 +29,8 @@ namespace SourceCode.Clay.OpenApi
         /// <param name="name">The licese named used for the API.</param>
         /// <param name="url">The URL to the license used for the API.</param>
         public License(
-            string name = null,
-            Uri url = null)
+            string name = default,
+            Uri url = default)
         {
             Name = name;
             Url = url;

--- a/src/SourceCode.Clay.OpenApi/License.cs
+++ b/src/SourceCode.Clay.OpenApi/License.cs
@@ -1,3 +1,10 @@
+#region License
+
+// Copyright (c) K2 Workflow (SourceCode Technology Holdings Inc.). All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+#endregion
+
 using System;
 
 namespace SourceCode.Clay.OpenApi
@@ -40,6 +47,15 @@ namespace SourceCode.Clay.OpenApi
 
         #region IEquatable
 
+        public static bool operator ==(License license1, License license2)
+        {
+            if (ReferenceEquals(license1, null) && ReferenceEquals(license2, null)) return true;
+            if (ReferenceEquals(license1, null) || ReferenceEquals(license2, null)) return false;
+            return license1.Equals((object)license2);
+        }
+
+        public static bool operator !=(License license1, License license2) => !(license1 == license2);
+
         /// <summary>Determines whether the specified object is equal to the current object.</summary>
         /// <param name="obj">The object to compare with the current object.</param>
         /// <returns>true if the specified object  is equal to the current object; otherwise, false.</returns>
@@ -73,15 +89,6 @@ namespace SourceCode.Clay.OpenApi
                 return ((int)(hc >> 32)) ^ (int)hc;
             }
         }
-
-        public static bool operator ==(License license1, License license2)
-        {
-            if (ReferenceEquals(license1, null) && ReferenceEquals(license2, null)) return true;
-            if (ReferenceEquals(license1, null) || ReferenceEquals(license2, null)) return false;
-            return license1.Equals((object)license2);
-        }
-
-        public static bool operator !=(License license1, License license2) => !(license1 == license2);
 
         #endregion
     }

--- a/src/SourceCode.Clay.OpenApi/Link.cs
+++ b/src/SourceCode.Clay.OpenApi/Link.cs
@@ -1,3 +1,10 @@
+#region License
+
+// Copyright (c) K2 Workflow (SourceCode Technology Holdings Inc.). All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+#endregion
+
 using System;
 
 namespace SourceCode.Clay.OpenApi
@@ -63,6 +70,15 @@ namespace SourceCode.Clay.OpenApi
 
         #region IEquatable
 
+        public static bool operator ==(Link link1, Link link2)
+        {
+            if (ReferenceEquals(link1, null) && ReferenceEquals(link2, null)) return true;
+            if (ReferenceEquals(link1, null) || ReferenceEquals(link2, null)) return false;
+            return link1.Equals((object)link2);
+        }
+
+        public static bool operator !=(Link link1, Link link2) => !(link1 == link2);
+
         /// <summary>Determines whether the specified object is equal to the current object.</summary>
         /// <param name="obj">The object to compare with the current object.</param>
         /// <returns>true if the specified object  is equal to the current object; otherwise, false.</returns>
@@ -100,15 +116,6 @@ namespace SourceCode.Clay.OpenApi
                 return ((int)(hc >> 32)) ^ (int)hc;
             }
         }
-
-        public static bool operator ==(Link link1, Link link2)
-        {
-            if (ReferenceEquals(link1, null) && ReferenceEquals(link2, null)) return true;
-            if (ReferenceEquals(link1, null) || ReferenceEquals(link2, null)) return false;
-            return link1.Equals((object)link2);
-        }
-
-        public static bool operator !=(Link link1, Link link2) => !(link1 == link2);
 
         #endregion
     }

--- a/src/SourceCode.Clay.OpenApi/MediaType.cs
+++ b/src/SourceCode.Clay.OpenApi/MediaType.cs
@@ -1,3 +1,10 @@
+#region License
+
+// Copyright (c) K2 Workflow (SourceCode Technology Holdings Inc.). All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+#endregion
+
 using SourceCode.Clay.Collections.Generic;
 using System;
 using System.Collections.Generic;
@@ -54,6 +61,15 @@ namespace SourceCode.Clay.OpenApi
 
         #region IEquatable
 
+        public static bool operator ==(MediaType mediaType1, MediaType mediaType2)
+        {
+            if (ReferenceEquals(mediaType1, null) && ReferenceEquals(mediaType2, null)) return true;
+            if (ReferenceEquals(mediaType1, null) || ReferenceEquals(mediaType2, null)) return false;
+            return mediaType1.Equals((object)mediaType2);
+        }
+
+        public static bool operator !=(MediaType mediaType1, MediaType mediaType2) => !(mediaType1 == mediaType2);
+
         /// <summary>Determines whether the specified object is equal to the current object.</summary>
         /// <param name="obj">The object to compare with the current object.</param>
         /// <returns>true if the specified object  is equal to the current object; otherwise, false.</returns>
@@ -89,15 +105,6 @@ namespace SourceCode.Clay.OpenApi
                 return ((int)(hc >> 32)) ^ (int)hc;
             }
         }
-
-        public static bool operator ==(MediaType mediaType1, MediaType mediaType2)
-        {
-            if (ReferenceEquals(mediaType1, null) && ReferenceEquals(mediaType2, null)) return true;
-            if (ReferenceEquals(mediaType1, null) || ReferenceEquals(mediaType2, null)) return false;
-            return mediaType1.Equals((object)mediaType2);
-        }
-
-        public static bool operator !=(MediaType mediaType1, MediaType mediaType2) => !(mediaType1 == mediaType2);
 
         #endregion
     }

--- a/src/SourceCode.Clay.OpenApi/NumberRange.cs
+++ b/src/SourceCode.Clay.OpenApi/NumberRange.cs
@@ -1,3 +1,10 @@
+#region License
+
+// Copyright (c) K2 Workflow (SourceCode Technology Holdings Inc.). All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+#endregion
+
 using System;
 using System.Collections.Generic;
 using System.Globalization;
@@ -10,6 +17,8 @@ namespace SourceCode.Clay.OpenApi
     /// </summary>
     public struct NumberRange : IEquatable<NumberRange>
     {
+        #region Properties
+
         /// <summary>
         /// Gets the minimum value.
         /// </summary>
@@ -35,6 +44,10 @@ namespace SourceCode.Clay.OpenApi
         /// has a value.
         /// </summary>
         public bool HasValue => Minimum.HasValue || Maximum.HasValue;
+
+        #endregion
+
+        #region Constructors
 
         /// <summary>
         /// Creates a new inclusive <see cref="NumberRange"/> value.
@@ -75,6 +88,10 @@ namespace SourceCode.Clay.OpenApi
             MultipleOf = multipleOf;
             RangeOptions = rangeOptions;
         }
+
+        #endregion
+
+        #region Methods
 
         /// <summary>Indicates whether this instance and a specified object are equal.</summary>
         /// <param name="obj">The object to compare with the current instance.</param>
@@ -133,5 +150,7 @@ namespace SourceCode.Clay.OpenApi
 
             return sb.ToString();
         }
+
+        #endregion
     }
 }

--- a/src/SourceCode.Clay.OpenApi/OAuth2SecurityScheme.cs
+++ b/src/SourceCode.Clay.OpenApi/OAuth2SecurityScheme.cs
@@ -1,3 +1,10 @@
+#region License
+
+// Copyright (c) K2 Workflow (SourceCode Technology Holdings Inc.). All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+#endregion
+
 using System;
 
 namespace SourceCode.Clay.OpenApi
@@ -7,6 +14,8 @@ namespace SourceCode.Clay.OpenApi
     /// </summary>
     public class OAuth2SecurityScheme : SecurityScheme, IEquatable<OAuth2SecurityScheme>
     {
+        #region Properties
+
         /// <summary>Gets the type of the security scheme.</summary>
         public override SecuritySchemeType Type => SecuritySchemeType.OAuth2;
 
@@ -30,6 +39,10 @@ namespace SourceCode.Clay.OpenApi
         /// </summary>
         public OAuthFlow AuthorizationCodeFlow { get; }
 
+        #endregion
+
+        #region Constructors
+
         /// <summary>
         /// Creates a new instance of the <see cref="OAuth2SecurityScheme"/> class.
         /// </summary>
@@ -51,7 +64,19 @@ namespace SourceCode.Clay.OpenApi
             AuthorizationCodeFlow = authorizationCodeFlow;
         }
 
+        #endregion
+
         #region Equatable
+
+        public static bool operator ==(OAuth2SecurityScheme scheme1, OAuth2SecurityScheme scheme2)
+        {
+            if (ReferenceEquals(scheme1, null) && ReferenceEquals(scheme2, null)) return true;
+            if (ReferenceEquals(scheme1, null) || ReferenceEquals(scheme2, null)) return false;
+            return scheme1.Equals((object)scheme2);
+        }
+
+        public static bool operator !=(OAuth2SecurityScheme scheme1, OAuth2SecurityScheme scheme2)
+                    => !(scheme1 == scheme2);
 
         /// <summary>Determines whether the specified object is equal to the current object.</summary>
         /// <param name="obj">The object to compare with the current object.</param>
@@ -89,16 +114,6 @@ namespace SourceCode.Clay.OpenApi
                 return ((int)(hc >> 32)) ^ (int)hc;
             }
         }
-
-        public static bool operator ==(OAuth2SecurityScheme scheme1, OAuth2SecurityScheme scheme2)
-        {
-            if (ReferenceEquals(scheme1, null) && ReferenceEquals(scheme2, null)) return true;
-            if (ReferenceEquals(scheme1, null) || ReferenceEquals(scheme2, null)) return false;
-            return scheme1.Equals((object)scheme2);
-        }
-
-        public static bool operator !=(OAuth2SecurityScheme scheme1, OAuth2SecurityScheme scheme2)
-            => !(scheme1 == scheme2);
 
         #endregion
     }

--- a/src/SourceCode.Clay.OpenApi/OAuthFlow.cs
+++ b/src/SourceCode.Clay.OpenApi/OAuthFlow.cs
@@ -1,3 +1,10 @@
+#region License
+
+// Copyright (c) K2 Workflow (SourceCode Technology Holdings Inc.). All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+#endregion
+
 using SourceCode.Clay.Collections.Generic;
 using System;
 using System.Collections.Generic;
@@ -9,6 +16,8 @@ namespace SourceCode.Clay.OpenApi
     /// </summary>
     public class OAuthFlow : IEquatable<OAuthFlow>
     {
+        #region Properties
+
         /// <summary>
         /// Gets the authorization URL to be used for this flow.
         /// </summary>
@@ -36,6 +45,10 @@ namespace SourceCode.Clay.OpenApi
         /// </summary>
         public IReadOnlyDictionary<string, string> Scopes { get; }
 
+        #endregion
+
+        #region Constructors
+
         /// <summary>
         /// Creates a new instance of the <see cref="OAuthFlow"/> class.
         /// </summary>
@@ -55,7 +68,19 @@ namespace SourceCode.Clay.OpenApi
             Scopes = scopes ?? ReadOnlyDictionary.Empty<string, string>();
         }
 
+        #endregion
+
         #region Equatable
+
+        public static bool operator ==(OAuthFlow flow1, OAuthFlow flow2)
+        {
+            if (ReferenceEquals(flow1, null) && ReferenceEquals(flow2, null)) return true;
+            if (ReferenceEquals(flow1, null) || ReferenceEquals(flow2, null)) return false;
+            return flow1.Equals((object)flow2);
+        }
+
+        public static bool operator !=(OAuthFlow flow1, OAuthFlow flow2) =>
+                    !(flow1 == flow2);
 
         /// <summary>Determines whether the specified object is equal to the current object.</summary>
         /// <param name="obj">The object to compare with the current object.</param>
@@ -94,16 +119,6 @@ namespace SourceCode.Clay.OpenApi
                 return ((int)(hc >> 32)) ^ (int)hc;
             }
         }
-
-        public static bool operator ==(OAuthFlow flow1, OAuthFlow flow2)
-        {
-            if (ReferenceEquals(flow1, null) && ReferenceEquals(flow2, null)) return true;
-            if (ReferenceEquals(flow1, null) || ReferenceEquals(flow2, null)) return false;
-            return flow1.Equals((object)flow2);
-        }
-
-        public static bool operator !=(OAuthFlow flow1, OAuthFlow flow2) =>
-            !(flow1 == flow2);
 
         #endregion
     }

--- a/src/SourceCode.Clay.OpenApi/OpenIdConnectSecurityScheme.cs
+++ b/src/SourceCode.Clay.OpenApi/OpenIdConnectSecurityScheme.cs
@@ -1,3 +1,10 @@
+#region License
+
+// Copyright (c) K2 Workflow (SourceCode Technology Holdings Inc.). All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+#endregion
+
 using System;
 
 namespace SourceCode.Clay.OpenApi
@@ -7,6 +14,8 @@ namespace SourceCode.Clay.OpenApi
     /// </summary>
     public class OpenIdConnectSecurityScheme : SecurityScheme, IEquatable<OpenIdConnectSecurityScheme>
     {
+        #region Properties
+
         /// <summary>Gets the type of the security scheme.</summary>
         public override SecuritySchemeType Type => SecuritySchemeType.OpenIdConnect;
 
@@ -14,6 +23,10 @@ namespace SourceCode.Clay.OpenApi
         /// Gets the OpenId Connect URL to discover OAuth2 configuration values.
         /// </summary>
         public Uri Url { get; }
+
+        #endregion
+
+        #region Constructors
 
         /// <summary>
         /// Creates a new instance of the <see cref="OpenIdConnectSecurityScheme"/>.
@@ -28,7 +41,19 @@ namespace SourceCode.Clay.OpenApi
             Url = url;
         }
 
+        #endregion
+
         #region Equatable
+
+        public static bool operator ==(OpenIdConnectSecurityScheme scheme1, OpenIdConnectSecurityScheme scheme2)
+        {
+            if (ReferenceEquals(scheme1, null) && ReferenceEquals(scheme2, null)) return true;
+            if (ReferenceEquals(scheme1, null) || ReferenceEquals(scheme2, null)) return false;
+            return scheme1.Equals((object)scheme2);
+        }
+
+        public static bool operator !=(OpenIdConnectSecurityScheme scheme1, OpenIdConnectSecurityScheme scheme2)
+                    => !(scheme1 == scheme2);
 
         /// <summary>Determines whether the specified object is equal to the current object.</summary>
         /// <param name="obj">The object to compare with the current object.</param>
@@ -60,16 +85,6 @@ namespace SourceCode.Clay.OpenApi
                 return ((int)(hc >> 32)) ^ (int)hc;
             }
         }
-
-        public static bool operator ==(OpenIdConnectSecurityScheme scheme1, OpenIdConnectSecurityScheme scheme2)
-        {
-            if (ReferenceEquals(scheme1, null) && ReferenceEquals(scheme2, null)) return true;
-            if (ReferenceEquals(scheme1, null) || ReferenceEquals(scheme2, null)) return false;
-            return scheme1.Equals((object)scheme2);
-        }
-
-        public static bool operator !=(OpenIdConnectSecurityScheme scheme1, OpenIdConnectSecurityScheme scheme2)
-            => !(scheme1 == scheme2);
 
         #endregion
     }

--- a/src/SourceCode.Clay.OpenApi/Operation.cs
+++ b/src/SourceCode.Clay.OpenApi/Operation.cs
@@ -1,3 +1,10 @@
+#region License
+
+// Copyright (c) K2 Workflow (SourceCode Technology Holdings Inc.). All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+#endregion
+
 using SourceCode.Clay.Collections.Generic;
 using System;
 using System.Collections.Generic;
@@ -125,6 +132,15 @@ namespace SourceCode.Clay.OpenApi
 
         #region IEquatable
 
+        public static bool operator ==(Operation operation1, Operation operation2)
+        {
+            if (ReferenceEquals(operation1, null) && ReferenceEquals(operation2, null)) return true;
+            if (ReferenceEquals(operation1, null) || ReferenceEquals(operation2, null)) return false;
+            return operation1.Equals((object)operation2);
+        }
+
+        public static bool operator !=(Operation operation1, Operation operation2) => !(operation1 == operation2);
+
         /// <summary>Determines whether the specified object is equal to the current object.</summary>
         /// <param name="obj">The object to compare with the current object.</param>
         /// <returns>true if the specified object  is equal to the current object; otherwise, false.</returns>
@@ -175,15 +191,6 @@ namespace SourceCode.Clay.OpenApi
                 return ((int)(hc >> 32)) ^ (int)hc;
             }
         }
-
-        public static bool operator ==(Operation operation1, Operation operation2)
-        {
-            if (ReferenceEquals(operation1, null) && ReferenceEquals(operation2, null)) return true;
-            if (ReferenceEquals(operation1, null) || ReferenceEquals(operation2, null)) return false;
-            return operation1.Equals((object)operation2);
-        }
-
-        public static bool operator !=(Operation operation1, Operation operation2) => !(operation1 == operation2);
 
         #endregion
     }

--- a/src/SourceCode.Clay.OpenApi/OperationOptions.cs
+++ b/src/SourceCode.Clay.OpenApi/OperationOptions.cs
@@ -1,3 +1,10 @@
+#region License
+
+// Copyright (c) K2 Workflow (SourceCode Technology Holdings Inc.). All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+#endregion
+
 namespace SourceCode.Clay.OpenApi
 {
     /// <summary>

--- a/src/SourceCode.Clay.OpenApi/Parameter.cs
+++ b/src/SourceCode.Clay.OpenApi/Parameter.cs
@@ -33,12 +33,12 @@ namespace SourceCode.Clay.OpenApi
         public Parameter(
             string name = default,
             ParameterLocation location = default,
-            string description = null,
-            ParameterOptions options = ParameterOptions.None,
-            ParameterStyle style = ParameterStyle.Default,
+            string description = default,
+            ParameterOptions options = default,
+            ParameterStyle style = default,
             Referable<Schema> schema = default,
-            IReadOnlyDictionary<ContentType, Referable<Example>> examples = null,
-            IReadOnlyDictionary<ContentType, MediaType> content = null)
+            IReadOnlyDictionary<ContentType, Referable<Example>> examples = default,
+            IReadOnlyDictionary<ContentType, MediaType> content = default)
             : base(description, options, style, schema, examples, content)
         {
             Name = name;

--- a/src/SourceCode.Clay.OpenApi/Parameter.cs
+++ b/src/SourceCode.Clay.OpenApi/Parameter.cs
@@ -1,3 +1,10 @@
+#region License
+
+// Copyright (c) K2 Workflow (SourceCode Technology Holdings Inc.). All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+#endregion
+
 using System;
 using System.Collections.Generic;
 using System.Net.Mime;
@@ -9,6 +16,8 @@ namespace SourceCode.Clay.OpenApi
     /// </summary>
     public class Parameter : ParameterBody, IEquatable<Parameter>
     {
+        #region Properties
+
         /// <summary>
         /// Gets the name of the parameter.
         /// </summary>
@@ -18,6 +27,10 @@ namespace SourceCode.Clay.OpenApi
         /// Gets the location of the parameter.
         /// </summary>
         public ParameterLocation Location { get; }
+
+        #endregion
+
+        #region Constructors
 
         /// <summary>
         /// Creates a new instance of the <see cref="ParameterBody"/> class.
@@ -45,7 +58,18 @@ namespace SourceCode.Clay.OpenApi
             Location = location;
         }
 
+        #endregion
+
         #region Equatable
+
+        public static bool operator ==(Parameter parameter1, Parameter parameter2)
+        {
+            if (ReferenceEquals(parameter1, null) && ReferenceEquals(parameter2, null)) return true;
+            if (ReferenceEquals(parameter1, null) || ReferenceEquals(parameter2, null)) return false;
+            return parameter1.Equals((object)parameter2);
+        }
+
+        public static bool operator !=(Parameter parameter1, Parameter parameter2) => !(parameter1 == parameter2);
 
         /// <summary>Determines whether the specified object is equal to the current object.</summary>
         /// <param name="obj">The object to compare with the current object.</param>
@@ -82,15 +106,6 @@ namespace SourceCode.Clay.OpenApi
                 return ((int)(hc >> 32)) ^ (int)hc;
             }
         }
-
-        public static bool operator ==(Parameter parameter1, Parameter parameter2)
-        {
-            if (ReferenceEquals(parameter1, null) && ReferenceEquals(parameter2, null)) return true;
-            if (ReferenceEquals(parameter1, null) || ReferenceEquals(parameter2, null)) return false;
-            return parameter1.Equals((object)parameter2);
-        }
-
-        public static bool operator !=(Parameter parameter1, Parameter parameter2) => !(parameter1 == parameter2);
 
         #endregion
     }

--- a/src/SourceCode.Clay.OpenApi/ParameterBody.cs
+++ b/src/SourceCode.Clay.OpenApi/ParameterBody.cs
@@ -1,3 +1,10 @@
+#region License
+
+// Copyright (c) K2 Workflow (SourceCode Technology Holdings Inc.). All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+#endregion
+
 using SourceCode.Clay.Collections.Generic;
 using System;
 using System.Collections.Generic;
@@ -78,6 +85,16 @@ namespace SourceCode.Clay.OpenApi
 
         #region IEquatable
 
+        public static bool operator ==(ParameterBody parameterBody1, ParameterBody parameterBody2)
+        {
+            if (ReferenceEquals(parameterBody1, null) && ReferenceEquals(parameterBody2, null)) return true;
+            if (ReferenceEquals(parameterBody1, null) || ReferenceEquals(parameterBody2, null)) return false;
+            return parameterBody1.Equals((object)parameterBody2);
+        }
+
+        public static bool operator !=(ParameterBody parameterBody1, ParameterBody parameterBody2)
+                    => !(parameterBody1 == parameterBody2);
+
         /// <summary>Determines whether the specified object is equal to the current object.</summary>
         /// <param name="obj">The object to compare with the current object.</param>
         /// <returns>true if the specified object  is equal to the current object; otherwise, false.</returns>
@@ -119,16 +136,6 @@ namespace SourceCode.Clay.OpenApi
                 return ((int)(hc >> 32)) ^ (int)hc;
             }
         }
-
-        public static bool operator ==(ParameterBody parameterBody1, ParameterBody parameterBody2)
-        {
-            if (ReferenceEquals(parameterBody1, null) && ReferenceEquals(parameterBody2, null)) return true;
-            if (ReferenceEquals(parameterBody1, null) || ReferenceEquals(parameterBody2, null)) return false;
-            return parameterBody1.Equals((object)parameterBody2);
-        }
-
-        public static bool operator !=(ParameterBody parameterBody1, ParameterBody parameterBody2)
-            => !(parameterBody1 == parameterBody2);
 
         #endregion
     }

--- a/src/SourceCode.Clay.OpenApi/ParameterKey.cs
+++ b/src/SourceCode.Clay.OpenApi/ParameterKey.cs
@@ -1,3 +1,10 @@
+#region License
+
+// Copyright (c) K2 Workflow (SourceCode Technology Holdings Inc.). All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+#endregion
+
 using System;
 
 namespace SourceCode.Clay.OpenApi
@@ -7,6 +14,8 @@ namespace SourceCode.Clay.OpenApi
     /// </summary>
     public struct ParameterKey : IEquatable<ParameterKey>
     {
+        #region Properties
+
         /// <summary>
         /// Gets the name of the parameter.
         /// </summary>
@@ -16,6 +25,10 @@ namespace SourceCode.Clay.OpenApi
         /// Gets the location of the parameter.
         /// </summary>
         public ParameterLocation Location { get; }
+
+        #endregion
+
+        #region Constructors
 
         /// <summary>
         /// Creates a new <see cref="ParameterKey"/> value.
@@ -30,6 +43,14 @@ namespace SourceCode.Clay.OpenApi
             Name = name;
             Location = location;
         }
+
+        #endregion
+
+        #region Methods
+
+        public static bool operator ==(ParameterKey key1, ParameterKey key2) => key1.Equals(key2);
+
+        public static bool operator !=(ParameterKey key1, ParameterKey key2) => !(key1 == key2);
 
         /// <summary>Indicates whether this instance and a specified object are equal.</summary>
         /// <param name="obj">The object to compare with the current instance.</param>
@@ -62,8 +83,6 @@ namespace SourceCode.Clay.OpenApi
             }
         }
 
-        public static bool operator ==(ParameterKey key1, ParameterKey key2) => key1.Equals(key2);
-
-        public static bool operator !=(ParameterKey key1, ParameterKey key2) => !(key1 == key2);
+        #endregion
     }
 }

--- a/src/SourceCode.Clay.OpenApi/ParameterLocation.cs
+++ b/src/SourceCode.Clay.OpenApi/ParameterLocation.cs
@@ -1,3 +1,10 @@
+#region License
+
+// Copyright (c) K2 Workflow (SourceCode Technology Holdings Inc.). All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+#endregion
+
 namespace SourceCode.Clay.OpenApi
 {
     /// <summary>

--- a/src/SourceCode.Clay.OpenApi/ParameterOptions.cs
+++ b/src/SourceCode.Clay.OpenApi/ParameterOptions.cs
@@ -1,3 +1,10 @@
+#region License
+
+// Copyright (c) K2 Workflow (SourceCode Technology Holdings Inc.). All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+#endregion
+
 using System;
 
 namespace SourceCode.Clay.OpenApi

--- a/src/SourceCode.Clay.OpenApi/ParameterStyle.cs
+++ b/src/SourceCode.Clay.OpenApi/ParameterStyle.cs
@@ -1,3 +1,10 @@
+#region License
+
+// Copyright (c) K2 Workflow (SourceCode Technology Holdings Inc.). All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+#endregion
+
 namespace SourceCode.Clay.OpenApi
 {
     /// <summary>

--- a/src/SourceCode.Clay.OpenApi/Path.cs
+++ b/src/SourceCode.Clay.OpenApi/Path.cs
@@ -1,3 +1,10 @@
+#region License
+
+// Copyright (c) K2 Workflow (SourceCode Technology Holdings Inc.). All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+#endregion
+
 using SourceCode.Clay.Collections.Generic;
 using System;
 using System.Collections.Generic;
@@ -127,6 +134,15 @@ namespace SourceCode.Clay.OpenApi
 
         #region IEquatable
 
+        public static bool operator ==(Path path1, Path path2)
+        {
+            if (ReferenceEquals(path1, null) && ReferenceEquals(path2, null)) return true;
+            if (ReferenceEquals(path1, null) || ReferenceEquals(path2, null)) return false;
+            return path1.Equals((object)path2);
+        }
+
+        public static bool operator !=(Path path1, Path path2) => !(path1 == path2);
+
         /// <summary>Determines whether the specified object is equal to the current object.</summary>
         /// <param name="obj">The object to compare with the current object.</param>
         /// <returns>true if the specified object  is equal to the current object; otherwise, false.</returns>
@@ -180,15 +196,6 @@ namespace SourceCode.Clay.OpenApi
                 return ((int)(hc >> 32)) ^ (int)hc;
             }
         }
-
-        public static bool operator ==(Path path1, Path path2)
-        {
-            if (ReferenceEquals(path1, null) && ReferenceEquals(path2, null)) return true;
-            if (ReferenceEquals(path1, null) || ReferenceEquals(path2, null)) return false;
-            return path1.Equals((object)path2);
-        }
-
-        public static bool operator !=(Path path1, Path path2) => !(path1 == path2);
 
         #endregion
     }

--- a/src/SourceCode.Clay.OpenApi/Path.cs
+++ b/src/SourceCode.Clay.OpenApi/Path.cs
@@ -96,18 +96,18 @@ namespace SourceCode.Clay.OpenApi
         /// <param name="servers">The alternative server list to service all operations in this path.</param>
         /// <param name="parameters">The list of parameters that are applicable for all the operations described under this path.</param>
         public Path(
-            string summary,
-            string description,
-            Operation get,
-            Operation put,
-            Operation post,
-            Operation delete,
-            Operation options,
-            Operation head,
-            Operation patch,
-            Operation trace,
-            IReadOnlyList<Server> servers,
-            IReadOnlyDictionary<ParameterKey, Referable<ParameterBody>> parameters)
+            string summary = default,
+            string description = default,
+            Operation get = default,
+            Operation put = default,
+            Operation post = default,
+            Operation delete = default,
+            Operation options = default,
+            Operation head = default,
+            Operation patch = default,
+            Operation trace = default,
+            IReadOnlyList<Server> servers = default,
+            IReadOnlyDictionary<ParameterKey, Referable<ParameterBody>> parameters = default)
         {
             Summary = summary;
             Description = description;

--- a/src/SourceCode.Clay.OpenApi/PropertyEncoding.cs
+++ b/src/SourceCode.Clay.OpenApi/PropertyEncoding.cs
@@ -1,3 +1,10 @@
+#region License
+
+// Copyright (c) K2 Workflow (SourceCode Technology Holdings Inc.). All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+#endregion
+
 using SourceCode.Clay.Collections.Generic;
 using System;
 using System.Collections.Generic;
@@ -31,6 +38,8 @@ namespace SourceCode.Clay.OpenApi
 
         #endregion
 
+        #region Constructors
+
         /// <summary>
         /// Creates a new instance of the <see cref="PropertyEncoding"/> class.
         /// </summary>
@@ -50,7 +59,19 @@ namespace SourceCode.Clay.OpenApi
             Options = options;
         }
 
+        #endregion
+
         #region IEquatable
+
+        public static bool operator ==(PropertyEncoding propertyEncoding1, PropertyEncoding propertyEncoding2)
+        {
+            if (ReferenceEquals(propertyEncoding1, null) && ReferenceEquals(propertyEncoding2, null)) return true;
+            if (ReferenceEquals(propertyEncoding1, null) || ReferenceEquals(propertyEncoding2, null)) return false;
+            return propertyEncoding1.Equals((object)propertyEncoding2);
+        }
+
+        public static bool operator !=(PropertyEncoding propertyEncoding1, PropertyEncoding propertyEncoding2)
+                    => !(propertyEncoding1 == propertyEncoding2);
 
         /// <summary>Determines whether the specified object is equal to the current object.</summary>
         /// <param name="obj">The object to compare with the current object.</param>
@@ -89,16 +110,6 @@ namespace SourceCode.Clay.OpenApi
                 return ((int)(hc >> 32)) ^ (int)hc;
             }
         }
-
-        public static bool operator ==(PropertyEncoding propertyEncoding1, PropertyEncoding propertyEncoding2)
-        {
-            if (ReferenceEquals(propertyEncoding1, null) && ReferenceEquals(propertyEncoding2, null)) return true;
-            if (ReferenceEquals(propertyEncoding1, null) || ReferenceEquals(propertyEncoding2, null)) return false;
-            return propertyEncoding1.Equals((object)propertyEncoding2);
-        }
-
-        public static bool operator !=(PropertyEncoding propertyEncoding1, PropertyEncoding propertyEncoding2)
-            => !(propertyEncoding1 == propertyEncoding2);
 
         #endregion
     }

--- a/src/SourceCode.Clay.OpenApi/PropertyEncodingOptions.cs
+++ b/src/SourceCode.Clay.OpenApi/PropertyEncodingOptions.cs
@@ -1,3 +1,10 @@
+#region License
+
+// Copyright (c) K2 Workflow (SourceCode Technology Holdings Inc.). All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+#endregion
+
 namespace SourceCode.Clay.OpenApi
 {
     /// <summary>

--- a/src/SourceCode.Clay.OpenApi/RangeOptions.cs
+++ b/src/SourceCode.Clay.OpenApi/RangeOptions.cs
@@ -1,3 +1,10 @@
+#region License
+
+// Copyright (c) K2 Workflow (SourceCode Technology Holdings Inc.). All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+#endregion
+
 using System;
 
 namespace SourceCode.Clay.OpenApi

--- a/src/SourceCode.Clay.OpenApi/Referable.cs
+++ b/src/SourceCode.Clay.OpenApi/Referable.cs
@@ -1,3 +1,10 @@
+#region License
+
+// Copyright (c) K2 Workflow (SourceCode Technology Holdings Inc.). All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+#endregion
+
 using SourceCode.Clay.Json.Pointers;
 using System;
 using System.Collections.Generic;
@@ -11,6 +18,8 @@ namespace SourceCode.Clay.OpenApi
     public struct Referable<T> : IEquatable<Referable<T>>
         where T : class, IEquatable<T>
     {
+        #region Properties
+
         /// <summary>
         /// Gets the contained value.
         /// </summary>
@@ -35,6 +44,10 @@ namespace SourceCode.Clay.OpenApi
         /// Gets a value indicating whether the reference is null.
         /// </summary>
         public bool HasValue => IsReference || IsValue;
+
+        #endregion
+
+        #region Constructors
 
         /// <summary>
         /// Creates a new value <see cref="Referable{T}"/>.
@@ -80,6 +93,22 @@ namespace SourceCode.Clay.OpenApi
             Reference = new Reference(url, reference);
         }
 
+        #endregion
+
+        #region Methods
+
+        public static bool operator ==(Referable<T> referable1, Referable<T> referable2) => referable1.Equals(referable2);
+
+        public static bool operator !=(Referable<T> referable1, Referable<T> referable2) => !(referable1 == referable2);
+
+        public static implicit operator Referable<T>(T value) => new Referable<T>(value);
+
+        public static implicit operator Referable<T>(JsonPointer internalReference) => new Referable<T>(internalReference);
+
+        public static implicit operator Referable<T>(Uri reference) => new Referable<T>(reference);
+
+        public static implicit operator Referable<T>(string reference) => new Referable<T>(reference);
+
         /// <summary>Indicates whether this instance and a specified object are equal.</summary>
         /// <param name="obj">The object to compare with the current instance.</param>
         /// <returns>true if <paramref name="obj">obj</paramref> and this instance are the same type and represent the same value; otherwise, false.</returns>
@@ -119,16 +148,6 @@ namespace SourceCode.Clay.OpenApi
             else return string.Empty;
         }
 
-        public static bool operator ==(Referable<T> referable1, Referable<T> referable2) => referable1.Equals(referable2);
-
-        public static bool operator !=(Referable<T> referable1, Referable<T> referable2) => !(referable1 == referable2);
-
-        public static implicit operator Referable<T>(T value) => new Referable<T>(value);
-
-        public static implicit operator Referable<T>(JsonPointer internalReference) => new Referable<T>(internalReference);
-
-        public static implicit operator Referable<T>(Uri reference) => new Referable<T>(reference);
-
-        public static implicit operator Referable<T>(string reference) => new Referable<T>(reference);
+        #endregion
     }
 }

--- a/src/SourceCode.Clay.OpenApi/Reference.cs
+++ b/src/SourceCode.Clay.OpenApi/Reference.cs
@@ -1,3 +1,10 @@
+#region License
+
+// Copyright (c) K2 Workflow (SourceCode Technology Holdings Inc.). All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+#endregion
+
 using SourceCode.Clay.Json.Pointers;
 using System;
 
@@ -8,6 +15,8 @@ namespace SourceCode.Clay.OpenApi
     /// </summary>
     public struct Reference : IEquatable<Reference>
     {
+        #region Properties
+
         /// <summary>
         /// Gets the URL portion of the reference.
         /// </summary>
@@ -22,6 +31,10 @@ namespace SourceCode.Clay.OpenApi
         /// Gets a value indicating whether the reference has a value.
         /// </summary>
         public bool HasValue => Url != null || Pointer.Count != 0;
+
+        #endregion
+
+        #region Constructors
 
         /// <summary>
         /// Creates a new internal <see cref="Reference"/> value.
@@ -67,7 +80,13 @@ namespace SourceCode.Clay.OpenApi
             Pointer = pointer;
         }
 
+        #endregion
+
         #region Equatable
+
+        public static bool operator ==(Reference reference1, Reference reference2) => reference1.Equals(reference2);
+
+        public static bool operator !=(Reference reference1, Reference reference2) => !(reference1 == reference2);
 
         /// <summary>Indicates whether this instance and a specified object are equal.</summary>
         /// <param name="obj">The object to compare with the current instance.</param>
@@ -97,28 +116,9 @@ namespace SourceCode.Clay.OpenApi
             }
         }
 
-        public static bool operator ==(Reference reference1, Reference reference2) => reference1.Equals(reference2);
-
-        public static bool operator !=(Reference reference1, Reference reference2) => !(reference1 == reference2);
-
         #endregion
 
         #region Conversion
-
-        /// <summary>
-        /// Returns the reference formatted as a <see cref="Uri"/>.
-        /// </summary>
-        /// <returns>The reference formatted as a <see cref="Uri"/>.</returns>
-        public Uri ToUri()
-        {
-            if (!HasValue) return null;
-
-            var frag = "#" + Uri.EscapeUriString(Pointer.ToString());
-            if (Url == null) return new Uri(frag, UriKind.Relative);
-            else if (frag == "#") return Url;
-            else if (Url.IsAbsoluteUri) return new UriBuilder(Url) { Fragment = frag }.Uri;
-            else return new Uri(Url.OriginalString + frag, UriKind.Relative);
-        }
 
         /// <summary>
         /// Converts the URL representation of a reference to its structured equivalent.
@@ -197,10 +197,6 @@ namespace SourceCode.Clay.OpenApi
             return true;
         }
 
-        /// <summary>Returns reference formatted as a string.</summary>
-        /// <returns>The reference formatted as a string.</returns>
-        public override string ToString() => ToUri()?.ToString() ?? string.Empty;
-
         public static implicit operator Reference(JsonPointer pointer) => pointer.Count == 0 ? default : new Reference(pointer);
 
         public static implicit operator Reference(Uri url) => url == null ? default : ParseUrl(url);
@@ -214,6 +210,25 @@ namespace SourceCode.Clay.OpenApi
 
             return ParseUrl(uri);
         }
+
+        /// <summary>
+        /// Returns the reference formatted as a <see cref="Uri"/>.
+        /// </summary>
+        /// <returns>The reference formatted as a <see cref="Uri"/>.</returns>
+        public Uri ToUri()
+        {
+            if (!HasValue) return null;
+
+            var frag = "#" + Uri.EscapeUriString(Pointer.ToString());
+            if (Url == null) return new Uri(frag, UriKind.Relative);
+            else if (frag == "#") return Url;
+            else if (Url.IsAbsoluteUri) return new UriBuilder(Url) { Fragment = frag }.Uri;
+            else return new Uri(Url.OriginalString + frag, UriKind.Relative);
+        }
+
+        /// <summary>Returns reference formatted as a string.</summary>
+        /// <returns>The reference formatted as a string.</returns>
+        public override string ToString() => ToUri()?.ToString() ?? string.Empty;
 
         #endregion
     }

--- a/src/SourceCode.Clay.OpenApi/RequestBody.cs
+++ b/src/SourceCode.Clay.OpenApi/RequestBody.cs
@@ -1,3 +1,10 @@
+#region License
+
+// Copyright (c) K2 Workflow (SourceCode Technology Holdings Inc.). All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+#endregion
+
 using SourceCode.Clay.Collections.Generic;
 using System;
 using System.Collections.Generic;
@@ -54,6 +61,16 @@ namespace SourceCode.Clay.OpenApi
 
         #region IEquatable
 
+        public static bool operator ==(RequestBody requestBody1, RequestBody requestBody2)
+        {
+            if (ReferenceEquals(requestBody1, null) && ReferenceEquals(requestBody2, null)) return true;
+            if (ReferenceEquals(requestBody1, null) || ReferenceEquals(requestBody2, null)) return false;
+            return requestBody1.Equals((object)requestBody2);
+        }
+
+        public static bool operator !=(RequestBody requestBody1, RequestBody requestBody2)
+                    => !(requestBody1 == requestBody2);
+
         /// <summary>Determines whether the specified object is equal to the current object.</summary>
         /// <param name="obj">The object to compare with the current object.</param>
         /// <returns>true if the specified object  is equal to the current object; otherwise, false.</returns>
@@ -89,16 +106,6 @@ namespace SourceCode.Clay.OpenApi
                 return ((int)(hc >> 32)) ^ (int)hc;
             }
         }
-
-        public static bool operator ==(RequestBody requestBody1, RequestBody requestBody2)
-        {
-            if (ReferenceEquals(requestBody1, null) && ReferenceEquals(requestBody2, null)) return true;
-            if (ReferenceEquals(requestBody1, null) || ReferenceEquals(requestBody2, null)) return false;
-            return requestBody1.Equals((object)requestBody2);
-        }
-
-        public static bool operator !=(RequestBody requestBody1, RequestBody requestBody2)
-            => !(requestBody1 == requestBody2);
 
         #endregion
     }

--- a/src/SourceCode.Clay.OpenApi/RequestBodyOptions.cs
+++ b/src/SourceCode.Clay.OpenApi/RequestBodyOptions.cs
@@ -1,3 +1,10 @@
+#region License
+
+// Copyright (c) K2 Workflow (SourceCode Technology Holdings Inc.). All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+#endregion
+
 namespace SourceCode.Clay.OpenApi
 {
     /// <summary>

--- a/src/SourceCode.Clay.OpenApi/Response.cs
+++ b/src/SourceCode.Clay.OpenApi/Response.cs
@@ -44,10 +44,10 @@ namespace SourceCode.Clay.OpenApi
         /// <param name="content">The map containing descriptions of potential response payloads.</param>
         /// <param name="links">The map of operations links that can be followed from the response.</param>
         public Response(
-            string description,
-            IReadOnlyDictionary<string, Referable<ParameterBody>> headers,
-            IReadOnlyDictionary<ContentType, MediaType> content,
-            IReadOnlyDictionary<string, Referable<Link>> links)
+            string description = default,
+            IReadOnlyDictionary<string, Referable<ParameterBody>> headers = default,
+            IReadOnlyDictionary<ContentType, MediaType> content = default,
+            IReadOnlyDictionary<string, Referable<Link>> links = default)
         {
             Description = description;
             Headers = headers ?? ReadOnlyDictionary.Empty<string, Referable<ParameterBody>>();

--- a/src/SourceCode.Clay.OpenApi/Response.cs
+++ b/src/SourceCode.Clay.OpenApi/Response.cs
@@ -1,3 +1,10 @@
+#region License
+
+// Copyright (c) K2 Workflow (SourceCode Technology Holdings Inc.). All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+#endregion
+
 using SourceCode.Clay.Collections.Generic;
 using System;
 using System.Collections.Generic;
@@ -59,6 +66,15 @@ namespace SourceCode.Clay.OpenApi
 
         #region IEquatable
 
+        public static bool operator ==(Response response1, Response response2)
+        {
+            if (ReferenceEquals(response1, null) && ReferenceEquals(response2, null)) return true;
+            if (ReferenceEquals(response1, null) || ReferenceEquals(response2, null)) return false;
+            return response1.Equals((object)response2);
+        }
+
+        public static bool operator !=(Response response1, Response response2) => !(response1 == response2);
+
         /// <summary>Determines whether the specified object is equal to the current object.</summary>
         /// <param name="obj">The object to compare with the current object.</param>
         /// <returns>true if the specified object  is equal to the current object; otherwise, false.</returns>
@@ -96,15 +112,6 @@ namespace SourceCode.Clay.OpenApi
                 return ((int)(hc >> 32)) ^ (int)hc;
             }
         }
-
-        public static bool operator ==(Response response1, Response response2)
-        {
-            if (ReferenceEquals(response1, null) && ReferenceEquals(response2, null)) return true;
-            if (ReferenceEquals(response1, null) || ReferenceEquals(response2, null)) return false;
-            return response1.Equals((object)response2);
-        }
-
-        public static bool operator !=(Response response1, Response response2) => !(response1 == response2);
 
         #endregion
     }

--- a/src/SourceCode.Clay.OpenApi/ResponseKey.cs
+++ b/src/SourceCode.Clay.OpenApi/ResponseKey.cs
@@ -1,3 +1,10 @@
+#region License
+
+// Copyright (c) K2 Workflow (SourceCode Technology Holdings Inc.). All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+#endregion
+
 using System;
 using System.Collections.Generic;
 using System.Globalization;
@@ -163,6 +170,14 @@ namespace SourceCode.Clay.OpenApi
 
         #endregion
 
+        #region Fields
+
+        private readonly HttpStatusCode? _httpStatusCode;
+
+        #endregion
+
+        #region Properties
+
         /// <summary>
         /// Gets a value indicating whether this response key is the default response.
         /// </summary>
@@ -173,7 +188,9 @@ namespace SourceCode.Clay.OpenApi
         /// </summary>
         public HttpStatusCode HttpStatusCode => _httpStatusCode ?? throw new InvalidOperationException("Cannot retrieve the status code from a default ResponseKey.");
 
-        private readonly HttpStatusCode? _httpStatusCode;
+        #endregion
+
+        #region Constructors
 
         /// <summary>
         /// Creates a new <see cref="ResponseKey"/> value.
@@ -211,6 +228,16 @@ namespace SourceCode.Clay.OpenApi
                 throw new FormatException("The response key is not valid.");
         }
 
+        #endregion
+
+        #region Methods
+
+        public static bool operator ==(ResponseKey key1, ResponseKey key2) => key1.Equals(key2);
+
+        public static bool operator !=(ResponseKey key1, ResponseKey key2) => !(key1 == key2);
+
+        public static implicit operator ResponseKey(HttpStatusCode httpStatusCode) => new ResponseKey(httpStatusCode);
+
         /// <summary>Indicates whether this instance and a specified object are equal.</summary>
         /// <param name="obj">The object to compare with the current instance.</param>
         /// <returns>true if <paramref name="obj">obj</paramref> and this instance are the same type and represent the same value; otherwise, false.</returns>
@@ -240,10 +267,6 @@ namespace SourceCode.Clay.OpenApi
             ? ((int)_httpStatusCode.Value).ToString(CultureInfo.InvariantCulture)
             : "default";
 
-        public static bool operator ==(ResponseKey key1, ResponseKey key2) => key1.Equals(key2);
-
-        public static bool operator !=(ResponseKey key1, ResponseKey key2) => !(key1 == key2);
-
-        public static implicit operator ResponseKey(HttpStatusCode httpStatusCode) => new ResponseKey(httpStatusCode);
+        #endregion
     }
 }

--- a/src/SourceCode.Clay.OpenApi/ScalarValue.cs
+++ b/src/SourceCode.Clay.OpenApi/ScalarValue.cs
@@ -1,3 +1,10 @@
+#region License
+
+// Copyright (c) K2 Workflow (SourceCode Technology Holdings Inc.). All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+#endregion
+
 using System;
 
 namespace SourceCode.Clay.OpenApi
@@ -7,9 +14,15 @@ namespace SourceCode.Clay.OpenApi
     /// </summary>
     public struct ScalarValue : IEquatable<ScalarValue>, IFormattable
     {
+        #region Fields
+
         private readonly byte _typeCode;
         private readonly Number _number;
         private readonly string _string;
+
+        #endregion
+
+        #region Properties
 
         /// <summary>
         /// Gets the <see cref="Number"/> value.
@@ -79,6 +92,8 @@ namespace SourceCode.Clay.OpenApi
                 }
             }
         }
+
+        #endregion
 
         #region Constructors
 

--- a/src/SourceCode.Clay.OpenApi/ScalarValue.cs
+++ b/src/SourceCode.Clay.OpenApi/ScalarValue.cs
@@ -80,7 +80,7 @@ namespace SourceCode.Clay.OpenApi
             }
         }
 
-        #region Ctor
+        #region Constructors
 
         /// <summary>
         /// Creates a new <see cref="ScalarValue"/> containing a <see cref="Number"/>.

--- a/src/SourceCode.Clay.OpenApi/Schema.cs
+++ b/src/SourceCode.Clay.OpenApi/Schema.cs
@@ -1,3 +1,10 @@
+#region License
+
+// Copyright (c) K2 Workflow (SourceCode Technology Holdings Inc.). All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+#endregion
+
 using SourceCode.Clay.Collections.Generic;
 using System;
 using System.Collections.Generic;
@@ -190,6 +197,15 @@ namespace SourceCode.Clay.OpenApi
 
         #region Equatable
 
+        public static bool operator ==(Schema schema1, Schema schema2)
+        {
+            if (ReferenceEquals(schema1, null) && ReferenceEquals(schema2, null)) return true;
+            if (ReferenceEquals(schema1, null) || ReferenceEquals(schema2, null)) return false;
+            return schema1.Equals((object)schema2);
+        }
+
+        public static bool operator !=(Schema schema1, Schema schema2) => !(schema1 == schema2);
+
         /// <summary>Indicates whether this instance and a specified object are equal.</summary>
         /// <param name="obj">The object to compare with the current instance.</param>
         /// <returns>true if <paramref name="obj">obj</paramref> and this instance are the same type and represent the same value; otherwise, false.</returns>
@@ -256,15 +272,6 @@ namespace SourceCode.Clay.OpenApi
                 return ((int)(hc >> 32)) ^ (int)hc;
             }
         }
-
-        public static bool operator ==(Schema schema1, Schema schema2)
-        {
-            if (ReferenceEquals(schema1, null) && ReferenceEquals(schema2, null)) return true;
-            if (ReferenceEquals(schema1, null) || ReferenceEquals(schema2, null)) return false;
-            return schema1.Equals((object)schema2);
-        }
-
-        public static bool operator !=(Schema schema1, Schema schema2) => !(schema1 == schema2);
 
         #endregion
     }

--- a/src/SourceCode.Clay.OpenApi/SchemaOptions.cs
+++ b/src/SourceCode.Clay.OpenApi/SchemaOptions.cs
@@ -1,3 +1,10 @@
+#region License
+
+// Copyright (c) K2 Workflow (SourceCode Technology Holdings Inc.). All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+#endregion
+
 using System;
 
 namespace SourceCode.Clay.OpenApi

--- a/src/SourceCode.Clay.OpenApi/SchemaType.cs
+++ b/src/SourceCode.Clay.OpenApi/SchemaType.cs
@@ -1,3 +1,10 @@
+#region License
+
+// Copyright (c) K2 Workflow (SourceCode Technology Holdings Inc.). All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+#endregion
+
 namespace SourceCode.Clay.OpenApi
 {
     /// <summary>

--- a/src/SourceCode.Clay.OpenApi/SecurityScheme.cs
+++ b/src/SourceCode.Clay.OpenApi/SecurityScheme.cs
@@ -1,3 +1,10 @@
+#region License
+
+// Copyright (c) K2 Workflow (SourceCode Technology Holdings Inc.). All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+#endregion
+
 using System;
 
 namespace SourceCode.Clay.OpenApi
@@ -7,6 +14,22 @@ namespace SourceCode.Clay.OpenApi
     /// </summary>
     public abstract class SecurityScheme : IEquatable<SecurityScheme>
     {
+        #region Constructors
+
+        /// <summary>
+        /// Creates a new instance of the <see cref="SecurityScheme"/> class.
+        /// </summary>
+        /// <param name="description">The short description for security scheme.</param>
+        protected SecurityScheme(
+            string description = default)
+        {
+            Description = description;
+        }
+
+        #endregion
+
+        #region Properties
+
         /// <summary>
         /// Gets the type of the security scheme.
         /// </summary>
@@ -20,17 +43,18 @@ namespace SourceCode.Clay.OpenApi
         /// </remarks>
         public string Description { get; }
 
-        /// <summary>
-        /// Creates a new instance of the <see cref="SecurityScheme"/> class.
-        /// </summary>
-        /// <param name="description">The short description for security scheme.</param>
-        protected SecurityScheme(
-            string description = default)
-        {
-            Description = description;
-        }
+        #endregion
 
         #region Equatable
+
+        public static bool operator ==(SecurityScheme scheme1, SecurityScheme scheme2)
+        {
+            if (ReferenceEquals(scheme1, null) && ReferenceEquals(scheme2, null)) return true;
+            if (ReferenceEquals(scheme1, null) || ReferenceEquals(scheme2, null)) return false;
+            return scheme1.Equals((object)scheme2);
+        }
+
+        public static bool operator !=(SecurityScheme scheme1, SecurityScheme scheme2) => !(scheme1 == scheme2);
 
         /// <summary>Determines whether the specified object is equal to the current object.</summary>
         /// <param name="obj">The object to compare with the current object.</param>
@@ -65,15 +89,6 @@ namespace SourceCode.Clay.OpenApi
                 return ((int)(hc >> 32)) ^ (int)hc;
             }
         }
-
-        public static bool operator ==(SecurityScheme scheme1, SecurityScheme scheme2)
-        {
-            if (ReferenceEquals(scheme1, null) && ReferenceEquals(scheme2, null)) return true;
-            if (ReferenceEquals(scheme1, null) || ReferenceEquals(scheme2, null)) return false;
-            return scheme1.Equals((object)scheme2);
-        }
-
-        public static bool operator !=(SecurityScheme scheme1, SecurityScheme scheme2) => !(scheme1 == scheme2);
 
         #endregion
     }

--- a/src/SourceCode.Clay.OpenApi/SecuritySchemeType.cs
+++ b/src/SourceCode.Clay.OpenApi/SecuritySchemeType.cs
@@ -1,3 +1,10 @@
+#region License
+
+// Copyright (c) K2 Workflow (SourceCode Technology Holdings Inc.). All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+#endregion
+
 namespace SourceCode.Clay.OpenApi
 {
     /// <summary>

--- a/src/SourceCode.Clay.OpenApi/Server.cs
+++ b/src/SourceCode.Clay.OpenApi/Server.cs
@@ -1,3 +1,10 @@
+#region License
+
+// Copyright (c) K2 Workflow (SourceCode Technology Holdings Inc.). All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+#endregion
+
 using SourceCode.Clay.Collections.Generic;
 using System;
 using System.Collections.Generic;
@@ -53,6 +60,15 @@ namespace SourceCode.Clay.OpenApi
 
         #region IEquatable
 
+        public static bool operator ==(Server server1, Server server2)
+        {
+            if (ReferenceEquals(server1, null) && ReferenceEquals(server2, null)) return true;
+            if (ReferenceEquals(server1, null) || ReferenceEquals(server2, null)) return false;
+            return server1.Equals((object)server2);
+        }
+
+        public static bool operator !=(Server server1, Server server2) => !(server1 == server2);
+
         /// <summary>Determines whether the specified object is equal to the current object.</summary>
         /// <param name="obj">The object to compare with the current object.</param>
         /// <returns>true if the specified object  is equal to the current object; otherwise, false.</returns>
@@ -88,15 +104,6 @@ namespace SourceCode.Clay.OpenApi
                 return ((int)(hc >> 32)) ^ (int)hc;
             }
         }
-
-        public static bool operator ==(Server server1, Server server2)
-        {
-            if (ReferenceEquals(server1, null) && ReferenceEquals(server2, null)) return true;
-            if (ReferenceEquals(server1, null) || ReferenceEquals(server2, null)) return false;
-            return server1.Equals((object)server2);
-        }
-
-        public static bool operator !=(Server server1, Server server2) => !(server1 == server2);
 
         #endregion
     }

--- a/src/SourceCode.Clay.OpenApi/Server.cs
+++ b/src/SourceCode.Clay.OpenApi/Server.cs
@@ -40,9 +40,9 @@ namespace SourceCode.Clay.OpenApi
         /// <param name="description">The optional string describing the host designated by the URL.</param>
         /// <param name="variables">The map between a variable name and its value.</param>
         public Server(
-            Uri url,
-            string description,
-            IReadOnlyDictionary<string, ServerVariable> variables)
+            Uri url = default,
+            string description = default,
+            IReadOnlyDictionary<string, ServerVariable> variables = default)
         {
             Url = url;
             Description = description;

--- a/src/SourceCode.Clay.OpenApi/ServerVariable.cs
+++ b/src/SourceCode.Clay.OpenApi/ServerVariable.cs
@@ -1,3 +1,10 @@
+#region License
+
+// Copyright (c) K2 Workflow (SourceCode Technology Holdings Inc.). All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+#endregion
+
 using SourceCode.Clay.Collections.Generic;
 using System;
 using System.Collections.Generic;
@@ -53,6 +60,16 @@ namespace SourceCode.Clay.OpenApi
 
         #region IEquatable
 
+        public static bool operator ==(ServerVariable serverVariable1, ServerVariable serverVariable2)
+        {
+            if (ReferenceEquals(serverVariable1, null) && ReferenceEquals(serverVariable2, null)) return true;
+            if (ReferenceEquals(serverVariable1, null) || ReferenceEquals(serverVariable2, null)) return false;
+            return serverVariable1.Equals((object)serverVariable2);
+        }
+
+        public static bool operator !=(ServerVariable serverVariable1, ServerVariable serverVariable2)
+                    => !(serverVariable1 == serverVariable2);
+
         /// <summary>Determines whether the specified object is equal to the current object.</summary>
         /// <param name="obj">The object to compare with the current object.</param>
         /// <returns>true if the specified object  is equal to the current object; otherwise, false.</returns>
@@ -88,16 +105,6 @@ namespace SourceCode.Clay.OpenApi
                 return ((int)(hc >> 32)) ^ (int)hc;
             }
         }
-
-        public static bool operator ==(ServerVariable serverVariable1, ServerVariable serverVariable2)
-        {
-            if (ReferenceEquals(serverVariable1, null) && ReferenceEquals(serverVariable2, null)) return true;
-            if (ReferenceEquals(serverVariable1, null) || ReferenceEquals(serverVariable2, null)) return false;
-            return serverVariable1.Equals((object)serverVariable2);
-        }
-
-        public static bool operator !=(ServerVariable serverVariable1, ServerVariable serverVariable2)
-            => !(serverVariable1 == serverVariable2);
 
         #endregion
     }

--- a/src/SourceCode.Clay.OpenApi/ServerVariable.cs
+++ b/src/SourceCode.Clay.OpenApi/ServerVariable.cs
@@ -40,9 +40,9 @@ namespace SourceCode.Clay.OpenApi
         /// <param name="default">The default value to use for substitution, and to send, if an alternate value is not supplied. </param>
         /// <param name="description">The description for the server variable.</param>
         public ServerVariable(
-            IReadOnlyList<string> @enum,
-            string @default,
-            string description)
+            IReadOnlyList<string> @enum = default,
+            string @default = default,
+            string description = default)
         {
             Enum = @enum ?? Array.Empty<string>();
             Default = @default;

--- a/src/SourceCode.Clay.OpenApi/Tag.cs
+++ b/src/SourceCode.Clay.OpenApi/Tag.cs
@@ -35,9 +35,9 @@ namespace SourceCode.Clay.OpenApi
         /// <param name="description">The short description for the tag.</param>
         /// <param name="externalDocumentation">The additional external documentation for the tag.</param>
         public Tag(
-            string name = null,
-            string description = null,
-            ExternalDocumentation externalDocumentation = null)
+            string name = default,
+            string description = default,
+            ExternalDocumentation externalDocumentation = default)
         {
             Name = name;
             Description = description;

--- a/src/SourceCode.Clay.OpenApi/Tag.cs
+++ b/src/SourceCode.Clay.OpenApi/Tag.cs
@@ -1,3 +1,10 @@
+#region License
+
+// Copyright (c) K2 Workflow (SourceCode Technology Holdings Inc.). All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+#endregion
+
 using System;
 
 namespace SourceCode.Clay.OpenApi
@@ -48,6 +55,15 @@ namespace SourceCode.Clay.OpenApi
 
         #region IEquatable
 
+        public static bool operator ==(Tag tag1, Tag tag2)
+        {
+            if (ReferenceEquals(tag1, null) && ReferenceEquals(tag2, null)) return true;
+            if (ReferenceEquals(tag1, null) || ReferenceEquals(tag2, null)) return false;
+            return tag1.Equals((object)tag2);
+        }
+
+        public static bool operator !=(Tag tag1, Tag tag2) => !(tag1 == tag2);
+
         /// <summary>Determines whether the specified object is equal to the current object.</summary>
         /// <param name="obj">The object to compare with the current object.</param>
         /// <returns>true if the specified object  is equal to the current object; otherwise, false.</returns>
@@ -83,15 +99,6 @@ namespace SourceCode.Clay.OpenApi
                 return ((int)(hc >> 32)) ^ (int)hc;
             }
         }
-
-        public static bool operator ==(Tag tag1, Tag tag2)
-        {
-            if (ReferenceEquals(tag1, null) && ReferenceEquals(tag2, null)) return true;
-            if (ReferenceEquals(tag1, null) || ReferenceEquals(tag2, null)) return false;
-            return tag1.Equals((object)tag2);
-        }
-
-        public static bool operator !=(Tag tag1, Tag tag2) => !(tag1 == tag2);
 
         #endregion
     }

--- a/src/SourceCode.Clay.Tests/DateTimeExtensionsTests.cs
+++ b/src/SourceCode.Clay.Tests/DateTimeExtensionsTests.cs
@@ -1,10 +1,19 @@
-﻿using System;
+#region License
+
+// Copyright (c) K2 Workflow (SourceCode Technology Holdings Inc.). All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+#endregion
+
+using System;
 using Xunit;
 
 namespace SourceCode.Clay.Tests
 {
     public static class DateTimeExtensionsTests
     {
+        #region Methods
+
         [Trait("Type", "Unit")]
         [Fact(DisplayName = nameof(DateTimeExtensions_ToPosixFileTime))]
         public static void DateTimeExtensions_ToPosixFileTime()
@@ -36,5 +45,7 @@ namespace SourceCode.Clay.Tests
             var dt = DateTimeExtensions.FromPosixFileTimeUtc(5380218331230000);
             Assert.Equal(new DateTime(1987, 01, 19, 02, 30, 33, 123, DateTimeKind.Utc), dt);
         }
+
+        #endregion
     }
 }

--- a/src/SourceCode.Clay.Tests/EquatableExtensionsTests.cs
+++ b/src/SourceCode.Clay.Tests/EquatableExtensionsTests.cs
@@ -1,10 +1,23 @@
-﻿using Xunit;
+#region License
+
+// Copyright (c) K2 Workflow (SourceCode Technology Holdings Inc.). All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+#endregion
+
+using Xunit;
 
 namespace SourceCode.Clay.Tests
 {
     public static class EquatableExtensionsTests
     {
+        #region Fields
+
         private const string _a = "a";
+
+        #endregion
+
+        #region Methods
 
         [Trait("Type", "Unit")]
         [Theory(DisplayName = nameof(When_nullable_equals_string))]
@@ -28,5 +41,7 @@ namespace SourceCode.Clay.Tests
         {
             Assert.Equal(expected, x.NullableEquals(y));
         }
+
+        #endregion
     }
 }

--- a/src/SourceCode.Clay.Tests/ExceptionExtensionsTests.cs
+++ b/src/SourceCode.Clay.Tests/ExceptionExtensionsTests.cs
@@ -1,4 +1,11 @@
-﻿using System;
+#region License
+
+// Copyright (c) K2 Workflow (SourceCode Technology Holdings Inc.). All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+#endregion
+
+using System;
 using Xunit;
 
 namespace SourceCode.Clay.Tests

--- a/src/SourceCode.Clay.Tests/NumberTests.cs
+++ b/src/SourceCode.Clay.Tests/NumberTests.cs
@@ -1,3 +1,10 @@
+#region License
+
+// Copyright (c) K2 Workflow (SourceCode Technology Holdings Inc.). All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+#endregion
+
 using System;
 using Xunit;
 
@@ -8,8 +15,10 @@ namespace SourceCode.Clay.Tests
 
     public static class NumberTests
     {
+        #region Methods
+
         [
-            InlineData("null", null, NumberKind.Null, false),
+                    InlineData("null", null, NumberKind.Null, false),
             InlineData(nameof(SByte) + "=0", (sbyte)0, NumberKind.Integer | NumberKind.Signed, true),
             InlineData(nameof(SByte), (sbyte)1, NumberKind.Integer | NumberKind.Signed, false),
             InlineData(nameof(Byte) + "=0", (byte)0, NumberKind.Integer, true),
@@ -403,6 +412,8 @@ namespace SourceCode.Clay.Tests
             aMax.CompareTo(bMin);
             aMax.CompareTo(bMax);
         }
+
+        #endregion
     }
 
 #   pragma warning restore xUnit1026 // Theory methods should use all of their parameters

--- a/src/SourceCode.Clay.Tests/SemanticVersionComparerTests.cs
+++ b/src/SourceCode.Clay.Tests/SemanticVersionComparerTests.cs
@@ -1,9 +1,18 @@
-﻿using Xunit;
+#region License
+
+// Copyright (c) K2 Workflow (SourceCode Technology Holdings Inc.). All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+#endregion
+
+using Xunit;
 
 namespace SourceCode.Clay.Tests
 {
     public static class SemanticVersionComparerTests
     {
+        #region Methods
+
         [InlineData(
             0, 1, 2, null, null,
             0, 1, 2, null, null,
@@ -212,5 +221,7 @@ namespace SourceCode.Clay.Tests
             Assert.Equal(strictResult < 0, strictActual < 0);
             Assert.Equal(strictResult > 0, strictActual > 0);
         }
+
+        #endregion
     }
 }

--- a/src/SourceCode.Clay.Tests/SemanticVersionTests.cs
+++ b/src/SourceCode.Clay.Tests/SemanticVersionTests.cs
@@ -1,9 +1,18 @@
-﻿using Xunit;
+#region License
+
+// Copyright (c) K2 Workflow (SourceCode Technology Holdings Inc.). All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+#endregion
+
+using Xunit;
 
 namespace SourceCode.Clay.Tests
 {
     public static class SemanticVersionTests
     {
+        #region Methods
+
         [InlineData("123.4.56", 123, 4, 56, null, null)]
         [InlineData("123.4.56-pre-0", 123, 4, 56, "pre-0", null)]
         [InlineData("123.4.56+build-0.1", 123, 4, 56, null, "build-0.1")]
@@ -142,5 +151,7 @@ namespace SourceCode.Clay.Tests
             var compat = SemanticVersion.GetCompatabilities(sut1, sut2);
             Assert.Equal(expected, compat);
         }
+
+        #endregion
     }
 }

--- a/src/SourceCode.Clay.Tests/StringExtensionsTests.cs
+++ b/src/SourceCode.Clay.Tests/StringExtensionsTests.cs
@@ -1,12 +1,25 @@
-﻿using System;
+#region License
+
+// Copyright (c) K2 Workflow (SourceCode Technology Holdings Inc.). All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+#endregion
+
+using System;
 using Xunit;
 
 namespace SourceCode.Clay.Tests
 {
     public static class StringExtensionsTests
     {
+        #region Fields
+
         private const string LongStr = @"From Wikipedia: Astley was born on 6 February 1966 in Newton-le-Willows in Lancashire, the fourth child of his family. His parents divorced when he was five, and Astley was brought up by his father.[9] His musical career started when he was ten, singing in the local church choir.[10] During his schooldays, Astley formed and played the drums in a number of local bands, where he met guitarist David Morris.[2][11] After leaving school at sixteen, Astley was employed during the day as a driver in his father's market-gardening business and played drums on the Northern club circuit at night in bands such as Give Way – specialising in covering Beatles and Shadows songs – and FBI, which won several local talent competitions.[10]";
         private const string SurrogatePair = "\uD869\uDE01";
+
+        #endregion
+
+        #region Methods
 
         [Trait("Type", "Unit")]
         [Fact(DisplayName = nameof(When_left_string))]
@@ -234,5 +247,7 @@ namespace SourceCode.Clay.Tests
             exp = StringComparer.Ordinal.Equals(y, x);
             Assert.Equal(exp, actual);
         }
+
+        #endregion
     }
 }

--- a/src/SourceCode.Clay.Text.Tests/OrdinalIgnoreCaseStringTests.cs
+++ b/src/SourceCode.Clay.Text.Tests/OrdinalIgnoreCaseStringTests.cs
@@ -1,9 +1,18 @@
-﻿using Xunit;
+#region License
+
+// Copyright (c) K2 Workflow (SourceCode Technology Holdings Inc.). All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+#endregion
+
+using Xunit;
 
 namespace SourceCode.Clay.Text.Tests
 {
     public static class OrdinalIgnoreCaseStringTests
     {
+        #region Methods
+
         [Trait("Type", "Unit")]
         [Fact(DisplayName = "OrdinalIgnoreCaseString NotEqual null")]
         public static void When_not_equal_null()
@@ -33,5 +42,7 @@ namespace SourceCode.Clay.Text.Tests
 
             Assert.Equal(expected, actual);
         }
+
+        #endregion
     }
 }

--- a/src/SourceCode.Clay.Text.Tests/OrdinalStringTests.cs
+++ b/src/SourceCode.Clay.Text.Tests/OrdinalStringTests.cs
@@ -1,9 +1,18 @@
-﻿using Xunit;
+#region License
+
+// Copyright (c) K2 Workflow (SourceCode Technology Holdings Inc.). All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+#endregion
+
+using Xunit;
 
 namespace SourceCode.Clay.Text.Tests
 {
     public static class OrdinalStringTests
     {
+        #region Methods
+
         [Trait("Type", "Unit")]
         [Fact(DisplayName = "OrdinalStringTests NotEqual null")]
         public static void When_not_equal_null()
@@ -43,5 +52,7 @@ namespace SourceCode.Clay.Text.Tests
 
             Assert.Equal(expected, actual);
         }
+
+        #endregion
     }
 }

--- a/src/SourceCode.Clay.Text.Tests/StringBuilderTests.cs
+++ b/src/SourceCode.Clay.Text.Tests/StringBuilderTests.cs
@@ -1,10 +1,19 @@
-﻿using System.Text;
+#region License
+
+// Copyright (c) K2 Workflow (SourceCode Technology Holdings Inc.). All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+#endregion
+
+using System.Text;
 using Xunit;
 
 namespace SourceCode.Clay.Text.Tests
 {
     public static class StringBuilderTests
     {
+        #region Methods
+
         [Trait("Type", "Unit")]
         [Fact(DisplayName = "StringBuilderExtensions AppendFormatLine 1 arg")]
         public static void When_append_format_line_1()
@@ -116,5 +125,7 @@ namespace SourceCode.Clay.Text.Tests
             Assert.Equal(expected.Length, actual.Length);
             Assert.Equal(expected, actual.ToString());
         }
+
+        #endregion
     }
 }

--- a/src/SourceCode.Clay.Text/OrdinalIgnoreCaseString.cs
+++ b/src/SourceCode.Clay.Text/OrdinalIgnoreCaseString.cs
@@ -1,3 +1,10 @@
+#region License
+
+// Copyright (c) K2 Workflow (SourceCode Technology Holdings Inc.). All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+#endregion
+
 using System;
 
 namespace SourceCode.Clay.Text

--- a/src/SourceCode.Clay.Text/OrdinalString.cs
+++ b/src/SourceCode.Clay.Text/OrdinalString.cs
@@ -1,3 +1,10 @@
+#region License
+
+// Copyright (c) K2 Workflow (SourceCode Technology Holdings Inc.). All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+#endregion
+
 using System;
 
 namespace SourceCode.Clay.Text

--- a/src/SourceCode.Clay.Text/StringBuilderExtensions.cs
+++ b/src/SourceCode.Clay.Text/StringBuilderExtensions.cs
@@ -1,4 +1,11 @@
-﻿using System;
+#region License
+
+// Copyright (c) K2 Workflow (SourceCode Technology Holdings Inc.). All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+#endregion
+
+using System;
 using System.Text;
 
 namespace SourceCode.Clay.Text
@@ -8,6 +15,8 @@ namespace SourceCode.Clay.Text
     /// </summary>
     public static class StringBuilderExtensions
     {
+        #region Methods
+
         /// <summary>
         /// Appends a formatted string (using zero or more format items) to this instance,
         /// followed by the default line terminator.
@@ -161,5 +170,7 @@ namespace SourceCode.Clay.Text
 
             return concat;
         }
+
+        #endregion
     }
 }

--- a/src/SourceCode.Clay.Threading.Tests/ParallelAsyncTests.cs
+++ b/src/SourceCode.Clay.Threading.Tests/ParallelAsyncTests.cs
@@ -1,3 +1,10 @@
+#region License
+
+// Copyright (c) K2 Workflow (SourceCode Technology Holdings Inc.). All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+#endregion
+
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -10,6 +17,8 @@ namespace SourceCode.Clay.Threading.Tests
 {
     public static class ParallelAsyncTests
     {
+        #region Methods
+
         [Trait("Type", "Unit")]
         [Theory(DisplayName = nameof(ParallelAsync_ForEach_Action_Default_Arguments))]
         [InlineData(null)]
@@ -261,6 +270,8 @@ namespace SourceCode.Clay.Threading.Tests
 
             Assert.Collection(actual.Result, n => Assert.Equal(0, n.Value), n => Assert.Equal(2, n.Value), n => Assert.Equal(4, n.Value));
         }
+
+        #endregion
 
         #region Timing
 

--- a/src/SourceCode.Clay.Threading/ParallelAsync.cs
+++ b/src/SourceCode.Clay.Threading/ParallelAsync.cs
@@ -1,3 +1,10 @@
+#region License
+
+// Copyright (c) K2 Workflow (SourceCode Technology Holdings Inc.). All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+#endregion
+
 using SourceCode.Clay.Collections.Generic;
 using System;
 using System.Collections.Concurrent;

--- a/src/SourceCode.Clay/DateTimeExtensions.cs
+++ b/src/SourceCode.Clay/DateTimeExtensions.cs
@@ -14,18 +14,17 @@ namespace SourceCode.Clay
     /// </summary>
     public static class DateTimeExtensions
     {
-        #region Fields
-
-        private static readonly long _difference = UnixEpoch.ToFileTimeUtc();
-
-        #endregion
-
         #region Properties
 
         /// <summary>
         /// Gets the Unix epoch as a <see cref="DateTime"/>.
         /// </summary>
         public static DateTime UnixEpoch { get; } = new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+
+        /// <summary>
+        /// Gets the difference between the Unix epoch and the Windows epoch.
+        /// </summary>
+        public static long UnixEpochDifference { get; } = UnixEpoch.ToFileTimeUtc();
 
         #endregion
 
@@ -36,28 +35,28 @@ namespace SourceCode.Clay
         /// </summary>
         /// <param name="value">The value to convert.</param>
         /// <returns>The Posix timestamp.</returns>
-        public static long ToPosixFileTime(this DateTime value) => value.ToFileTime() - _difference;
+        public static long ToPosixFileTime(this DateTime value) => value.ToFileTime() - UnixEpochDifference;
 
         /// <summary>
         /// Converts the specified <see cref="DateTime"/> to a UTC Posix timestamp.
         /// </summary>
         /// <param name="value">The value to convert.</param>
         /// <returns>The UTC Posix timestamp.</returns>
-        public static long ToPosixFileTimeUtc(this DateTime value) => value.ToFileTimeUtc() - _difference;
+        public static long ToPosixFileTimeUtc(this DateTime value) => value.ToFileTimeUtc() - UnixEpochDifference;
 
         /// <summary>
         /// Converts the specified Posix timestamp to a <see cref="DateTime"/>.
         /// </summary>
         /// <param name="posix">The Posix timestamp to convert.</param>
         /// <returns>The <see cref="DateTime"/>.</returns>
-        public static DateTime FromPosixFileTime(long posix) => DateTime.FromFileTime(posix + _difference);
+        public static DateTime FromPosixFileTime(long posix) => DateTime.FromFileTime(posix + UnixEpochDifference);
 
         /// <summary>
         /// Converts the specified Posix timestamp to a <see cref="DateTime"/>.
         /// </summary>
         /// <param name="posix">The Posix timestamp to convert.</param>
         /// <returns>The <see cref="DateTime"/>.</returns>
-        public static DateTime FromPosixFileTimeUtc(long posix) => DateTime.FromFileTimeUtc(posix + _difference);
+        public static DateTime FromPosixFileTimeUtc(long posix) => DateTime.FromFileTimeUtc(posix + UnixEpochDifference);
 
         #endregion
     }

--- a/src/SourceCode.Clay/DateTimeExtensions.cs
+++ b/src/SourceCode.Clay/DateTimeExtensions.cs
@@ -1,4 +1,11 @@
-﻿using System;
+#region License
+
+// Copyright (c) K2 Workflow (SourceCode Technology Holdings Inc.). All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+#endregion
+
+using System;
 
 namespace SourceCode.Clay
 {
@@ -7,12 +14,22 @@ namespace SourceCode.Clay
     /// </summary>
     public static class DateTimeExtensions
     {
+        #region Fields
+
+        private static readonly long _difference = UnixEpoch.ToFileTimeUtc();
+
+        #endregion
+
+        #region Properties
+
         /// <summary>
         /// Gets the Unix epoch as a <see cref="DateTime"/>.
         /// </summary>
         public static DateTime UnixEpoch { get; } = new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc);
 
-        private static readonly long _difference = UnixEpoch.ToFileTimeUtc();
+        #endregion
+
+        #region Methods
 
         /// <summary>
         /// Converts the specified <see cref="DateTime"/> to a Posix timestamp.
@@ -41,5 +58,7 @@ namespace SourceCode.Clay
         /// <param name="posix">The Posix timestamp to convert.</param>
         /// <returns>The <see cref="DateTime"/>.</returns>
         public static DateTime FromPosixFileTimeUtc(long posix) => DateTime.FromFileTimeUtc(posix + _difference);
+
+        #endregion
     }
 }

--- a/src/SourceCode.Clay/EquatableExtensions.cs
+++ b/src/SourceCode.Clay/EquatableExtensions.cs
@@ -1,4 +1,11 @@
-﻿using System;
+#region License
+
+// Copyright (c) K2 Workflow (SourceCode Technology Holdings Inc.). All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+#endregion
+
+using System;
 using System.Runtime.CompilerServices;
 
 namespace SourceCode.Clay
@@ -8,6 +15,8 @@ namespace SourceCode.Clay
     /// </summary>
     public static class EquatableExtensions
     {
+        #region Methods
+
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool NullableEquals<T>(this T x, T y)
             where T : IEquatable<T>
@@ -21,5 +30,7 @@ namespace SourceCode.Clay
 
             return x.Equals(y);
         }
+
+        #endregion
     }
 }

--- a/src/SourceCode.Clay/ExceptionExtensions.cs
+++ b/src/SourceCode.Clay/ExceptionExtensions.cs
@@ -1,4 +1,11 @@
-﻿using System;
+#region License
+
+// Copyright (c) K2 Workflow (SourceCode Technology Holdings Inc.). All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+#endregion
+
+using System;
 using System.Runtime.CompilerServices;
 
 namespace SourceCode.Clay
@@ -8,7 +15,9 @@ namespace SourceCode.Clay
     /// </summary>
     public static class ExceptionExtensions
     {
-#       pragma warning disable RECS0154 // Parameter is never used
+#pragma warning disable RECS0154 // Parameter is never used
+
+        #region Methods
 
         /// <summary>
         /// Does nothing.
@@ -24,6 +33,8 @@ namespace SourceCode.Clay
             return exception;
         }
 
-#       pragma warning restore RECS0154 // Parameter is never used
+        #endregion
+
+#pragma warning restore RECS0154 // Parameter is never used
     }
 }

--- a/src/SourceCode.Clay/Number.cs
+++ b/src/SourceCode.Clay/Number.cs
@@ -1,3 +1,10 @@
+#region License
+
+// Copyright (c) K2 Workflow (SourceCode Technology Holdings Inc.). All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+#endregion
+
 using System;
 using System.Globalization;
 using System.Linq.Expressions;

--- a/src/SourceCode.Clay/SafeRandom.cs
+++ b/src/SourceCode.Clay/SafeRandom.cs
@@ -1,4 +1,11 @@
-﻿using System;
+#region License
+
+// Copyright (c) K2 Workflow (SourceCode Technology Holdings Inc.). All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+#endregion
+
+using System;
 using System.Security.Cryptography;
 using System.Threading;
 
@@ -9,6 +16,8 @@ namespace SourceCode.Clay
     /// </summary>
     public sealed class SafeRandom : Random
     {
+        #region Fields
+
         private static readonly RandomNumberGenerator _seedSource = RandomNumberGenerator.Create();
 
         private static ThreadLocal<Random> _local = new ThreadLocal<Random>(() =>
@@ -20,6 +29,10 @@ namespace SourceCode.Clay
             var rand = new Random(seed);
             return rand;
         });
+
+        #endregion
+
+        #region Methods
 
         /// <summary>
         /// Returns a non-negative random integer.
@@ -61,5 +74,7 @@ namespace SourceCode.Clay
         /// A double-precision floating point number that is greater than or equal to 0.0, and less than 1.0.
         /// </returns>
         public override double NextDouble() => _local.Value.NextDouble();
+
+        #endregion
     }
 }

--- a/src/SourceCode.Clay/SemanticVersion.cs
+++ b/src/SourceCode.Clay/SemanticVersion.cs
@@ -1,4 +1,11 @@
-﻿using System;
+#region License
+
+// Copyright (c) K2 Workflow (SourceCode Technology Holdings Inc.). All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+#endregion
+
+using System;
 using System.Globalization;
 
 namespace SourceCode.Clay
@@ -111,6 +118,59 @@ namespace SourceCode.Clay
 
         #region Parse
 
+        private static bool TryParseInt(string value, int startIndex, int endIndex, out int result)
+        {
+            if (endIndex < 0) endIndex = value.Length;
+
+            result = 0;
+            for (var i = startIndex; i < endIndex; i++)
+            {
+                var c = value[i];
+                if (c < '0' || c > '9') return false;
+                result = unchecked((result * 10) + (c - '0'));
+                if (result < 0) return false;
+            }
+
+            return true;
+        }
+
+        private static bool ValidateBuildMetadata(string value, int startIndex, int endIndex)
+        {
+            if (value == null) return true;
+            if (endIndex < 0) endIndex = value.Length - 1;
+
+            for (var i = startIndex; i <= endIndex; i++)
+            {
+                var c = value[i];
+                if (
+                    (c < '0' || c > '9') &&
+                    (c < 'a' || c > 'z') &&
+                    (c < 'A' || c > 'Z') &&
+                    (c != '-') &&
+                    (c != '.'))
+                    return false;
+            }
+            return true;
+        }
+
+        private static bool ValidatePreRelease(string value, int startIndex, int endIndex)
+        {
+            if (value == null) return true;
+            if (endIndex < 0) endIndex = value.Length - 1;
+
+            for (var i = startIndex; i <= endIndex; i++)
+            {
+                var c = value[i];
+                if (
+                    (c < '0' || c > '9') &&
+                    (c < 'a' || c > 'z') &&
+                    (c < 'A' || c > 'Z') &&
+                    (c != '-'))
+                    return false;
+            }
+            return true;
+        }
+
         /// <summary>
         /// Converts the <see cref="string"/> representation of a semantic version to its structured equivalent.
         /// </summary>
@@ -209,59 +269,6 @@ namespace SourceCode.Clay
                     : s.Substring(preReleaseIndex + 1, buildMetadataIndex - preReleaseIndex - 1);
 
             result = new SemanticVersion(major, minor, patch, preRelease, buildMetadata);
-            return true;
-        }
-
-        private static bool TryParseInt(string value, int startIndex, int endIndex, out int result)
-        {
-            if (endIndex < 0) endIndex = value.Length;
-
-            result = 0;
-            for (var i = startIndex; i < endIndex; i++)
-            {
-                var c = value[i];
-                if (c < '0' || c > '9') return false;
-                result = unchecked((result * 10) + (c - '0'));
-                if (result < 0) return false;
-            }
-
-            return true;
-        }
-
-        private static bool ValidateBuildMetadata(string value, int startIndex, int endIndex)
-        {
-            if (value == null) return true;
-            if (endIndex < 0) endIndex = value.Length - 1;
-
-            for (var i = startIndex; i <= endIndex; i++)
-            {
-                var c = value[i];
-                if (
-                    (c < '0' || c > '9') &&
-                    (c < 'a' || c > 'z') &&
-                    (c < 'A' || c > 'Z') &&
-                    (c != '-') &&
-                    (c != '.'))
-                    return false;
-            }
-            return true;
-        }
-
-        private static bool ValidatePreRelease(string value, int startIndex, int endIndex)
-        {
-            if (value == null) return true;
-            if (endIndex < 0) endIndex = value.Length - 1;
-
-            for (var i = startIndex; i <= endIndex; i++)
-            {
-                var c = value[i];
-                if (
-                    (c < '0' || c > '9') &&
-                    (c < 'a' || c > 'z') &&
-                    (c < 'A' || c > 'Z') &&
-                    (c != '-'))
-                    return false;
-            }
             return true;
         }
 
@@ -427,20 +434,6 @@ namespace SourceCode.Clay
 
         #region String
 
-        /// <inheritdoc/>
-        public override string ToString() => ToDefinedFormatString('F', CultureInfo.InvariantCulture);
-
-        /// <inheritdoc/>
-        public string ToString(string format) => ToString(format, CultureInfo.InvariantCulture);
-
-        /// <inheritdoc/>
-        public string ToString(string format, IFormatProvider formatProvider)
-        {
-            if (string.IsNullOrEmpty(format)) format = "F";
-            if (format.Length != 1) throw new ArgumentOutOfRangeException(nameof(format));
-            return ToDefinedFormatString(format[0], formatProvider);
-        }
-
         private string ToDefinedFormatString(char format, IFormatProvider formatProvider)
         {
             FormattableString str;
@@ -484,6 +477,20 @@ namespace SourceCode.Clay
             }
 
             return str.ToString(formatProvider ?? CultureInfo.InvariantCulture);
+        }
+
+        /// <inheritdoc/>
+        public override string ToString() => ToDefinedFormatString('F', CultureInfo.InvariantCulture);
+
+        /// <inheritdoc/>
+        public string ToString(string format) => ToString(format, CultureInfo.InvariantCulture);
+
+        /// <inheritdoc/>
+        public string ToString(string format, IFormatProvider formatProvider)
+        {
+            if (string.IsNullOrEmpty(format)) format = "F";
+            if (format.Length != 1) throw new ArgumentOutOfRangeException(nameof(format));
+            return ToDefinedFormatString(format[0], formatProvider);
         }
 
         #endregion

--- a/src/SourceCode.Clay/SemanticVersionComparer.cs
+++ b/src/SourceCode.Clay/SemanticVersionComparer.cs
@@ -1,3 +1,10 @@
+#region License
+
+// Copyright (c) K2 Workflow (SourceCode Technology Holdings Inc.). All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+#endregion
+
 using System;
 using System.Collections.Generic;
 
@@ -53,8 +60,14 @@ namespace SourceCode.Clay
 
         private sealed class StrictSemanticVersionComparer : SemanticVersionComparer
         {
+            #region Constructors
+
             internal StrictSemanticVersionComparer()
             { }
+
+            #endregion
+
+            #region Methods
 
             public override int Compare(SemanticVersion x, SemanticVersion y)
             {
@@ -100,12 +113,20 @@ namespace SourceCode.Clay
 
                 return ((int)(hc >> 32)) ^ (int)hc;
             }
+
+            #endregion
         }
 
         private sealed class StandardSemanticVersionComparer : SemanticVersionComparer
         {
+            #region Constructors
+
             internal StandardSemanticVersionComparer()
             { }
+
+            #endregion
+
+            #region Methods
 
             public override int Compare(SemanticVersion x, SemanticVersion y)
             {
@@ -146,6 +167,8 @@ namespace SourceCode.Clay
 
                 return ((int)(hc >> 32)) ^ (int)hc;
             }
+
+            #endregion
         }
 
         #endregion

--- a/src/SourceCode.Clay/SemanticVersionCompatabilities.cs
+++ b/src/SourceCode.Clay/SemanticVersionCompatabilities.cs
@@ -1,4 +1,11 @@
-﻿using System;
+#region License
+
+// Copyright (c) K2 Workflow (SourceCode Technology Holdings Inc.). All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+#endregion
+
+using System;
 
 namespace SourceCode.Clay
 {

--- a/src/SourceCode.Clay/StringExtensions.cs
+++ b/src/SourceCode.Clay/StringExtensions.cs
@@ -1,4 +1,11 @@
-﻿using System;
+#region License
+
+// Copyright (c) K2 Workflow (SourceCode Technology Holdings Inc.). All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+#endregion
+
+using System;
 using System.Runtime.CompilerServices;
 
 namespace SourceCode.Clay
@@ -8,6 +15,8 @@ namespace SourceCode.Clay
     /// </summary>
     public static class StringExtensions
     {
+        #region Methods
+
         /// <summary>
         /// Returns the specified number of characters from the left of a string.
         /// Tolerates <paramref name="length"/> values that are too large or too small (or negative).
@@ -107,5 +116,7 @@ namespace SourceCode.Clay
 
             return x.Equals(y); // (s, t)
         }
+
+        #endregion
     }
 }


### PR DESCRIPTION
Adding missing default params to some OpenApi ctors.

CodeMaid now includes a license header. NB: Don't enable comment formatting, as that duplicates license headers at the top of the file.