### PR TITLE
Open API Builders

### DIFF
--- a/src/SourceCode.Clay.OpenApi/Builders/ApiKeySecuritySchemeBuilder.cs
+++ b/src/SourceCode.Clay.OpenApi/Builders/ApiKeySecuritySchemeBuilder.cs
@@ -1,0 +1,71 @@
+#region License
+
+// Copyright (c) K2 Workflow (SourceCode Technology Holdings Inc.). All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+#endregion
+
+using System;
+
+namespace SourceCode.Clay.OpenApi
+{
+    /// <summary>
+    /// Defines an API key security scheme that can be used by the operations.
+    /// </summary>
+    public class ApiKeySecuritySchemeBuilder : SecuritySchemeBuilder
+    {
+        #region Properties
+
+        /// <summary>
+        /// Gets or sets the name of the header, query or cookie parameter to be used.
+        /// </summary>
+        public string Name { get; set; }
+
+        /// <summary>
+        /// Gets or sets the location of the API key.
+        /// </summary>
+        public ParameterLocation Location { get; set; }
+
+        #endregion
+
+        #region Constructors
+
+        /// <summary>
+        /// Creates a new instance of the <see cref="ApiKeySecuritySchemeBuilder"/> class.
+        /// </summary>
+        public ApiKeySecuritySchemeBuilder()
+        {
+        }
+
+        /// <summary>
+        /// Creates a new instance of the <see cref="ApiKeySecuritySchemeBuilder"/> class.
+        /// </summary>
+        /// <param name="value">The <see cref="ApiKeySecurityScheme"/> to copy values from.</param>
+        public ApiKeySecuritySchemeBuilder(ApiKeySecurityScheme value)
+            : base(value)
+        {
+            if (ReferenceEquals(value, null)) throw new ArgumentNullException(nameof(value));
+            Name = value.Name;
+            Location = value.Location;
+        }
+
+        #endregion
+
+        #region Methods
+
+        public static implicit operator ApiKeySecurityScheme(ApiKeySecuritySchemeBuilder builder) => builder?.Build();
+
+        public static implicit operator ApiKeySecuritySchemeBuilder(ApiKeySecurityScheme value) => ReferenceEquals(value, null) ? null : new ApiKeySecuritySchemeBuilder(value);
+
+        /// <summary>
+        /// Creates the <see cref="ApiKeySecurityScheme"/> from this builder.
+        /// </summary>
+        /// <returns>The <see cref="ApiKeySecurityScheme"/>.</returns>
+        public ApiKeySecurityScheme Build() => new ApiKeySecurityScheme(
+            description: Description,
+            name: Name,
+            location: Location);
+
+        #endregion
+    }
+}

--- a/src/SourceCode.Clay.OpenApi/Builders/CallbackBuilder.cs
+++ b/src/SourceCode.Clay.OpenApi/Builders/CallbackBuilder.cs
@@ -1,0 +1,196 @@
+#region License
+
+// Copyright (c) K2 Workflow (SourceCode Technology Holdings Inc.). All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+#endregion
+
+using SourceCode.Clay.OpenApi.Expressions;
+using System;
+using System.Collections.Generic;
+using System.Collections;
+
+namespace SourceCode.Clay.OpenApi
+{
+    /// <summary>
+    /// A map of possible out-of band callbacks related to the parent operation. Each value in the map is a
+    /// <see cref="Path"/> that describes a set of requests that may be initiated by the API provider and
+    /// the expected responses. The key value used to identify the callback object is an expression, evaluated
+    /// at runtime, that identifies a URL to use for the callback operation.
+    /// </summary>
+    public class CallbackBuilder : IDictionary<CompoundExpression, Referable<Path>>, IReadOnlyDictionary<CompoundExpression, Referable<Path>>
+    {
+        #region Fields
+
+        private readonly Dictionary<CompoundExpression, Referable<Path>> _dictionary;
+
+        #endregion
+
+        #region Properties
+
+        /// <summary>Gets a value indicating whether the <see cref="T:System.Collections.Generic.ICollection`1"></see> is read-only.</summary>
+        /// <returns>true if the <see cref="T:System.Collections.Generic.ICollection`1"></see> is read-only; otherwise, false.</returns>
+        public bool IsReadOnly => false;
+
+        /// <summary>Gets an <see cref="T:System.Collections.Generic.ICollection`1"></see> containing the keys of the <see cref="T:System.Collections.Generic.IDictionary`2"></see>.</summary>
+        /// <returns>An <see cref="T:System.Collections.Generic.ICollection`1"></see> containing the keys of the object that implements <see cref="T:System.Collections.Generic.IDictionary`2"></see>.</returns>
+        public ICollection<CompoundExpression> Keys
+            => _dictionary.Keys;
+
+        /// <summary>Gets an <see cref="T:System.Collections.Generic.ICollection`1"></see> containing the values in the <see cref="T:System.Collections.Generic.IDictionary`2"></see>.</summary>
+        /// <returns>An <see cref="T:System.Collections.Generic.ICollection`1"></see> containing the values in the object that implements <see cref="T:System.Collections.Generic.IDictionary`2"></see>.</returns>
+        public ICollection<Referable<Path>> Values
+            => _dictionary.Values;
+
+        /// <summary>Gets the number of elements in the collection.</summary>
+        /// <returns>The number of elements in the collection.</returns>
+        public int Count
+            => _dictionary.Count;
+
+        /// <summary>Gets an enumerable collection that contains the keys in the read-only dictionary.</summary>
+        /// <returns>An enumerable collection that contains the keys in the read-only dictionary.</returns>
+        IEnumerable<CompoundExpression> IReadOnlyDictionary<CompoundExpression, Referable<Path>>.Keys
+            => _dictionary.Keys;
+
+        /// <summary>Gets an enumerable collection that contains the values in the read-only dictionary.</summary>
+        /// <returns>An enumerable collection that contains the values in the read-only dictionary.</returns>
+        IEnumerable<Referable<Path>> IReadOnlyDictionary<CompoundExpression, Referable<Path>>.Values
+            => _dictionary.Values;
+
+        #endregion
+
+        #region Indexers
+
+        /// <summary>Gets the element that has the specified key in the read-only dictionary.</summary>
+        /// <param name="key">The key to locate.</param>
+        /// <returns>The element that has the specified key in the read-only dictionary.</returns>
+        /// <exception cref="T:System.ArgumentNullException">
+        ///   <paramref name="key">key</paramref> is null.</exception>
+        /// <exception cref="T:System.Collections.Generic.KeyNotFoundException">The property is retrieved and <paramref name="key">key</paramref> is not found.</exception>
+        public Referable<Path> this[CompoundExpression key]
+        {
+            get => _dictionary[key];
+            set => _dictionary[key] = value;
+        }
+
+        #endregion
+
+        #region Constructors
+
+        /// <summary>
+        /// Creates a new instance of the <see cref="CallbackBuilder"/> class.
+        /// </summary>
+        public CallbackBuilder()
+        {
+            _dictionary = new Dictionary<CompoundExpression, Referable<Path>>();
+        }
+
+        /// <summary>
+        /// Creates a new instance of the <see cref="CallbackBuilder"/> class.
+        /// </summary>
+        /// <param name="value">The <see cref="Callback"/> to copy values from.</param>
+        public CallbackBuilder(Callback value)
+        {
+            if (ReferenceEquals(value, null)) throw new ArgumentNullException(nameof(value));
+            _dictionary = new Dictionary<CompoundExpression, Referable<Path>>(value);
+        }
+
+        #endregion
+
+        #region Methods
+
+        public static implicit operator Callback(CallbackBuilder builder) => builder?.Build();
+
+        public static implicit operator CallbackBuilder(Callback value) => ReferenceEquals(value, null) ? null : new CallbackBuilder(value);
+
+        /// <summary>
+        /// Creates the <see cref="Callback"/> from this builder.
+        /// </summary>
+        /// <returns>The <see cref="Callback"/>.</returns>
+        public Callback Build() => new Callback(
+            paths: this);
+
+        /// <summary>Adds an element with the provided key and value to the <see cref="T:System.Collections.Generic.IDictionary`2"></see>.</summary>
+        /// <param name="key">The object to use as the key of the element to add.</param>
+        /// <param name="value">The object to use as the value of the element to add.</param>
+        /// <exception cref="T:System.ArgumentNullException">
+        ///   <paramref name="key">key</paramref> is null.</exception>
+        /// <exception cref="T:System.ArgumentException">An element with the same key already exists in the <see cref="T:System.Collections.Generic.IDictionary`2"></see>.</exception>
+        /// <exception cref="T:System.NotSupportedException">The <see cref="T:System.Collections.Generic.IDictionary`2"></see> is read-only.</exception>
+        public void Add(CompoundExpression key, Referable<Path> value)
+            => _dictionary.Add(key, value);
+
+        /// <summary>Determines whether the read-only dictionary contains an element that has the specified key.</summary>
+        /// <param name="key">The key to locate.</param>
+        /// <returns>true if the read-only dictionary contains an element that has the specified key; otherwise, false.</returns>
+        /// <exception cref="T:System.ArgumentNullException">
+        ///   <paramref name="key">key</paramref> is null.</exception>
+        public bool ContainsKey(CompoundExpression key)
+            => _dictionary.ContainsKey(key);
+
+        /// <summary>Removes the element with the specified key from the <see cref="T:System.Collections.Generic.IDictionary`2"></see>.</summary>
+        /// <param name="key">The key of the element to remove.</param>
+        /// <returns>true if the element is successfully removed; otherwise, false.  This method also returns false if <paramref name="key">key</paramref> was not found in the original <see cref="T:System.Collections.Generic.IDictionary`2"></see>.</returns>
+        /// <exception cref="T:System.ArgumentNullException">
+        ///   <paramref name="key">key</paramref> is null.</exception>
+        /// <exception cref="T:System.NotSupportedException">The <see cref="T:System.Collections.Generic.IDictionary`2"></see> is read-only.</exception>
+        public bool Remove(CompoundExpression key)
+            => _dictionary.Remove(key);
+
+        /// <summary>Gets the value that is associated with the specified key.</summary>
+        /// <param name="key">The key to locate.</param>
+        /// <param name="value">When this method returns, the value associated with the specified key, if the key is found; otherwise, the default value for the type of the value parameter. This parameter is passed uninitialized.</param>
+        /// <returns>true if the object that implements the <see cref="T:System.Collections.Generic.IReadOnlyDictionary`2"></see> interface contains an element that has the specified key; otherwise, false.</returns>
+        /// <exception cref="T:System.ArgumentNullException">
+        ///   <paramref name="key">key</paramref> is null.</exception>
+        public bool TryGetValue(CompoundExpression key, out Referable<Path> value)
+            => _dictionary.TryGetValue(key, out value);
+
+        /// <summary>Removes all items from the <see cref="T:System.Collections.Generic.ICollection`1"></see>.</summary>
+        /// <exception cref="T:System.NotSupportedException">The <see cref="T:System.Collections.Generic.ICollection`1"></see> is read-only.</exception>
+        public void Clear()
+            => _dictionary.Clear();
+
+        /// <summary>Returns an enumerator that iterates through the collection.</summary>
+        /// <returns>An enumerator that can be used to iterate through the collection.</returns>
+        public IEnumerator<KeyValuePair<CompoundExpression, Referable<Path>>> GetEnumerator()
+            => _dictionary.GetEnumerator();
+
+        /// <summary>Removes the first occurrence of a specific object from the <see cref="T:System.Collections.Generic.ICollection`1"></see>.</summary>
+        /// <param name="item">The object to remove from the <see cref="T:System.Collections.Generic.ICollection`1"></see>.</param>
+        /// <returns>true if <paramref name="item">item</paramref> was successfully removed from the <see cref="T:System.Collections.Generic.ICollection`1"></see>; otherwise, false. This method also returns false if <paramref name="item">item</paramref> is not found in the original <see cref="T:System.Collections.Generic.ICollection`1"></see>.</returns>
+        /// <exception cref="T:System.NotSupportedException">The <see cref="T:System.Collections.Generic.ICollection`1"></see> is read-only.</exception>
+        bool ICollection<KeyValuePair<CompoundExpression, Referable<Path>>>.Remove(KeyValuePair<CompoundExpression, Referable<Path>> item)
+            => ((ICollection<KeyValuePair<CompoundExpression, Referable<Path>>>)_dictionary).Remove(item);
+
+        /// <summary>Copies the elements of the <see cref="T:System.Collections.Generic.ICollection`1"></see> to an <see cref="T:System.Array"></see>, starting at a particular <see cref="T:System.Array"></see> index.</summary>
+        /// <param name="array">The one-dimensional <see cref="T:System.Array"></see> that is the destination of the elements copied from <see cref="T:System.Collections.Generic.ICollection`1"></see>. The <see cref="T:System.Array"></see> must have zero-based indexing.</param>
+        /// <param name="arrayIndex">The zero-based index in array at which copying begins.</param>
+        /// <exception cref="T:System.ArgumentNullException">
+        ///   <paramref name="array">array</paramref> is null.</exception>
+        /// <exception cref="T:System.ArgumentOutOfRangeException">
+        ///   <paramref name="arrayIndex">arrayIndex</paramref> is less than 0.</exception>
+        /// <exception cref="T:System.ArgumentException">The number of elements in the source <see cref="T:System.Collections.Generic.ICollection`1"></see> is greater than the available space from <paramref name="arrayIndex">arrayIndex</paramref> to the end of the destination <paramref name="array">array</paramref>.</exception>
+        void ICollection<KeyValuePair<CompoundExpression, Referable<Path>>>.CopyTo(KeyValuePair<CompoundExpression, Referable<Path>>[] array, int arrayIndex)
+            => ((ICollection<KeyValuePair<CompoundExpression, Referable<Path>>>)_dictionary).CopyTo(array, arrayIndex);
+
+        /// <summary>Determines whether the <see cref="T:System.Collections.Generic.ICollection`1"></see> contains a specific value.</summary>
+        /// <param name="item">The object to locate in the <see cref="T:System.Collections.Generic.ICollection`1"></see>.</param>
+        /// <returns>true if <paramref name="item">item</paramref> is found in the <see cref="T:System.Collections.Generic.ICollection`1"></see>; otherwise, false.</returns>
+        bool ICollection<KeyValuePair<CompoundExpression, Referable<Path>>>.Contains(KeyValuePair<CompoundExpression, Referable<Path>> item)
+            => ((ICollection<KeyValuePair<CompoundExpression, Referable<Path>>>)_dictionary).Contains(item);
+
+        /// <summary>Adds an item to the <see cref="T:System.Collections.Generic.ICollection`1"></see>.</summary>
+        /// <param name="item">The object to add to the <see cref="T:System.Collections.Generic.ICollection`1"></see>.</param>
+        /// <exception cref="T:System.NotSupportedException">The <see cref="T:System.Collections.Generic.ICollection`1"></see> is read-only.</exception>
+        void ICollection<KeyValuePair<CompoundExpression, Referable<Path>>>.Add(KeyValuePair<CompoundExpression, Referable<Path>> item)
+            => _dictionary.Add(item.Key, item.Value);
+
+        /// <summary>Returns an enumerator that iterates through a collection.</summary>
+        /// <returns>An <see cref="T:System.Collections.IEnumerator"></see> object that can be used to iterate through the collection.</returns>
+        IEnumerator IEnumerable.GetEnumerator() =>
+            _dictionary.GetEnumerator();
+
+        #endregion
+    }
+}

--- a/src/SourceCode.Clay.OpenApi/Builders/ComponentsBuilder.cs
+++ b/src/SourceCode.Clay.OpenApi/Builders/ComponentsBuilder.cs
@@ -1,0 +1,122 @@
+#region License
+
+// Copyright (c) K2 Workflow (SourceCode Technology Holdings Inc.). All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+#endregion
+
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+
+namespace SourceCode.Clay.OpenApi
+{
+    /// <summary>
+    /// Holds a set of reusable objects for different aspects of the OAS. All objects
+    /// defined within the components object will have no effect on the API unless they
+    /// are explicitly referenced from properties outside the components object.
+    /// </summary>
+    public class ComponentsBuilder
+    {
+        #region Properties
+
+        /// <summary>
+        /// Gets the object that holds reusable <see cref="Schema"/> instances.
+        /// </summary>
+        public IDictionary<string, Referable<Schema>> Schemas { get; }
+
+        /// <summary>
+        /// Gets the object that holds reusable <see cref="Response"/> instances.
+        /// </summary>
+        public IDictionary<string, Referable<Response>> Responses { get; }
+
+        /// <summary>
+        /// Gets the object that holds reusable <see cref="Parameter"/> instances.
+        /// </summary>
+        public IDictionary<string, Referable<Parameter>> Parameters { get; }
+
+        /// <summary>
+        /// Gets the object that holds reusable <see cref="Example"/> instances.
+        /// </summary>
+        public IDictionary<string, Referable<Example>> Examples { get; }
+
+        /// <summary>
+        /// Gets the object that holds reusable <see cref="RequestBody"/> instances.
+        /// </summary>
+        public IDictionary<string, Referable<RequestBody>> RequestBodies { get; }
+
+        /// <summary>
+        /// Gets the object that holds reusable header <see cref="ParameterBody"/> instances.
+        /// </summary>
+        public IDictionary<string, Referable<ParameterBody>> Headers { get; }
+
+        /// <summary>
+        /// Gets the object that holds reusable <see cref="SecurityScheme"/> instances.
+        /// </summary>
+        public IDictionary<string, Referable<SecurityScheme>> SecuritySchemes { get; }
+
+        /// <summary>
+        /// Gets the object that holds reusable <see cref="Link"/> instances.
+        /// </summary>
+        public IDictionary<string, Referable<Link>> Links { get; }
+
+        /// <summary>
+        /// Gets the object that holds reusable <see cref="Callback"/> instances.
+        /// </summary>
+        public IDictionary<string, Referable<Callback>> Callbacks { get; }
+
+        #endregion
+
+        #region Constructors
+
+        /// <summary>
+        /// Creates a new instance of the <see cref="ComponentsBuilder"/> class.
+        /// </summary>
+        public ComponentsBuilder()
+        {
+        }
+
+        /// <summary>
+        /// Creates a new instance of the <see cref="ComponentsBuilder"/> class.
+        /// </summary>
+        /// <param name="value">The <see cref="Components"/> to copy values from.</param>
+        public ComponentsBuilder(Components value)
+        {
+            if (ReferenceEquals(value, null)) throw new ArgumentNullException(nameof(value));
+            Schemas = new Dictionary<string, Referable<Schema>>(value.Schemas);
+            Responses = new Dictionary<string, Referable<Response>>(value.Responses);
+            Parameters = new Dictionary<string, Referable<Parameter>>(value.Parameters);
+            Examples = new Dictionary<string, Referable<Example>>(value.Examples);
+            RequestBodies = new Dictionary<string, Referable<RequestBody>>(value.RequestBodies);
+            Headers = new Dictionary<string, Referable<ParameterBody>>(value.Headers);
+            SecuritySchemes = new Dictionary<string, Referable<SecurityScheme>>(value.SecuritySchemes);
+            Links = new Dictionary<string, Referable<Link>>(value.Links);
+            Callbacks = new Dictionary<string, Referable<Callback>>(value.Callbacks);
+        }
+
+        #endregion
+
+        #region Methods
+
+        public static implicit operator Components(ComponentsBuilder builder) => builder?.Build();
+
+        public static implicit operator ComponentsBuilder(Components value) => ReferenceEquals(value, null) ? null : new ComponentsBuilder(value);
+
+        /// <summary>
+        /// Creates the <see cref="Components"/> from this builder.
+        /// </summary>
+        /// <returns>The <see cref="Components"/>.</returns>
+        public Components Build() => new Components(
+            schemas: new ReadOnlyDictionary<string, Referable<Schema>>(Schemas),
+            responses: new ReadOnlyDictionary<string, Referable<Response>>(Responses),
+            parameters: new ReadOnlyDictionary<string, Referable<Parameter>>(Parameters),
+            examples: new ReadOnlyDictionary<string, Referable<Example>>(Examples),
+            requestBodies: new ReadOnlyDictionary<string, Referable<RequestBody>>(RequestBodies),
+            headers: new ReadOnlyDictionary<string, Referable<ParameterBody>>(Headers),
+            securitySchemes: new ReadOnlyDictionary<string, Referable<SecurityScheme>>(SecuritySchemes),
+            links: new ReadOnlyDictionary<string, Referable<Link>>(Links),
+            callbacks: new ReadOnlyDictionary<string, Referable<Callback>>(Callbacks));
+
+        #endregion
+    }
+}

--- a/src/SourceCode.Clay.OpenApi/Builders/ContactBuilder.cs
+++ b/src/SourceCode.Clay.OpenApi/Builders/ContactBuilder.cs
@@ -1,0 +1,77 @@
+#region License
+
+// Copyright (c) K2 Workflow (SourceCode Technology Holdings Inc.). All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+#endregion
+
+using System;
+using System.Net.Mail;
+
+namespace SourceCode.Clay.OpenApi
+{
+    /// <summary>
+    /// Contact information for the exposed API.
+    /// </summary>
+    public class ContactBuilder
+    {
+        #region Properties
+
+        /// <summary>
+        /// Gets or sets the identifying name of the contact person/organization.
+        /// </summary>
+        public string Name { get; set; }
+
+        /// <summary>
+        /// Gets or sets the URL pointing to the contact information.
+        /// </summary>
+        public Uri Url { get; set; }
+
+        /// <summary>
+        /// Gets or sets email address of the contact person/organization.
+        /// </summary>
+        public MailAddress Email { get; set; }
+
+        #endregion
+
+        #region Constructors
+
+        /// <summary>
+        /// Creates a new instance of the <see cref="ContactBuilder"/> class.
+        /// </summary>
+        public ContactBuilder()
+        {
+        }
+
+        /// <summary>
+        /// Creates a new instance of the <see cref="ContactBuilder"/> class.
+        /// </summary>
+        /// <param name="value">The <see cref="Contact"/> to copy values from.</param>
+        public ContactBuilder(Contact value)
+        {
+            if (ReferenceEquals(value, null)) throw new ArgumentNullException(nameof(value));
+            Name = value.Name;
+            Url = value.Url;
+            Email = value.Email;
+        }
+
+        #endregion
+
+        #region Methods
+
+        public static implicit operator Contact(ContactBuilder builder) => builder?.Build();
+
+        public static implicit operator ContactBuilder(Contact value) => ReferenceEquals(value, null) ? null : new ContactBuilder(value);
+
+        /// <summary>
+        /// Creates the <see cref="Contact"/> from this builder.
+        /// </summary>
+        /// <returns>The <see cref="Contact"/>.</returns>
+        public Contact Build() => new Contact(
+            name: Name,
+            url: Url,
+            email: Email);
+
+        #endregion
+    }
+}

--- a/src/SourceCode.Clay.OpenApi/Builders/DocumentBuilder.cs
+++ b/src/SourceCode.Clay.OpenApi/Builders/DocumentBuilder.cs
@@ -1,0 +1,113 @@
+#region License
+
+// Copyright (c) K2 Workflow (SourceCode Technology Holdings Inc.). All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+#endregion
+
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+
+namespace SourceCode.Clay.OpenApi
+{
+    /// <summary>
+    /// This is the root document object of the OpenAPI document.
+    /// </summary>
+    public class DocumentBuilder
+    {
+        #region Properties
+
+        /// <summary>
+        /// Gets or sets the semantic version number of the OpenAPI Specification version that the OpenAPI document uses.
+        /// </summary>
+        public SemanticVersion? Version { get; set; }
+
+        /// <summary>
+        /// Gets or sets the metadata about the API.
+        /// </summary>
+        public Information Info { get; set; }
+
+        /// <summary>
+        /// Gets the list of <see cref="Server"/> instances, which provide connectivity information to a target server.
+        /// </summary>
+        public IList<Server> Servers { get; }
+
+        /// <summary>
+        /// Gets the available paths and operations for the API.
+        /// </summary>
+        public IDictionary<string, Referable<Path>> Paths { get; }
+
+        /// <summary>
+        /// Gets or sets the list that holds various schemas for the specification.
+        /// </summary>
+        public Components Components { get; set; }
+
+        /// <summary>
+        /// Gets the declaration of which security mechanisms can be used across the API.
+        /// </summary>
+        public IList<Referable<SecurityScheme>> Security { get; }
+
+        /// <summary>
+        /// Gets the list of tags used by the specification with additional metadata.
+        /// </summary>
+        public IList<Tag> Tags { get; }
+
+        /// <summary>
+        /// Gets or sets the external documentation.
+        /// </summary>
+        public ExternalDocumentation ExternalDocumentation { get; set; }
+
+        #endregion
+
+        #region Constructors
+
+        /// <summary>
+        /// Creates a new instance of the <see cref="DocumentBuilder"/> class.
+        /// </summary>
+        public DocumentBuilder()
+        {
+        }
+
+        /// <summary>
+        /// Creates a new instance of the <see cref="DocumentBuilder"/> class.
+        /// </summary>
+        /// <param name="value">The <see cref="Document"/> to copy values from.</param>
+        public DocumentBuilder(Document value)
+        {
+            if (ReferenceEquals(value, null)) throw new ArgumentNullException(nameof(value));
+            Version = value.Version;
+            Info = value.Info;
+            Servers = new List<Server>(value.Servers);
+            Paths = new Dictionary<string, Referable<Path>>(value.Paths);
+            Components = value.Components;
+            Security = new List<Referable<SecurityScheme>>(value.Security);
+            Tags = new List<Tag>(value.Tags);
+            ExternalDocumentation = value.ExternalDocumentation;
+        }
+
+        #endregion
+
+        #region Methods
+
+        public static implicit operator Document(DocumentBuilder builder) => builder?.Build();
+
+        public static implicit operator DocumentBuilder(Document value) => ReferenceEquals(value, null) ? null : new DocumentBuilder(value);
+
+        /// <summary>
+        /// Creates the <see cref="Document"/> from this builder.
+        /// </summary>
+        /// <returns>The <see cref="Document"/>.</returns>
+        public Document Build() => new Document(
+            version: Version,
+            info: Info,
+            servers: new ReadOnlyCollection<Server>(Servers),
+            paths: new ReadOnlyDictionary<string, Referable<Path>>(Paths),
+            components: Components,
+            security: new ReadOnlyCollection<Referable<SecurityScheme>>(Security),
+            tags: new ReadOnlyCollection<Tag>(Tags),
+            externalDocumentation: ExternalDocumentation);
+
+        #endregion
+    }
+}

--- a/src/SourceCode.Clay.OpenApi/Builders/ExampleBuilder.cs
+++ b/src/SourceCode.Clay.OpenApi/Builders/ExampleBuilder.cs
@@ -1,0 +1,77 @@
+#region License
+
+// Copyright (c) K2 Workflow (SourceCode Technology Holdings Inc.). All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+#endregion
+
+using System;
+
+namespace SourceCode.Clay.OpenApi
+{
+    /// <summary>
+    /// Contains an example of how to use an entity in an Open API document.
+    /// </summary>
+    public class ExampleBuilder
+    {
+        #region Properties
+
+        /// <summary>
+        /// Gets or sets the short description for the example.
+        /// </summary>
+        public string Summary { get; set; }
+
+        /// <summary>
+        /// Gets or sets the long description for the example.
+        /// </summary>
+        /// <remarks>CommonMark syntax MAY be used for rich text representation.</remarks>
+        public string Description { get; set; }
+
+        /// <summary>
+        /// Gets the URL that points to the literal example.
+        /// </summary>
+        public Uri ExternalValue { get; set; }
+
+        #endregion
+
+        #region Constructors
+
+        /// <summary>
+        /// Creates a new instance of the <see cref="ExampleBuilder"/> class.
+        /// </summary>
+        public ExampleBuilder()
+        {
+        }
+
+        /// <summary>
+        /// Creates a new instance of the <see cref="ExampleBuilder"/> class.
+        /// </summary>
+        /// <param name="value">The <see cref="Example"/> to copy values from.</param>
+        public ExampleBuilder(Example value)
+        {
+            if (ReferenceEquals(value, null)) throw new ArgumentNullException(nameof(value));
+            Summary = value.Summary;
+            Description = value.Description;
+            ExternalValue = value.ExternalValue;
+        }
+
+        #endregion
+
+        #region Methods
+
+        public static implicit operator Example(ExampleBuilder builder) => builder?.Build();
+
+        public static implicit operator ExampleBuilder(Example value) => ReferenceEquals(value, null) ? null : new ExampleBuilder(value);
+
+        /// <summary>
+        /// Creates the <see cref="Example"/> from this builder.
+        /// </summary>
+        /// <returns>The <see cref="Example"/>.</returns>
+        public Example Build() => new Example(
+            summary: Summary,
+            description: Description,
+            externalValue: ExternalValue);
+
+        #endregion
+    }
+}

--- a/src/SourceCode.Clay.OpenApi/Builders/ExternalDocumentationBuilder.cs
+++ b/src/SourceCode.Clay.OpenApi/Builders/ExternalDocumentationBuilder.cs
@@ -1,0 +1,72 @@
+#region License
+
+// Copyright (c) K2 Workflow (SourceCode Technology Holdings Inc.). All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+#endregion
+
+using System;
+
+namespace SourceCode.Clay.OpenApi
+{
+    /// <summary>
+    /// Allows referencing an external resource for extended documentation.
+    /// </summary>
+    public class ExternalDocumentationBuilder
+    {
+        #region Properties
+
+        /// <summary>
+        /// Get or sets the short description of the target documentation.
+        /// </summary>
+        /// <remarks>
+        /// CommonMark syntax MAY be used for rich text representation.
+        /// </remarks>
+        public string Description { get; set; }
+
+        /// <summary>
+        /// Gets the URL for the target documentation.
+        /// </summary>
+        public Uri Url { get; set; }
+
+        #endregion
+
+        #region Constructors
+
+        /// <summary>
+        /// Creates a new instance of the <see cref="ExternalDocumentationBuilder"/> class.
+        /// </summary>
+        public ExternalDocumentationBuilder()
+        {
+        }
+
+        /// <summary>
+        /// Creates a new instance of the <see cref="ExternalDocumentationBuilder"/> class.
+        /// </summary>
+        /// <param name="value">The <see cref="ExternalDocumentation"/> to copy values from.</param>
+        public ExternalDocumentationBuilder(ExternalDocumentation value)
+        {
+            if (ReferenceEquals(value, null)) throw new ArgumentNullException(nameof(value));
+            Description = value.Description;
+            Url = value.Url;
+        }
+
+        #endregion
+
+        #region Methods
+
+        public static implicit operator ExternalDocumentation(ExternalDocumentationBuilder builder) => builder?.Build();
+
+        public static implicit operator ExternalDocumentationBuilder(ExternalDocumentation value) => ReferenceEquals(value, null) ? null : new ExternalDocumentationBuilder(value);
+
+        /// <summary>
+        /// Creates the <see cref="ExternalDocumentation"/> from this builder.
+        /// </summary>
+        /// <returns>The <see cref="ExternalDocumentation"/>.</returns>
+        public ExternalDocumentation Build() => new ExternalDocumentation(
+            description: Description,
+            url: Url);
+
+        #endregion
+    }
+}

--- a/src/SourceCode.Clay.OpenApi/Builders/HttpSecuritySchemeBuilder.cs
+++ b/src/SourceCode.Clay.OpenApi/Builders/HttpSecuritySchemeBuilder.cs
@@ -1,0 +1,68 @@
+#region License
+
+// Copyright (c) K2 Workflow (SourceCode Technology Holdings Inc.). All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+#endregion
+
+using System;
+
+namespace SourceCode.Clay.OpenApi
+{
+    public class HttpSecuritySchemeBuilder : SecuritySchemeBuilder
+    {
+        #region Properties
+
+        /// <summary>
+        /// Gets or sets the name of the HTTP Authorization scheme to be used in the Authorization header.
+        /// </summary>
+        public string Scheme { get; }
+
+        /// <summary>
+        /// Gets or sets the hint to the client to identify how the bearer token is formatted.
+        /// </summary>
+        public string BearerFormat { get; }
+
+        #endregion
+
+        #region Constructors
+
+        /// <summary>
+        /// Creates a new instance of the <see cref="HttpSecuritySchemeBuilder"/> class.
+        /// </summary>
+        public HttpSecuritySchemeBuilder()
+        {
+        }
+
+        /// <summary>
+        /// Creates a new instance of the <see cref="HttpSecuritySchemeBuilder"/> class.
+        /// </summary>
+        /// <param name="value">The <see cref="HttpSecurityScheme"/> to copy values from.</param>
+        public HttpSecuritySchemeBuilder(HttpSecurityScheme value)
+            : base(value)
+        {
+            if (ReferenceEquals(value, null)) throw new ArgumentNullException(nameof(value));
+            Scheme = value.Scheme;
+            BearerFormat = value.BearerFormat;
+        }
+
+        #endregion
+
+        #region Methods
+
+        public static implicit operator HttpSecurityScheme(HttpSecuritySchemeBuilder builder) => builder?.Build();
+
+        public static implicit operator HttpSecuritySchemeBuilder(HttpSecurityScheme value) => ReferenceEquals(value, null) ? null : new HttpSecuritySchemeBuilder(value);
+
+        /// <summary>
+        /// Creates the <see cref="HttpSecurityScheme"/> from this builder.
+        /// </summary>
+        /// <returns>The <see cref="HttpSecurityScheme"/>.</returns>
+        public HttpSecurityScheme Build() => new HttpSecurityScheme(
+            description: Description,
+            scheme: Scheme,
+            bearerFormat: BearerFormat);
+
+        #endregion
+    }
+}

--- a/src/SourceCode.Clay.OpenApi/Builders/InformationBuilder.cs
+++ b/src/SourceCode.Clay.OpenApi/Builders/InformationBuilder.cs
@@ -1,0 +1,102 @@
+#region License
+
+// Copyright (c) K2 Workflow (SourceCode Technology Holdings Inc.). All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+#endregion
+
+using System;
+
+namespace SourceCode.Clay.OpenApi
+{
+    /// <summary>
+    /// The object provides metadata about the API. The metadata MAY be used by the
+    /// clients if needed, and MAY be presented in editing or documentation generation
+    /// tools for convenience.
+    /// </summary>
+    public class InformationBuilder
+    {
+        #region Properties
+
+        /// <summary>
+        /// Gets or sets the title of the exposed API.
+        /// </summary>
+        public string Title { get; set; }
+
+        /// <summary>
+        /// Gets the short description of the exposed API.
+        /// </summary>
+        /// <remarks>
+        /// CommonMark syntax MAY be used for rich text representation.
+        /// </remarks>
+        public string Description { get; set; }
+
+        /// <summary>
+        /// Gets or sets the URL to the Terms of Service for the exposed API.
+        /// </summary>
+        public Uri TermsOfService { get; set; }
+
+        /// <summary>
+        /// Gets or sets the contact information for the exposed API.
+        /// </summary>
+        public Contact Contact { get; set; }
+
+        /// <summary>
+        /// Gets or sets the license information for the exposed API.
+        /// </summary>
+        public License License { get; set; }
+
+        /// <summary>
+        /// Gets or sets the version of the exposed API.
+        /// </summary>
+        public SemanticVersion Version { get; set; }
+
+        #endregion
+
+        #region Constructors
+
+        /// <summary>
+        /// Creates a new instance of the <see cref="InformationBuilder"/> class.
+        /// </summary>
+        public InformationBuilder()
+        {
+        }
+
+        /// <summary>
+        /// Creates a new instance of the <see cref="InformationBuilder"/> class.
+        /// </summary>
+        /// <param name="value">The <see cref="Information"/> to copy values from.</param>
+        public InformationBuilder(Information value)
+        {
+            if (ReferenceEquals(value, null)) throw new ArgumentNullException(nameof(value));
+            Title = value.Title;
+            Description = value.Description;
+            TermsOfService = value.TermsOfService;
+            Contact = value.Contact;
+            License = value.License;
+            Version = value.Version;
+        }
+
+        #endregion
+
+        #region Methods
+
+        public static implicit operator Information(InformationBuilder builder) => builder?.Build();
+
+        public static implicit operator InformationBuilder(Information value) => ReferenceEquals(value, null) ? null : new InformationBuilder(value);
+
+        /// <summary>
+        /// Creates the <see cref="Information"/> from this builder.
+        /// </summary>
+        /// <returns>The <see cref="Information"/>.</returns>
+        public Information Build() => new Information(
+            title: Title,
+            description: Description,
+            termsOfService: TermsOfService,
+            contact: Contact,
+            license: License,
+            version: Version);
+
+        #endregion
+    }
+}

--- a/src/SourceCode.Clay.OpenApi/Builders/LicenseBuilder.cs
+++ b/src/SourceCode.Clay.OpenApi/Builders/LicenseBuilder.cs
@@ -1,0 +1,69 @@
+#region License
+
+// Copyright (c) K2 Workflow (SourceCode Technology Holdings Inc.). All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+#endregion
+
+using System;
+
+namespace SourceCode.Clay.OpenApi
+{
+    /// <summary>
+    /// License information for the exposed API.
+    /// </summary>
+    public class LicenseBuilder
+    {
+        #region Properties
+
+        /// <summary>
+        /// Gets or sets the license name used for the API.
+        /// </summary>
+        public string Name { get; set; }
+
+        /// <summary>
+        /// Gets or sets the URL to the license used for the API
+        /// </summary>
+        public Uri Url { get; set; }
+
+        #endregion
+
+        #region Constructors
+
+        /// <summary>
+        /// Creates a new instance of the <see cref="LicenseBuilder"/> class.
+        /// </summary>
+        public LicenseBuilder()
+        {
+        }
+
+        /// <summary>
+        /// Creates a new instance of the <see cref="LicenseBuilder"/> class.
+        /// </summary>
+        /// <param name="value">The <see cref="License"/> to copy values from.</param>
+        public LicenseBuilder(License value)
+        {
+            if (ReferenceEquals(value, null)) throw new ArgumentNullException(nameof(value));
+            Name = value.Name;
+            Url = value.Url;
+        }
+
+        #endregion
+
+        #region Methods
+
+        public static implicit operator License(LicenseBuilder builder) => builder?.Build();
+
+        public static implicit operator LicenseBuilder(License value) => ReferenceEquals(value, null) ? null : new LicenseBuilder(value);
+
+        /// <summary>
+        /// Creates the <see cref="License"/> from this builder.
+        /// </summary>
+        /// <returns>The <see cref="License"/>.</returns>
+        public License Build() => new License(
+            name: Name,
+            url: Url);
+
+        #endregion
+    }
+}

--- a/src/SourceCode.Clay.OpenApi/Builders/LinkBuilder.cs
+++ b/src/SourceCode.Clay.OpenApi/Builders/LinkBuilder.cs
@@ -1,0 +1,86 @@
+#region License
+
+// Copyright (c) K2 Workflow (SourceCode Technology Holdings Inc.). All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+#endregion
+
+using System;
+
+namespace SourceCode.Clay.OpenApi
+{
+    /// <summary>
+    /// Represents a possible design-time link for a response.
+    /// </summary>
+    public class LinkBuilder
+    {
+        #region Properties
+
+        /// <summary>
+        /// Gets or sets the relative or absolute reference to an OAS operation.
+        /// </summary>
+        public Reference OperationReference { get; set; }
+
+        /// <summary>
+        /// Gets or sets the name of an existing, resolvable OAS operation, as defined with a unique operation identifier.
+        /// </summary>
+        public string OperationIdentifier { get; set; }
+
+        /// <summary>
+        /// Get or sets the description of the link.
+        /// </summary>
+        /// <remarks>
+        /// CommonMark syntax MAY be used for rich text representation.
+        /// </remarks>
+        public string Description { get; set; }
+
+        /// <summary>
+        /// A server object to be used by the target operation.
+        /// </summary>
+        public Server Server { get; set; }
+
+        #endregion
+
+        #region Constructors
+
+        /// <summary>
+        /// Creates a new instance of the <see cref="LinkBuilder"/> class.
+        /// </summary>
+        public LinkBuilder()
+        {
+        }
+
+        /// <summary>
+        /// Creates a new instance of the <see cref="LinkBuilder"/> class.
+        /// </summary>
+        /// <param name="value">The <see cref="Link"/> to copy values from.</param>
+        public LinkBuilder(Link value)
+        {
+            if (ReferenceEquals(value, null)) throw new ArgumentNullException(nameof(value));
+            OperationReference = value.OperationReference;
+            OperationIdentifier = value.OperationIdentifier;
+            Description = value.Description;
+            Server = value.Server;
+        }
+
+        #endregion
+
+        #region Methods
+
+        public static implicit operator Link(LinkBuilder builder) => builder?.Build();
+
+        public static implicit operator LinkBuilder(Link value) => ReferenceEquals(value, null) ? null : new LinkBuilder(value);
+
+        /// <summary>
+        /// Creates the <see cref="Link"/> from this builder.
+        /// </summary>
+        /// <returns>The <see cref="Link"/>.</returns>
+        public Link Build() => new Link(
+            operationReference: OperationReference,
+            operationIdentifier: OperationIdentifier,
+            description: Description,
+            server: Server);
+
+        #endregion
+    }
+}

--- a/src/SourceCode.Clay.OpenApi/Builders/MediaTypeBuilder.cs
+++ b/src/SourceCode.Clay.OpenApi/Builders/MediaTypeBuilder.cs
@@ -1,0 +1,75 @@
+#region License
+
+// Copyright (c) K2 Workflow (SourceCode Technology Holdings Inc.). All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+#endregion
+
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+
+namespace SourceCode.Clay.OpenApi
+{
+    public class MediaTypeBuilder
+    {
+        #region Properties
+
+        /// <summary>
+        /// Gets or sets the schema defining the type used for the request body.
+        /// </summary>
+        public Referable<Schema> Schema { get; set; }
+
+        /// <summary>
+        /// The examples of the media type.
+        /// </summary>
+        public IDictionary<string, Referable<Example>> Examples { get; }
+
+        /// <summary>
+        /// Gets the map between a property name and its encoding information.
+        /// </summary>
+        public IDictionary<string, PropertyEncoding> Encoding { get; }
+
+        #endregion
+
+        #region Constructors
+
+        /// <summary>
+        /// Creates a new instance of the <see cref="MediaTypeBuilder"/> class.
+        /// </summary>
+        public MediaTypeBuilder()
+        {
+        }
+
+        /// <summary>
+        /// Creates a new instance of the <see cref="MediaTypeBuilder"/> class.
+        /// </summary>
+        /// <param name="value">The <see cref="MediaType"/> to copy values from.</param>
+        public MediaTypeBuilder(MediaType value)
+        {
+            if (ReferenceEquals(value, null)) throw new ArgumentNullException(nameof(value));
+            Schema = value.Schema;
+            Examples = new Dictionary<string, Referable<Example>>(value.Examples);
+            Encoding = new Dictionary<string, PropertyEncoding>(value.Encoding);
+        }
+
+        #endregion
+
+        #region Methods
+
+        public static implicit operator MediaType(MediaTypeBuilder builder) => builder?.Build();
+
+        public static implicit operator MediaTypeBuilder(MediaType value) => ReferenceEquals(value, null) ? null : new MediaTypeBuilder(value);
+
+        /// <summary>
+        /// Creates the <see cref="MediaType"/> from this builder.
+        /// </summary>
+        /// <returns>The <see cref="MediaType"/>.</returns>
+        public MediaType Build() => new MediaType(
+            schema: Schema,
+            examples: new ReadOnlyDictionary<string, Referable<Example>>(Examples),
+            encoding: new ReadOnlyDictionary<string, PropertyEncoding>(Encoding));
+
+        #endregion
+    }
+}

--- a/src/SourceCode.Clay.OpenApi/Builders/OAuth2SecuritySchemeBuilder.cs
+++ b/src/SourceCode.Clay.OpenApi/Builders/OAuth2SecuritySchemeBuilder.cs
@@ -1,0 +1,85 @@
+#region License
+
+// Copyright (c) K2 Workflow (SourceCode Technology Holdings Inc.). All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+#endregion
+
+using System;
+
+namespace SourceCode.Clay.OpenApi
+{
+    /// <summary>
+    /// Defines an OAuth 2 security scheme that can be used by the operations.
+    /// </summary>
+    public class OAuth2SecuritySchemeBuilder : SecuritySchemeBuilder
+    {
+        #region Properties
+
+        /// <summary>
+        /// Gets or sets the configuration for the OAuth Implicit flow.
+        /// </summary>
+        public OAuthFlow ImplicitFlow { get; set; }
+
+        /// <summary>
+        /// Gets or sets the configuration for the OAuth Password flow.
+        /// </summary>
+        public OAuthFlow PasswordFlow { get; set; }
+
+        /// <summary>
+        /// Gets or sets the configuration for the OAuth Credentials flow.
+        /// </summary>
+        public OAuthFlow ClientCredentialsFlow { get; set; }
+
+        /// <summary>
+        /// Gets or sets the configuration for the OAuth Authorization flow.
+        /// </summary>
+        public OAuthFlow AuthorizationCodeFlow { get; set; }
+
+        #endregion
+
+        #region Constructors
+
+        /// <summary>
+        /// Creates a new instance of the <see cref="OAuth2SecuritySchemeBuilder"/> class.
+        /// </summary>
+        public OAuth2SecuritySchemeBuilder()
+        {
+        }
+
+        /// <summary>
+        /// Creates a new instance of the <see cref="OAuth2SecuritySchemeBuilder"/> class.
+        /// </summary>
+        /// <param name="value">The <see cref="OAuth2SecurityScheme"/> to copy values from.</param>
+        public OAuth2SecuritySchemeBuilder(OAuth2SecurityScheme value)
+            : base(value)
+        {
+            if (ReferenceEquals(value, null)) throw new ArgumentNullException(nameof(value));
+            ImplicitFlow = value.ImplicitFlow;
+            PasswordFlow = value.PasswordFlow;
+            ClientCredentialsFlow = value.ClientCredentialsFlow;
+            AuthorizationCodeFlow = value.AuthorizationCodeFlow;
+        }
+
+        #endregion
+
+        #region Methods
+
+        public static implicit operator OAuth2SecurityScheme(OAuth2SecuritySchemeBuilder builder) => builder?.Build();
+
+        public static implicit operator OAuth2SecuritySchemeBuilder(OAuth2SecurityScheme value) => ReferenceEquals(value, null) ? null : new OAuth2SecuritySchemeBuilder(value);
+
+        /// <summary>
+        /// Creates the <see cref="OAuth2SecurityScheme"/> from this builder.
+        /// </summary>
+        /// <returns>The <see cref="OAuth2SecurityScheme"/>.</returns>
+        public OAuth2SecurityScheme Build() => new OAuth2SecurityScheme(
+            description: Description,
+            implicitFlow: ImplicitFlow,
+            passwordFlow: PasswordFlow,
+            clientCredentialsFlow: ClientCredentialsFlow,
+            authorizationCodeFlow: AuthorizationCodeFlow);
+
+        #endregion
+    }
+}

--- a/src/SourceCode.Clay.OpenApi/Builders/OAuthFlowBuilder.cs
+++ b/src/SourceCode.Clay.OpenApi/Builders/OAuthFlowBuilder.cs
@@ -1,0 +1,92 @@
+#region License
+
+// Copyright (c) K2 Workflow (SourceCode Technology Holdings Inc.). All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+#endregion
+
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+
+namespace SourceCode.Clay.OpenApi
+{
+    /// <summary>
+    /// Configuration details for a supported OAuth Flow.
+    /// </summary>
+    public class OAuthFlowBuilder
+    {
+        #region Properties
+
+        /// <summary>
+        /// Gets or sets the authorization URL to be used for this flow.
+        /// </summary>
+        /// <remarks>
+        /// Applies to <see cref="OAuth2SecurityScheme.ImplicitFlow"/> and <see cref="OAuth2SecurityScheme.AuthorizationCodeFlow"/>.
+        /// </remarks>
+        public Uri AuthorizationUrl { get; set; }
+
+        /// <summary>
+        /// Gets or sets the token URL to be used for this flow.
+        /// </summary>
+        /// <remarks>
+        /// Applies to <see cref="OAuth2SecurityScheme.PasswordFlow"/>, <see cref="OAuth2SecurityScheme.ClientCredentialsFlow"/>
+        /// and <see cref="OAuth2SecurityScheme.AuthorizationCodeFlow"/>.
+        /// </remarks>
+        public Uri TokenUrl { get; set; }
+
+        /// <summary>
+        /// Gets or sets the URL to be used for obtaining refresh tokens.
+        /// </summary>
+        public Uri RefreshUrl { get; set; }
+
+        /// <summary>
+        /// Get the available scopes for the OAuth2 security scheme.
+        /// </summary>
+        public IDictionary<String, String> Scopes { get; }
+
+        #endregion
+
+        #region Constructors
+
+        /// <summary>
+        /// Creates a new instance of the <see cref="OAuthFlowBuilder"/> class.
+        /// </summary>
+        public OAuthFlowBuilder()
+        {
+        }
+
+        /// <summary>
+        /// Creates a new instance of the <see cref="OAuthFlowBuilder"/> class.
+        /// </summary>
+        /// <param name="value">The <see cref="OAuthFlow"/> to copy values from.</param>
+        public OAuthFlowBuilder(OAuthFlow value)
+        {
+            if (ReferenceEquals(value, null)) throw new ArgumentNullException(nameof(value));
+            AuthorizationUrl = value.AuthorizationUrl;
+            TokenUrl = value.TokenUrl;
+            RefreshUrl = value.RefreshUrl;
+            Scopes = new Dictionary<String, String>(value.Scopes);
+        }
+
+        #endregion
+
+        #region Methods
+
+        public static implicit operator OAuthFlow(OAuthFlowBuilder builder) => builder?.Build();
+
+        public static implicit operator OAuthFlowBuilder(OAuthFlow value) => ReferenceEquals(value, null) ? null : new OAuthFlowBuilder(value);
+
+        /// <summary>
+        /// Creates the <see cref="OAuthFlow"/> from this builder.
+        /// </summary>
+        /// <returns>The <see cref="OAuthFlow"/>.</returns>
+        public OAuthFlow Build() => new OAuthFlow(
+            authorizationUrl: AuthorizationUrl,
+            tokenUrl: TokenUrl,
+            refreshUrl: RefreshUrl,
+            scopes: new ReadOnlyDictionary<String, String>(Scopes));
+
+        #endregion
+    }
+}

--- a/src/SourceCode.Clay.OpenApi/Builders/OpenIdConnectSecuritySchemeBuilder.cs
+++ b/src/SourceCode.Clay.OpenApi/Builders/OpenIdConnectSecuritySchemeBuilder.cs
@@ -1,0 +1,64 @@
+#region License
+
+// Copyright (c) K2 Workflow (SourceCode Technology Holdings Inc.). All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+#endregion
+
+using System;
+
+namespace SourceCode.Clay.OpenApi
+{
+    /// <summary>
+    /// Defines an API key security scheme that can be used by the operations.
+    /// </summary>
+    public class OpenIdConnectSecuritySchemeBuilder : SecuritySchemeBuilder
+    {
+        #region Properties
+
+        /// <summary>
+        /// Gets the OpenId Connect URL to discover OAuth2 configuration values.
+        /// </summary>
+        public Uri Url { get; set; }
+
+        #endregion
+
+        #region Constructors
+
+        /// <summary>
+        /// Creates a new instance of the <see cref="OpenIdConnectSecuritySchemeBuilder"/> class.
+        /// </summary>
+        public OpenIdConnectSecuritySchemeBuilder()
+        {
+        }
+
+        /// <summary>
+        /// Creates a new instance of the <see cref="OpenIdConnectSecuritySchemeBuilder"/> class.
+        /// </summary>
+        /// <param name="value">The <see cref="OpenIdConnectSecurityScheme"/> to copy values from.</param>
+        public OpenIdConnectSecuritySchemeBuilder(OpenIdConnectSecurityScheme value)
+            : base(value)
+        {
+            if (ReferenceEquals(value, null)) throw new ArgumentNullException(nameof(value));
+            Url = value.Url;
+        }
+
+        #endregion
+
+        #region Methods
+
+        public static implicit operator OpenIdConnectSecurityScheme(OpenIdConnectSecuritySchemeBuilder builder) => builder?.Build();
+
+        public static implicit operator OpenIdConnectSecuritySchemeBuilder(OpenIdConnectSecurityScheme value) => ReferenceEquals(value, null) ? null : new OpenIdConnectSecuritySchemeBuilder(value);
+
+        /// <summary>
+        /// Creates the <see cref="OpenIdConnectSecurityScheme"/> from this builder.
+        /// </summary>
+        /// <returns>The <see cref="OpenIdConnectSecurityScheme"/>.</returns>
+        public OpenIdConnectSecurityScheme Build() => new OpenIdConnectSecurityScheme(
+            description: Description,
+            url: Url);
+
+        #endregion
+    }
+}

--- a/src/SourceCode.Clay.OpenApi/Builders/OperationBuilder.cs
+++ b/src/SourceCode.Clay.OpenApi/Builders/OperationBuilder.cs
@@ -1,0 +1,144 @@
+#region License
+
+// Copyright (c) K2 Workflow (SourceCode Technology Holdings Inc.). All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+#endregion
+
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+
+namespace SourceCode.Clay.OpenApi
+{
+    /// <summary>
+    /// Describes a single API operation on a path.
+    /// </summary>
+    public class OperationBuilder
+    {
+        #region Properties
+
+        /// <summary>
+        /// Gets the list of tags for API documentation control.
+        /// </summary>
+        public IList<string> Tags { get; }
+
+        /// <summary>
+        /// Gets or sets the short summary of what the operation does.
+        /// </summary>
+        public string Summary { get; set; }
+
+        /// <summary>
+        /// Gets or sets the verbose explanation of the operation behavior.
+        /// </summary>
+        /// <remarks>
+        /// CommonMark syntax MAY be used for rich text representation.
+        /// </remarks>
+        public string Description { get; set; }
+
+        /// <summary>
+        /// Gets or sets the additional external documentation for this operation.
+        /// </summary>
+        public ExternalDocumentation ExternalDocumentation { get; set; }
+
+        /// <summary>
+        /// Gets or sets the unique string used to identify the operation.
+        /// </summary>
+        public string OperationIdentifier { get; set; }
+
+        /// <summary>
+        /// Gets the list of parameters that are applicable for this operation.
+        /// </summary>
+        public IDictionary<ParameterKey, Referable<Parameter>> Parameters { get; }
+
+        /// <summary>
+        /// Gets or sets the request body applicable for this operation.
+        /// </summary>
+        public Referable<RequestBody> RequestBody { get; set; }
+
+        /// <summary>
+        /// Gets the list of possible responses as they are returned from executing this operation.
+        /// </summary>
+        public IDictionary<ResponseKey, Referable<Response>> Responses { get; }
+
+        /// <summary>
+        /// Gets the map of possible out-of band callbacks related to the parent operation.
+        /// </summary>
+        public IDictionary<string, Referable<Callback>> Callbacks { get; }
+
+        /// <summary>
+        /// Gets or sets the flags that indicate what options are set on the operation.
+        /// </summary>
+        public OperationOptions Options { get; set; }
+
+        /// <summary>
+        /// Gets the declaration of which security mechanisms can be used for this operation.
+        /// </summary>
+        public IList<SecurityScheme> Security { get; }
+
+        /// <summary>
+        /// Gets the alternative server list to service this operation.
+        /// </summary>
+        public IList<Server> Servers { get; }
+
+        #endregion
+
+        #region Constructors
+
+        /// <summary>
+        /// Creates a new instance of the <see cref="OperationBuilder"/> class.
+        /// </summary>
+        public OperationBuilder()
+        {
+        }
+
+        /// <summary>
+        /// Creates a new instance of the <see cref="OperationBuilder"/> class.
+        /// </summary>
+        /// <param name="value">The <see cref="Operation"/> to copy values from.</param>
+        public OperationBuilder(Operation value)
+        {
+            if (ReferenceEquals(value, null)) throw new ArgumentNullException(nameof(value));
+            Tags = new List<string>(value.Tags);
+            Summary = value.Summary;
+            Description = value.Description;
+            ExternalDocumentation = value.ExternalDocumentation;
+            OperationIdentifier = value.OperationIdentifier;
+            Parameters = new Dictionary<ParameterKey, Referable<Parameter>>(value.Parameters);
+            RequestBody = value.RequestBody;
+            Responses = new Dictionary<ResponseKey, Referable<Response>>(value.Responses);
+            Callbacks = new Dictionary<string, Referable<Callback>>(value.Callbacks);
+            Options = value.Options;
+            Security = new List<SecurityScheme>(value.Security);
+            Servers = new List<Server>(value.Servers);
+        }
+
+        #endregion
+
+        #region Methods
+
+        public static implicit operator Operation(OperationBuilder builder) => builder?.Build();
+
+        public static implicit operator OperationBuilder(Operation value) => ReferenceEquals(value, null) ? null : new OperationBuilder(value);
+
+        /// <summary>
+        /// Creates the <see cref="Link"/> from this builder.
+        /// </summary>
+        /// <returns>The <see cref="Link"/>.</returns>
+        public Operation Build() => new Operation(
+            tags: new ReadOnlyCollection<string>(Tags),
+            summary: Summary,
+            description: Description,
+            externalDocumentation: ExternalDocumentation,
+            operationIdentifier: OperationIdentifier,
+            parameters: new ReadOnlyDictionary<ParameterKey, Referable<Parameter>>(Parameters),
+            requestBody: RequestBody,
+            responses: new ReadOnlyDictionary<ResponseKey, Referable<Response>>(Responses),
+            callbacks: new ReadOnlyDictionary<string, Referable<Callback>>(Callbacks),
+            options: Options,
+            security: new ReadOnlyCollection<SecurityScheme>(Security),
+            servers: new ReadOnlyCollection<Server>(Servers));
+
+        #endregion
+    }
+}

--- a/src/SourceCode.Clay.OpenApi/Builders/ParameterBodyBuilder.cs
+++ b/src/SourceCode.Clay.OpenApi/Builders/ParameterBodyBuilder.cs
@@ -1,0 +1,103 @@
+#region License
+
+// Copyright (c) K2 Workflow (SourceCode Technology Holdings Inc.). All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+#endregion
+
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Net.Mime;
+
+namespace SourceCode.Clay.OpenApi
+{
+    /// <summary>
+    /// Describes a single operation parameter.
+    /// </summary>
+    public class ParameterBodyBuilder
+    {
+        #region Properties
+
+        /// <summary>
+        /// Gets or sets the brief description of the parameter.
+        /// </summary>
+        /// <remarks>
+        /// CommonMark syntax MAY be used for rich text representation.
+        /// </remarks>
+        public String Description { get; set; }
+
+        /// <summary>
+        /// Gets or sets the parameter options.
+        /// </summary>
+        public ParameterOptions Options { get; set; }
+
+        /// <summary>
+        /// Gets or sets the value which indicates how the parameter value will be serialized depending on the type of the parameter value.
+        /// </summary>
+        public ParameterStyle Style { get; set; }
+
+        /// <summary>
+        /// Gets or sets the schema defining the type used for the parameter.
+        /// </summary>
+        public Referable<Schema> Schema { get; set; }
+
+        /// <summary>
+        /// Gets the list of examples of the parameter.
+        /// </summary>
+        public IDictionary<ContentType, Referable<Example>> Examples { get; }
+
+        /// <summary>
+        /// Gets the map containing the representations for the parameter.
+        /// </summary>
+        public IDictionary<ContentType, MediaType> Content { get; }
+
+        #endregion
+
+        #region Constructors
+
+        /// <summary>
+        /// Creates a new instance of the <see cref="ParameterBodyBuilder"/> class.
+        /// </summary>
+        public ParameterBodyBuilder()
+        {
+        }
+
+        /// <summary>
+        /// Creates a new instance of the <see cref="ParameterBodyBuilder"/> class.
+        /// </summary>
+        /// <param name="value">The <see cref="ParameterBody"/> to copy values from.</param>
+        public ParameterBodyBuilder(ParameterBody value)
+        {
+            if (ReferenceEquals(value, null)) throw new ArgumentNullException(nameof(value));
+            Description = value.Description;
+            Options = value.Options;
+            Style = value.Style;
+            Schema = value.Schema;
+            Examples = new Dictionary<ContentType, Referable<Example>>(value.Examples);
+            Content = new Dictionary<ContentType, MediaType>(value.Content);
+        }
+
+        #endregion
+
+        #region Methods
+
+        public static implicit operator ParameterBody(ParameterBodyBuilder builder) => builder?.Build();
+
+        public static implicit operator ParameterBodyBuilder(ParameterBody value) => ReferenceEquals(value, null) ? null : new ParameterBodyBuilder(value);
+
+        /// <summary>
+        /// Creates the <see cref="ParameterBody"/> from this builder.
+        /// </summary>
+        /// <returns>The <see cref="ParameterBody"/>.</returns>
+        public ParameterBody Build() => new ParameterBody(
+            description: Description,
+            options: Options,
+            style: Style,
+            schema: Schema,
+            examples: new ReadOnlyDictionary<ContentType, Referable<Example>>(Examples),
+            content: new ReadOnlyDictionary<ContentType, MediaType>(Content));
+
+        #endregion
+    }
+}

--- a/src/SourceCode.Clay.OpenApi/Builders/ParameterBuilder.cs
+++ b/src/SourceCode.Clay.OpenApi/Builders/ParameterBuilder.cs
@@ -1,0 +1,76 @@
+#region License
+
+// Copyright (c) K2 Workflow (SourceCode Technology Holdings Inc.). All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+#endregion
+
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Net.Mime;
+
+namespace SourceCode.Clay.OpenApi
+{
+    public class ParameterBuilder : ParameterBodyBuilder
+    {
+        #region Properties
+
+        /// <summary>
+        /// Gets or sets the name of the parameter.
+        /// </summary>
+        public string Name { get; set; }
+
+        /// <summary>
+        /// Gets or sets the location of the parameter.
+        /// </summary>
+        public ParameterLocation Location { get; set; }
+
+        #endregion
+
+        #region Constructors
+
+        /// <summary>
+        /// Creates a new instance of the <see cref="ParameterBuilder"/> class.
+        /// </summary>
+        public ParameterBuilder()
+        {
+        }
+
+        /// <summary>
+        /// Creates a new instance of the <see cref="ParameterBuilder"/> class.
+        /// </summary>
+        /// <param name="value">The <see cref="Parameter"/> to copy values from.</param>
+        public ParameterBuilder(Parameter value)
+            : base(value)
+        {
+            if (ReferenceEquals(value, null)) throw new ArgumentNullException(nameof(value));
+            Name = value.Name;
+            Location = value.Location;
+        }
+
+        #endregion
+
+        #region Methods
+
+        public static implicit operator Parameter(ParameterBuilder builder) => builder?.Build();
+
+        public static implicit operator ParameterBuilder(Parameter value) => ReferenceEquals(value, null) ? null : new ParameterBuilder(value);
+
+        /// <summary>
+        /// Creates the <see cref="Parameter"/> from this builder.
+        /// </summary>
+        /// <returns>The <see cref="Parameter"/>.</returns>
+        public new Parameter Build() => new Parameter(
+            name: Name,
+            location: Location,
+            description: Description,
+            options: Options,
+            style: Style,
+            schema: Schema,
+            examples: new ReadOnlyDictionary<ContentType, Referable<Example>>(Examples),
+            content: new ReadOnlyDictionary<ContentType, MediaType>(Content));
+
+        #endregion
+    }
+}

--- a/src/SourceCode.Clay.OpenApi/Builders/PathBuilder.cs
+++ b/src/SourceCode.Clay.OpenApi/Builders/PathBuilder.cs
@@ -1,0 +1,146 @@
+#region License
+
+// Copyright (c) K2 Workflow (SourceCode Technology Holdings Inc.). All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+#endregion
+
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+
+namespace SourceCode.Clay.OpenApi
+{
+    /// <summary>
+    /// Describes the operations available on a single path. A Path Item MAY be empty, due to ACL constraints.
+    /// The path itself is still exposed to the documentation viewer but they will not know which operations
+    /// and parameters are available.
+    /// </summary>
+    public class PathBuilder
+    {
+        #region Properties
+
+        /// <summary>
+        /// Gets or sets the string summary intended to apply to all operations in this path.
+        /// </summary>
+        public string Summary { get; set; }
+
+        /// <summary>
+        /// Gets or sets the string description intended to apply to all operations in this path.
+        /// </summary>
+        /// <remarks>
+        /// CommonMark syntax MAY be used for rich text representation.
+        /// </remarks>
+        public string Description { get; set; }
+
+        /// <summary>
+        /// Gets or sets the definition of a GET operation on this path.
+        /// </summary>
+        public Operation Get { get; set; }
+
+        /// <summary>
+        /// Gets or sets the definition of a PUT operation on this path.
+        /// </summary>
+        public Operation Put { get; set; }
+
+        /// <summary>
+        /// Gets or sets the definition of a POST operation on this path.
+        /// </summary>
+        public Operation Post { get; set; }
+
+        /// <summary>
+        /// Gets or sets the definition of a DELETE operation on this path.
+        /// </summary>
+        public Operation Delete { get; set; }
+
+        /// <summary>
+        /// Gets or sets the definition of a OPTIONS operation on this path.
+        /// </summary>
+        public Operation Options { get; set; }
+
+        /// <summary>
+        /// Gets or sets the definition of a HEAD operation on this path.
+        /// </summary>
+        public Operation Head { get; set; }
+
+        /// <summary>
+        /// Gets or sets the definition of a PATCH operation on this path.
+        /// </summary>
+        public Operation Patch { get; set; }
+
+        /// <summary>
+        /// Gets or sets the definition of a TRACE operation on this path.
+        /// </summary>
+        public Operation Trace { get; set; }
+
+        /// <summary>
+        /// Gets the alternative server array to service all operations in this path.
+        /// </summary>
+        public IList<Server> Servers { get; }
+
+        /// <summary>
+        /// Gets the list of parameters that are applicable for all the operations described under this path.
+        /// </summary>
+        public IDictionary<ParameterKey, Referable<ParameterBody>> Parameters { get; }
+
+        #endregion
+
+        #region Constructors
+
+        /// <summary>
+        /// Creates a new instance of the <see cref="PathBuilder"/> class.
+        /// </summary>
+        public PathBuilder()
+        {
+        }
+
+        /// <summary>
+        /// Creates a new instance of the <see cref="PathBuilder"/> class.
+        /// </summary>
+        /// <param name="value">The <see cref="Path"/> to copy values from.</param>
+        public PathBuilder(Path value)
+        {
+            if (ReferenceEquals(value, null)) throw new ArgumentNullException(nameof(value));
+            Summary = value.Summary;
+            Description = value.Description;
+            Get = value.Get;
+            Put = value.Put;
+            Post = value.Post;
+            Delete = value.Delete;
+            Options = value.Options;
+            Head = value.Head;
+            Patch = value.Patch;
+            Trace = value.Trace;
+            Servers = new List<Server>(value.Servers);
+            Parameters = new Dictionary<ParameterKey, Referable<ParameterBody>>(value.Parameters);
+        }
+
+        #endregion
+
+        #region Methods
+
+        public static implicit operator Path(PathBuilder builder) => builder?.Build();
+
+        public static implicit operator PathBuilder(Path value) => ReferenceEquals(value, null) ? null : new PathBuilder(value);
+
+        /// <summary>
+        /// Creates the <see cref="Path"/> from this builder.
+        /// </summary>
+        /// <returns>The <see cref="Path"/>.</returns>
+        public Path Build() => new Path(
+            summary: Summary,
+            description: Description,
+            get: Get,
+            put: Put,
+            post: Post,
+            delete: Delete,
+            options: Options,
+            head: Head,
+            patch: Patch,
+            trace: Trace,
+            servers: new ReadOnlyCollection<Server>(Servers),
+            parameters: new ReadOnlyDictionary<ParameterKey, Referable<ParameterBody>>(Parameters));
+
+        #endregion
+    }
+}

--- a/src/SourceCode.Clay.OpenApi/Builders/PropertyEncodingBuilder.cs
+++ b/src/SourceCode.Clay.OpenApi/Builders/PropertyEncodingBuilder.cs
@@ -1,0 +1,86 @@
+#region License
+
+// Copyright (c) K2 Workflow (SourceCode Technology Holdings Inc.). All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+#endregion
+
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Net.Mime;
+
+namespace SourceCode.Clay.OpenApi
+{
+    /// <summary>
+    /// A single encoding definition applied to a single schema property.
+    /// </summary>
+    public class PropertyEncodingBuilder
+    {
+        #region Properties
+
+        /// <summary>
+        /// Gets or sets the Content-Type for encoding a specific property.
+        /// </summary>
+        public ContentType ContentType { get; set; }
+
+        /// <summary>
+        /// Gets the list of headers.
+        /// </summary>
+        public IDictionary<string, Referable<ParameterBody>> Headers { get; }
+
+        /// <summary>
+        /// Gets or sets the value describing how the property value will be serialized depending on its type.
+        /// </summary>
+        public ParameterStyle Style { get; set; }
+
+        /// <summary>
+        /// Gets or sets the property options.
+        /// </summary>
+        public PropertyEncodingOptions Options { get; set; }
+
+        #endregion
+
+        #region Constructors
+
+        /// <summary>
+        /// Creates a new instance of the <see cref="PropertyEncodingBuilder"/> class.
+        /// </summary>
+        public PropertyEncodingBuilder()
+        {
+        }
+
+        /// <summary>
+        /// Creates a new instance of the <see cref="PropertyEncodingBuilder"/> class.
+        /// </summary>
+        /// <param name="value">The <see cref="PropertyEncoding"/> to copy values from.</param>
+        public PropertyEncodingBuilder(PropertyEncoding value)
+        {
+            if (ReferenceEquals(value, null)) throw new ArgumentNullException(nameof(value));
+            ContentType = value.ContentType;
+            Headers = new Dictionary<String, Referable<ParameterBody>>(value.Headers);
+            Style = value.Style;
+            Options = value.Options;
+        }
+
+        #endregion
+
+        #region Methods
+
+        public static implicit operator PropertyEncoding(PropertyEncodingBuilder builder) => builder?.Build();
+
+        public static implicit operator PropertyEncodingBuilder(PropertyEncoding value) => ReferenceEquals(value, null) ? null : new PropertyEncodingBuilder(value);
+
+        /// <summary>
+        /// Creates the <see cref="PropertyEncoding"/> from this builder.
+        /// </summary>
+        /// <returns>The <see cref="PropertyEncoding"/>.</returns>
+        public PropertyEncoding Build() => new PropertyEncoding(
+            contentType: ContentType,
+            headers: new ReadOnlyDictionary<String, Referable<ParameterBody>>(Headers),
+            style: Style,
+            options: Options);
+
+        #endregion
+    }
+}

--- a/src/SourceCode.Clay.OpenApi/Builders/RequestBodyBuilder.cs
+++ b/src/SourceCode.Clay.OpenApi/Builders/RequestBodyBuilder.cs
@@ -1,0 +1,82 @@
+#region License
+
+// Copyright (c) K2 Workflow (SourceCode Technology Holdings Inc.). All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+#endregion
+
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Net.Mime;
+
+namespace SourceCode.Clay.OpenApi
+{
+    /// <summary>
+    /// Describes a single request body.
+    /// </summary>
+    public class RequestBodyBuilder
+    {
+        #region Properties
+
+        /// <summary>
+        /// Gets or sets the brief description of the request body.
+        /// </summary>
+        /// <remarks>
+        /// CommonMark syntax MAY be used for rich text representation.
+        /// </remarks>
+        public String Description { get; set; }
+
+        /// <summary>
+        /// Gets or sets the content of the request body.
+        /// </summary>
+        public IDictionary<ContentType, MediaType> Content { get; }
+
+        /// <summary>
+        /// Gets or sets the request body options.
+        /// </summary>
+        public RequestBodyOptions Options { get; set; }
+
+        #endregion
+
+        #region Constructors
+
+        /// <summary>
+        /// Creates a new instance of the <see cref="RequestBodyBuilder"/> class.
+        /// </summary>
+        public RequestBodyBuilder()
+        {
+        }
+
+        /// <summary>
+        /// Creates a new instance of the <see cref="RequestBodyBuilder"/> class.
+        /// </summary>
+        /// <param name="value">The <see cref="RequestBody"/> to copy values from.</param>
+        public RequestBodyBuilder(RequestBody value)
+        {
+            if (ReferenceEquals(value, null)) throw new ArgumentNullException(nameof(value));
+            Description = value.Description;
+            Content = new Dictionary<ContentType, MediaType>(value.Content);
+            Options = value.Options;
+        }
+
+        #endregion
+
+        #region Methods
+
+        public static implicit operator RequestBody(RequestBodyBuilder builder) => builder?.Build();
+
+        public static implicit operator RequestBodyBuilder(RequestBody value) => ReferenceEquals(value, null) ? null : new RequestBodyBuilder(value);
+
+        /// <summary>
+        /// Creates the <see cref="RequestBody"/> from this builder.
+        /// </summary>
+        /// <returns>The <see cref="RequestBody"/>.</returns>
+        public RequestBody Build() => new RequestBody(
+            description: Description,
+            content: new ReadOnlyDictionary<ContentType, MediaType>(Content),
+            options: Options);
+
+        #endregion
+    }
+}

--- a/src/SourceCode.Clay.OpenApi/Builders/ResponseBuilder.cs
+++ b/src/SourceCode.Clay.OpenApi/Builders/ResponseBuilder.cs
@@ -1,0 +1,86 @@
+#region License
+
+// Copyright (c) K2 Workflow (SourceCode Technology Holdings Inc.). All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+#endregion
+
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Net.Mime;
+
+namespace SourceCode.Clay.OpenApi
+{
+    /// <summary>
+    /// Describes a single response from an API Operation.
+    /// </summary>
+    public class ResponseBuilder
+    {
+        #region Properties
+
+        /// <summary>
+        /// Gets or sets the short description of the response.
+        /// </summary>
+        public string Description { get; set; }
+
+        /// <summary>
+        /// Gets the map of headers to their definition.
+        /// </summary>
+        public IDictionary<string, Referable<ParameterBody>> Headers { get; }
+
+        /// <summary>
+        /// Gets the map containing descriptions of potential response payloads.
+        /// </summary>
+        public IDictionary<ContentType, MediaType> Content { get; }
+
+        /// <summary>
+        /// Gets the map of operations links that can be followed from the response.
+        /// </summary>
+        public IDictionary<string, Referable<Link>> Links { get; }
+
+        #endregion
+
+        #region Constructors
+
+        /// <summary>
+        /// Creates a new instance of the <see cref="ResponseBuilder"/> class.
+        /// </summary>
+        public ResponseBuilder()
+        {
+        }
+
+        /// <summary>
+        /// Creates a new instance of the <see cref="ResponseBuilder"/> class.
+        /// </summary>
+        /// <param name="value">The <see cref="Response"/> to copy values from.</param>
+        public ResponseBuilder(Response value)
+        {
+            if (ReferenceEquals(value, null)) throw new ArgumentNullException(nameof(value));
+            Description = value.Description;
+            Headers = new Dictionary<string, Referable<ParameterBody>>(value.Headers);
+            Content = new Dictionary<ContentType, MediaType>(value.Content);
+            Links = new Dictionary<string, Referable<Link>>(value.Links);
+        }
+
+        #endregion
+
+        #region Methods
+
+        public static implicit operator Response(ResponseBuilder builder) => builder?.Build();
+
+        public static implicit operator ResponseBuilder(Response value) => ReferenceEquals(value, null) ? null : new ResponseBuilder(value);
+
+        /// <summary>
+        /// Creates the <see cref="Link"/> from this builder.
+        /// </summary>
+        /// <returns>The <see cref="Link"/>.</returns>
+        public Response Build() => new Response(
+            description: Description,
+            headers: new ReadOnlyDictionary<string, Referable<ParameterBody>>(Headers),
+            content: new ReadOnlyDictionary<ContentType, MediaType>(Content),
+            links: new ReadOnlyDictionary<string, Referable<Link>>(Links));
+
+        #endregion
+    }
+}

--- a/src/SourceCode.Clay.OpenApi/Builders/SchemaBuilder.cs
+++ b/src/SourceCode.Clay.OpenApi/Builders/SchemaBuilder.cs
@@ -1,0 +1,190 @@
+#region License
+
+// Copyright (c) K2 Workflow (SourceCode Technology Holdings Inc.). All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+#endregion
+
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+
+namespace SourceCode.Clay.OpenApi
+{
+    public class SchemaBuilder
+    {
+        #region Properties
+
+        /// <summary>
+        /// Gets or sets the general type of the schema.
+        /// </summary>
+        public SchemaType Type { get; set; }
+
+        /// <summary>
+        /// Gets or sets the title of the schema.
+        /// </summary>
+        public string Title { get; set; }
+
+        /// <summary>
+        /// Gets or sets the format of the JSON schema.
+        /// </summary>
+        /// <remarks>
+        /// This conforms to the <a href="https://swagger.io/specification/#data-types-13">Open API specification</a>.
+        /// </remarks>
+        public string Format { get; set; }
+
+        /// <summary>
+        /// Gets or sets the schema description.
+        /// </summary>
+        public string Description { get; set; }
+
+        /// <summary>
+        /// Gets or sets the number range validation details.
+        /// </summary>
+        public NumberRange NumberRange { get; set; }
+
+        /// <summary>
+        /// Gets or sets the item count validation details.
+        /// </summary>
+        public CountRange ItemsRange { get; set; }
+
+        /// <summary>
+        /// Gets or sets the length validation details.
+        /// </summary>
+        public CountRange LengthRange { get; set; }
+
+        /// <summary>
+        /// Gets or sets the property count validation details.
+        /// </summary>
+        public CountRange PropertiesRange { get; set; }
+
+        /// <summary>
+        /// Gets or sets the schema options.
+        /// </summary>
+        public SchemaOptions Options { get; set; }
+
+        /// <summary>
+        /// Gets or sets the string validation pattern.
+        /// </summary>
+        public string Pattern { get; set; }
+
+        /// <summary>
+        /// Gets the valid enum values.
+        /// </summary>
+        public IList<ScalarValue> Enum { get; }
+
+        /// <summary>
+        /// Gets the list of schemas that this schema must conform to.
+        /// </summary>
+        public IList<Referable<Schema>> AllOf { get; }
+
+        /// <summary>
+        /// Gets the list of schemas that, from which exactly one, this schema must conform to.
+        /// </summary>
+        public IList<Referable<Schema>> OneOf { get; }
+
+        /// <summary>
+        /// Gets the list of schemas that, from which one or more, this schema must conform to.
+        /// </summary>
+        public IList<Referable<Schema>> AnyOf { get; }
+
+        /// <summary>
+        /// Gets the list of schemas that this schema must not conform to.
+        /// </summary>
+        public IList<Referable<Schema>> Not { get; }
+
+        /// <summary>
+        /// Gets or sets the list of schemas that represent the array items that this schema must contain.
+        /// </summary>
+        public Referable<Schema> Items { get; set; }
+
+        /// <summary>
+        /// Gets the list of valid properties.
+        /// </summary>
+        public IDictionary<string, Referable<Schema>> Properties { get; }
+
+        /// <summary>
+        /// Gets the list of valid properties for children.
+        /// </summary>
+        public IDictionary<string, Referable<Schema>> AdditionalProperties { get; }
+
+        /// <summary>
+        /// Gets or sets the external documentation.
+        /// </summary>
+        public ExternalDocumentation ExternalDocumentation { get; set; }
+
+        #endregion
+
+        #region Constructors
+
+        /// <summary>
+        /// Creates a new instance of the <see cref="SchemaBuilder"/> class.
+        /// </summary>
+        public SchemaBuilder()
+        {
+        }
+
+        /// <summary>
+        /// Creates a new instance of the <see cref="SchemaBuilder"/> class.
+        /// </summary>
+        /// <param name="value">The <see cref="Schema"/> to copy values from.</param>
+        public SchemaBuilder(Schema value)
+        {
+            if (ReferenceEquals(value, null)) throw new ArgumentNullException(nameof(value));
+            Type = value.Type;
+            Format = value.Format;
+            Title = value.Title;
+            Description = value.Description;
+            NumberRange = value.NumberRange;
+            ItemsRange = value.ItemsRange;
+            LengthRange = value.LengthRange;
+            PropertiesRange = value.PropertiesRange;
+            Options = value.Options;
+            Pattern = value.Pattern;
+            Enum = new List<ScalarValue>(value.Enum);
+            AllOf = new List<Referable<Schema>>(value.AllOf);
+            OneOf = new List<Referable<Schema>>(value.OneOf);
+            AnyOf = new List<Referable<Schema>>(value.AnyOf);
+            Not = new List<Referable<Schema>>(value.Not);
+            Items = value.Items;
+            Properties = new Dictionary<string, Referable<Schema>>(value.Properties);
+            AdditionalProperties = new Dictionary<string, Referable<Schema>>(value.AdditionalProperties);
+            ExternalDocumentation = value.ExternalDocumentation;
+        }
+
+        #endregion
+
+        #region Methods
+
+        public static implicit operator Schema(SchemaBuilder builder) => builder?.Build();
+
+        public static implicit operator SchemaBuilder(Schema value) => ReferenceEquals(value, null) ? null : new SchemaBuilder(value);
+
+        /// <summary>
+        /// Creates the <see cref="Schema"/> from this builder.
+        /// </summary>
+        /// <returns>The <see cref="Schema"/>.</returns>
+        public Schema Build() => new Schema(
+            type: Type,
+            format: Format,
+            title: Title,
+            description: Description,
+            numberRange: NumberRange,
+            itemsRange: ItemsRange,
+            lengthRange: LengthRange,
+            propertiesRange: PropertiesRange,
+            options: Options,
+            pattern: Pattern,
+            @enum: new ReadOnlyCollection<ScalarValue>(Enum),
+            allOf: new ReadOnlyCollection<Referable<Schema>>(AllOf),
+            oneOf: new ReadOnlyCollection<Referable<Schema>>(OneOf),
+            anyOf: new ReadOnlyCollection<Referable<Schema>>(AnyOf),
+            not: new ReadOnlyCollection<Referable<Schema>>(Not),
+            items: Items,
+            properties: new ReadOnlyDictionary<string, Referable<Schema>>(Properties),
+            additionalProperties: new ReadOnlyDictionary<string, Referable<Schema>>(AdditionalProperties),
+            externalDocumentation: ExternalDocumentation);
+
+        #endregion
+    }
+}

--- a/src/SourceCode.Clay.OpenApi/Builders/SecuritySchemeBuilder.cs
+++ b/src/SourceCode.Clay.OpenApi/Builders/SecuritySchemeBuilder.cs
@@ -1,0 +1,50 @@
+#region License
+
+// Copyright (c) K2 Workflow (SourceCode Technology Holdings Inc.). All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+#endregion
+
+using System;
+
+namespace SourceCode.Clay.OpenApi
+{
+    /// <summary>
+    /// Defines a security scheme that can be used by the operations.
+    /// </summary>
+    public abstract class SecuritySchemeBuilder
+    {
+        #region Properties
+
+        /// <summary>
+        /// Gets or sets the short description for security scheme.
+        /// </summary>
+        /// <remarks>
+        /// CommonMark syntax MAY be used for rich text representation.
+        /// </remarks>
+        public string Description { get; }
+
+        #endregion
+
+        #region Constructors
+
+        /// <summary>
+        /// Creates a new instance of the <see cref="SecuritySchemeBuilder"/> class.
+        /// </summary>
+        protected SecuritySchemeBuilder()
+        {
+        }
+
+        /// <summary>
+        /// Creates a new instance of the <see cref="SecuritySchemeBuilder"/> class.
+        /// </summary>
+        /// <param name="value">The <see cref="SecurityScheme"/> to copy values from.</param>
+        protected SecuritySchemeBuilder(SecurityScheme value)
+        {
+            if (ReferenceEquals(value, null)) throw new ArgumentNullException(nameof(value));
+            Description = value.Description;
+        }
+
+        #endregion
+    }
+}

--- a/src/SourceCode.Clay.OpenApi/Builders/ServerBuilder.cs
+++ b/src/SourceCode.Clay.OpenApi/Builders/ServerBuilder.cs
@@ -1,0 +1,81 @@
+#region License
+
+// Copyright (c) K2 Workflow (SourceCode Technology Holdings Inc.). All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+#endregion
+
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+
+namespace SourceCode.Clay.OpenApi
+{
+    /// <summary>
+    /// An object representing a Server.
+    /// </summary>
+    public class ServerBuilder
+    {
+        #region Properties
+
+        /// <summary>
+        /// Gets or sets the URL to the target host.
+        /// </summary>
+        public Uri Url { get; set; }
+
+        /// <summary>
+        /// Gets or sets the optional string describing the host designated by the URL.
+        /// </summary>
+        /// <remarks>
+        /// CommonMark syntax MAY be used for rich text representation.
+        /// </remarks>
+        public string Description { get; set; }
+
+        /// <summary>
+        /// Gets the map between a variable name and its value.
+        /// </summary>
+        public IDictionary<String, ServerVariable> Variables { get; }
+
+        #endregion
+
+        #region Constructors
+
+        /// <summary>
+        /// Creates a new instance of the <see cref="ServerBuilder"/> class.
+        /// </summary>
+        public ServerBuilder()
+        {
+        }
+
+        /// <summary>
+        /// Creates a new instance of the <see cref="ServerBuilder"/> class.
+        /// </summary>
+        /// <param name="value">The <see cref="Server"/> to copy values from.</param>
+        public ServerBuilder(Server value)
+        {
+            if (ReferenceEquals(value, null)) throw new ArgumentNullException(nameof(value));
+            Url = value.Url;
+            Description = value.Description;
+            Variables = new Dictionary<String, ServerVariable>(value.Variables);
+        }
+
+        #endregion
+
+        #region Methods
+
+        public static implicit operator Server(ServerBuilder builder) => builder?.Build();
+
+        public static implicit operator ServerBuilder(Server value) => ReferenceEquals(value, null) ? null : new ServerBuilder(value);
+
+        /// <summary>
+        /// Creates the <see cref="Server"/> from this builder.
+        /// </summary>
+        /// <returns>The <see cref="Server"/>.</returns>
+        public Server Build() => new Server(
+            url: Url,
+            description: Description,
+            variables: new ReadOnlyDictionary<String, ServerVariable>(Variables));
+
+        #endregion
+    }
+}

--- a/src/SourceCode.Clay.OpenApi/Builders/ServerVariableBuilder.cs
+++ b/src/SourceCode.Clay.OpenApi/Builders/ServerVariableBuilder.cs
@@ -1,0 +1,81 @@
+#region License
+
+// Copyright (c) K2 Workflow (SourceCode Technology Holdings Inc.). All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+#endregion
+
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+
+namespace SourceCode.Clay.OpenApi
+{
+    /// <summary>
+    /// An object representing a Server Variable for server URL template substitution.
+    /// </summary>
+    public class ServerVariableBuilder
+    {
+        #region Properties
+
+        /// <summary>
+        /// Gets the enumeration of string values to be used if the substitution options are from a limited set.
+        /// </summary>
+        public IList<string> Enum { get; }
+
+        /// <summary>
+        /// Gets or sets the default value to use for substitution, and to send, if an alternate value is not supplied.
+        /// </summary>
+        public string Default { get; set; }
+
+        /// <summary>
+        /// Gets or sets the description for the server variable.
+        /// </summary>
+        /// <remarks>
+        /// CommonMark syntax MAY be used for rich text representation.
+        /// </remarks>
+        public string Description { get; set; }
+
+        #endregion
+
+        #region Constructors
+
+        /// <summary>
+        /// Creates a new instance of the <see cref="ServerVariableBuilder"/> class.
+        /// </summary>
+        public ServerVariableBuilder()
+        {
+        }
+
+        /// <summary>
+        /// Creates a new instance of the <see cref="ServerVariableBuilder"/> class.
+        /// </summary>
+        /// <param name="value">The <see cref="ServerVariable"/> to copy values from.</param>
+        public ServerVariableBuilder(ServerVariable value)
+        {
+            if (ReferenceEquals(value, null)) throw new ArgumentNullException(nameof(value));
+            Enum = new List<string>(value.Enum);
+            Default = value.Default;
+            Description = value.Description;
+        }
+
+        #endregion
+
+        #region Methods
+
+        public static implicit operator ServerVariable(ServerVariableBuilder builder) => builder?.Build();
+
+        public static implicit operator ServerVariableBuilder(ServerVariable value) => ReferenceEquals(value, null) ? null : new ServerVariableBuilder(value);
+
+        /// <summary>
+        /// Creates the <see cref="ServerVariable"/> from this builder.
+        /// </summary>
+        /// <returns>The <see cref="ServerVariable"/>.</returns>
+        public ServerVariable Build() => new ServerVariable(
+            @enum: new ReadOnlyCollection<String>(Enum),
+            @default: Default,
+            description: Description);
+
+        #endregion
+    }
+}

--- a/src/SourceCode.Clay.OpenApi/Builders/TagBuilder.cs
+++ b/src/SourceCode.Clay.OpenApi/Builders/TagBuilder.cs
@@ -1,0 +1,76 @@
+#region License
+
+// Copyright (c) K2 Workflow (SourceCode Technology Holdings Inc.). All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+#endregion
+
+using System;
+
+namespace SourceCode.Clay.OpenApi
+{
+    /// <summary>
+    /// Adds metadata to a single tag that is used by <see cref="Operation"/>.
+    /// </summary>
+    public class TagBuilder
+    {
+        #region Properties
+
+        /// <summary>
+        /// Gets or sets the name of the tag.
+        /// </summary>
+        public string Name { get; set; }
+
+        /// <summary>
+        /// Gets or sets the short description for the tag.
+        /// </summary>
+        public string Description { get; set; }
+
+        /// <summary>
+        /// Gets or sets the additional external documentation for the tag.
+        /// </summary>
+        public ExternalDocumentation ExternalDocumentation { get; set; }
+
+        #endregion
+
+        #region Constructors
+
+        /// <summary>
+        /// Creates a new instance of the <see cref="TagBuilder"/> class.
+        /// </summary>
+        public TagBuilder()
+        {
+        }
+
+        /// <summary>
+        /// Creates a new instance of the <see cref="TagBuilder"/> class.
+        /// </summary>
+        /// <param name="value">The <see cref="Tag"/> to copy values from.</param>
+        public TagBuilder(Tag value)
+        {
+            if (ReferenceEquals(value, null)) throw new ArgumentNullException(nameof(value));
+            Name = value.Name;
+            Description = value.Description;
+            ExternalDocumentation = value.ExternalDocumentation;
+        }
+
+        #endregion
+
+        #region Methods
+
+        public static implicit operator Tag(TagBuilder builder) => builder?.Build();
+
+        public static implicit operator TagBuilder(Tag value) => ReferenceEquals(value, null) ? null : new TagBuilder(value);
+
+        /// <summary>
+        /// Creates the <see cref="Tag"/> from this builder.
+        /// </summary>
+        /// <returns>The <see cref="Tag"/>.</returns>
+        public Tag Build() => new Tag(
+            name: Name,
+            description: Description,
+            externalDocumentation: ExternalDocumentation);
+
+        #endregion
+    }
+}

--- a/src/SourceCode.Clay.OpenApi/Document.cs
+++ b/src/SourceCode.Clay.OpenApi/Document.cs
@@ -56,7 +56,7 @@ namespace SourceCode.Clay.OpenApi
         /// <summary>
         /// Gets the external documentation.
         /// </summary>
-        public ExternalDocumentation ExternalDocs { get; }
+        public ExternalDocumentation ExternalDocumentation { get; }
 
         #endregion
 
@@ -72,7 +72,7 @@ namespace SourceCode.Clay.OpenApi
         /// <param name="components">The list that holds various schemas for the specification.</param>
         /// <param name="security">The declaration of which security mechanisms can be used across the API.</param>
         /// <param name="tags">The list of tags used by the specification with additional metadata.</param>
-        /// <param name="externalDocs">The external documentation.</param>
+        /// <param name="externalDocumentation">The external documentation.</param>
         public Document(
             SemanticVersion? version = default,
             Information info = default,
@@ -81,7 +81,7 @@ namespace SourceCode.Clay.OpenApi
             Components components = default,
             IReadOnlyList<Referable<SecurityScheme>> security = default,
             IReadOnlyList<Tag> tags = default,
-            ExternalDocumentation externalDocs = default)
+            ExternalDocumentation externalDocumentation = default)
         {
             Version = version ?? new SemanticVersion(3, 0, 0);
             Info = info;
@@ -90,7 +90,7 @@ namespace SourceCode.Clay.OpenApi
             Components = components;
             Security = security ?? Array.Empty<Referable<SecurityScheme>>();
             Tags = tags ?? Array.Empty<Tag>();
-            ExternalDocs = externalDocs;
+            ExternalDocumentation = externalDocumentation;
         }
 
         #endregion
@@ -126,7 +126,7 @@ namespace SourceCode.Clay.OpenApi
             if (!Components.NullableEquals(other.Components)) return false;
             if (!Security.ListEquals(other.Security, false)) return false;
             if (!Tags.ListEquals(other.Tags, false)) return false;
-            if (!ExternalDocs.NullableEquals(other.ExternalDocs)) return false;
+            if (!ExternalDocumentation.NullableEquals(other.ExternalDocumentation)) return false;
 
             return true;
         }
@@ -146,7 +146,7 @@ namespace SourceCode.Clay.OpenApi
                 if (Components != null) hc = hc * 21 + Components.GetHashCode();
                 hc = hc * 21 + Security.Count;
                 hc = hc * 21 + Tags.Count;
-                if (ExternalDocs != null) hc = hc * 21 + ExternalDocs.GetHashCode();
+                if (ExternalDocumentation != null) hc = hc * 21 + ExternalDocumentation.GetHashCode();
 
                 return ((int)(hc >> 32)) ^ (int)hc;
             }

--- a/src/SourceCode.Clay.OpenApi/HttpSecurityScheme.cs
+++ b/src/SourceCode.Clay.OpenApi/HttpSecurityScheme.cs
@@ -21,7 +21,7 @@ namespace SourceCode.Clay.OpenApi
         /// </summary>
         /// <param name="description">The short description for security scheme.</param>
         /// <param name="scheme">The name of the HTTP Authorization scheme to be used in the Authorization header.</param>
-        protected HttpSecurityScheme(
+        public HttpSecurityScheme(
             string description = default,
             string scheme = default,
             string bearerFormat = default)

--- a/src/SourceCode.Clay.OpenApi/Operation.cs
+++ b/src/SourceCode.Clay.OpenApi/Operation.cs
@@ -47,7 +47,7 @@ namespace SourceCode.Clay.OpenApi
         public string OperationIdentifier { get; set; }
 
         /// <summary>
-        /// Get the list of parameters that are applicable for this operation.
+        /// Gets the list of parameters that are applicable for this operation.
         /// </summary>
         public IReadOnlyDictionary<ParameterKey, Referable<Parameter>> Parameters { get; }
 

--- a/src/SourceCode.Clay.OpenApi/PropertyEncoding.cs
+++ b/src/SourceCode.Clay.OpenApi/PropertyEncoding.cs
@@ -12,6 +12,9 @@ using System.Net.Mime;
 
 namespace SourceCode.Clay.OpenApi
 {
+    /// <summary>
+    /// A single encoding definition applied to a single schema property.
+    /// </summary>
     public class PropertyEncoding : IEquatable<PropertyEncoding>
     {
         #region Properties

--- a/src/SourceCode.Clay.OpenApi/Schema.cs
+++ b/src/SourceCode.Clay.OpenApi/Schema.cs
@@ -109,7 +109,7 @@ namespace SourceCode.Clay.OpenApi
         /// <summary>
         /// Gets the external documentation.
         /// </summary>
-        public ExternalDocumentation ExternalDocs { get; }
+        public ExternalDocumentation ExternalDocumentation { get; }
 
         /// <summary>
         /// Gets the string validation pattern.
@@ -141,7 +141,7 @@ namespace SourceCode.Clay.OpenApi
         /// <param name="items">The list of schemas that represent the array items that this schema must contain.</param>
         /// <param name="properties">The list of valid properties.</param>
         /// <param name="additionalProperties">The list of valid properties for children.</param>
-        /// <param name="externalDocs">The external documentation.</param>
+        /// <param name="externalDocumentation">The external documentation.</param>
         public Schema(
             SchemaType type = default,
             string format = null,
@@ -161,7 +161,7 @@ namespace SourceCode.Clay.OpenApi
             Referable<Schema> items = default,
             IReadOnlyDictionary<string, Referable<Schema>> properties = default,
             IReadOnlyDictionary<string, Referable<Schema>> additionalProperties = default,
-            ExternalDocumentation externalDocs = default)
+            ExternalDocumentation externalDocumentation = default)
         {
             Type = type;
             Title = title;
@@ -181,7 +181,7 @@ namespace SourceCode.Clay.OpenApi
             Items = items;
             Properties = properties ?? Dictionary.ReadOnlyEmpty<string, Referable<Schema>>();
             AdditionalProperties = additionalProperties ?? Dictionary.ReadOnlyEmpty<string, Referable<Schema>>();
-            ExternalDocs = externalDocs;
+            ExternalDocumentation = externalDocumentation;
         }
 
         #endregion
@@ -225,7 +225,7 @@ namespace SourceCode.Clay.OpenApi
             if (!ItemsRange.Equals(other.ItemsRange)) return false;
             if (!LengthRange.Equals(other.LengthRange)) return false;
             if (!PropertiesRange.Equals(other.PropertiesRange)) return false;
-            if (!ExternalDocs.Equals(other.ExternalDocs)) return false;
+            if (!ExternalDocumentation.Equals(other.ExternalDocumentation)) return false;
             if (!StringComparer.Ordinal.Equals(Title, other.Title)) return false;
             if (!StringComparer.Ordinal.Equals(Description, other.Description)) return false;
             if (!StringComparer.Ordinal.Equals(Pattern, other.Pattern)) return false;
@@ -255,7 +255,7 @@ namespace SourceCode.Clay.OpenApi
                 hc = hc * 21 + ItemsRange.GetHashCode();
                 hc = hc * 21 + LengthRange.GetHashCode();
                 hc = hc * 21 + PropertiesRange.GetHashCode();
-                hc = hc * 21 + ExternalDocs.GetHashCode();
+                hc = hc * 21 + ExternalDocumentation.GetHashCode();
                 if (Title != null) hc = hc * 21 + StringComparer.Ordinal.GetHashCode(Title);
                 if (Format != null) hc = hc * 21 + StringComparer.Ordinal.GetHashCode(Format);
                 if (Description != null) hc = hc * 21 + StringComparer.Ordinal.GetHashCode(Description);


### PR DESCRIPTION
- Rename ExternalDocs - ExternalDocumentation
- HttpSecurityScheme shouldn't be abstract
- Fixes #81: Add builders