### PR TITLE
EnumConvert

### DIFF
--- a/src/SourceCode.Clay.OpenApi/Builders/ApiKeySecuritySchemeBuilder.cs
+++ b/src/SourceCode.Clay.OpenApi/Builders/ApiKeySecuritySchemeBuilder.cs
@@ -12,7 +12,7 @@ namespace SourceCode.Clay.OpenApi
     /// <summary>
     /// Defines an API key security scheme that can be used by the operations.
     /// </summary>
-    public class ApiKeySecuritySchemeBuilder : SecuritySchemeBuilder, IBuilder<ApiKeySecurityScheme>
+    public class ApiKeySecuritySchemeBuilder : SecuritySchemeBuilder, IOpenApiBuilder<ApiKeySecurityScheme>
     {
         #region Properties
 

--- a/src/SourceCode.Clay.OpenApi/Builders/CallbackBuilder.cs
+++ b/src/SourceCode.Clay.OpenApi/Builders/CallbackBuilder.cs
@@ -18,7 +18,7 @@ namespace SourceCode.Clay.OpenApi
     /// the expected responses. The key value used to identify the callback object is an expression, evaluated
     /// at runtime, that identifies a URL to use for the callback operation.
     /// </summary>
-    public class CallbackBuilder : IDictionary<CompoundExpression, Referable<Path>>, IReadOnlyDictionary<CompoundExpression, Referable<Path>>, IBuilder<Callback>
+    public class CallbackBuilder : IDictionary<CompoundExpression, Referable<Path>>, IReadOnlyDictionary<CompoundExpression, Referable<Path>>, IOpenApiBuilder<Callback>
     {
         #region Fields
 

--- a/src/SourceCode.Clay.OpenApi/Builders/ComponentsBuilder.cs
+++ b/src/SourceCode.Clay.OpenApi/Builders/ComponentsBuilder.cs
@@ -16,7 +16,7 @@ namespace SourceCode.Clay.OpenApi
     /// defined within the components object will have no effect on the API unless they
     /// are explicitly referenced from properties outside the components object.
     /// </summary>
-    public class ComponentsBuilder : IBuilder<Components>
+    public class ComponentsBuilder : IOpenApiBuilder<Components>
     {
         #region Properties
 

--- a/src/SourceCode.Clay.OpenApi/Builders/ContactBuilder.cs
+++ b/src/SourceCode.Clay.OpenApi/Builders/ContactBuilder.cs
@@ -13,7 +13,7 @@ namespace SourceCode.Clay.OpenApi
     /// <summary>
     /// Contact information for the exposed API.
     /// </summary>
-    public class ContactBuilder : IBuilder<Contact>
+    public class ContactBuilder : IOpenApiBuilder<Contact>
     {
         #region Properties
 

--- a/src/SourceCode.Clay.OpenApi/Builders/DocumentBuilder.cs
+++ b/src/SourceCode.Clay.OpenApi/Builders/DocumentBuilder.cs
@@ -14,7 +14,7 @@ namespace SourceCode.Clay.OpenApi
     /// <summary>
     /// This is the root document object of the OpenAPI document.
     /// </summary>
-    public class DocumentBuilder : IBuilder<Document>
+    public class DocumentBuilder : IOpenApiBuilder<Document>
     {
         #region Properties
 

--- a/src/SourceCode.Clay.OpenApi/Builders/ExampleBuilder.cs
+++ b/src/SourceCode.Clay.OpenApi/Builders/ExampleBuilder.cs
@@ -12,7 +12,7 @@ namespace SourceCode.Clay.OpenApi
     /// <summary>
     /// Contains an example of how to use an entity in an Open API document.
     /// </summary>
-    public class ExampleBuilder : IBuilder<Example>
+    public class ExampleBuilder : IOpenApiBuilder<Example>
     {
         #region Properties
 

--- a/src/SourceCode.Clay.OpenApi/Builders/ExternalDocumentationBuilder.cs
+++ b/src/SourceCode.Clay.OpenApi/Builders/ExternalDocumentationBuilder.cs
@@ -12,7 +12,7 @@ namespace SourceCode.Clay.OpenApi
     /// <summary>
     /// Allows referencing an external resource for extended documentation.
     /// </summary>
-    public class ExternalDocumentationBuilder : IBuilder<ExternalDocumentation>
+    public class ExternalDocumentationBuilder : IOpenApiBuilder<ExternalDocumentation>
     {
         #region Properties
 

--- a/src/SourceCode.Clay.OpenApi/Builders/HttpSecuritySchemeBuilder.cs
+++ b/src/SourceCode.Clay.OpenApi/Builders/HttpSecuritySchemeBuilder.cs
@@ -12,7 +12,7 @@ namespace SourceCode.Clay.OpenApi
     /// <summary>
     /// Defines an HTTP security scheme that can be used by the operations.
     /// </summary>
-    public class HttpSecuritySchemeBuilder : SecuritySchemeBuilder, IBuilder<HttpSecurityScheme>
+    public class HttpSecuritySchemeBuilder : SecuritySchemeBuilder, IOpenApiBuilder<HttpSecurityScheme>
     {
         #region Properties
 

--- a/src/SourceCode.Clay.OpenApi/Builders/IOpenApiBuilder.cs
+++ b/src/SourceCode.Clay.OpenApi/Builders/IOpenApiBuilder.cs
@@ -11,7 +11,7 @@ namespace SourceCode.Clay.OpenApi
     /// Represents a type that builds another type.
     /// </summary>
     /// <typeparam name="TBuilt">The type that will be built.</typeparam>
-    public interface IBuilder<out TBuilt>
+    public interface IOpenApiBuilder<out TBuilt>
     {
         #region Methods
 

--- a/src/SourceCode.Clay.OpenApi/Builders/InformationBuilder.cs
+++ b/src/SourceCode.Clay.OpenApi/Builders/InformationBuilder.cs
@@ -14,7 +14,7 @@ namespace SourceCode.Clay.OpenApi
     /// clients if needed, and MAY be presented in editing or documentation generation
     /// tools for convenience.
     /// </summary>
-    public class InformationBuilder : IBuilder<Information>
+    public class InformationBuilder : IOpenApiBuilder<Information>
     {
         #region Properties
 

--- a/src/SourceCode.Clay.OpenApi/Builders/LicenseBuilder.cs
+++ b/src/SourceCode.Clay.OpenApi/Builders/LicenseBuilder.cs
@@ -12,7 +12,7 @@ namespace SourceCode.Clay.OpenApi
     /// <summary>
     /// License information for the exposed API.
     /// </summary>
-    public class LicenseBuilder : IBuilder<License>
+    public class LicenseBuilder : IOpenApiBuilder<License>
     {
         #region Properties
 

--- a/src/SourceCode.Clay.OpenApi/Builders/LinkBuilder.cs
+++ b/src/SourceCode.Clay.OpenApi/Builders/LinkBuilder.cs
@@ -12,7 +12,7 @@ namespace SourceCode.Clay.OpenApi
     /// <summary>
     /// Represents a possible design-time link for a response.
     /// </summary>
-    public class LinkBuilder : IBuilder<Link>
+    public class LinkBuilder : IOpenApiBuilder<Link>
     {
         #region Properties
 

--- a/src/SourceCode.Clay.OpenApi/Builders/MediaTypeBuilder.cs
+++ b/src/SourceCode.Clay.OpenApi/Builders/MediaTypeBuilder.cs
@@ -14,7 +14,7 @@ namespace SourceCode.Clay.OpenApi
     /// <summary>
     /// Provides schema and examples for the media type identified by a key.
     /// </summary>
-    public class MediaTypeBuilder : IBuilder<MediaType>
+    public class MediaTypeBuilder : IOpenApiBuilder<MediaType>
     {
         #region Properties
 

--- a/src/SourceCode.Clay.OpenApi/Builders/OAuth2SecuritySchemeBuilder.cs
+++ b/src/SourceCode.Clay.OpenApi/Builders/OAuth2SecuritySchemeBuilder.cs
@@ -12,7 +12,7 @@ namespace SourceCode.Clay.OpenApi
     /// <summary>
     /// Defines an OAuth 2 security scheme that can be used by the operations.
     /// </summary>
-    public class OAuth2SecuritySchemeBuilder : SecuritySchemeBuilder, IBuilder<OAuth2SecurityScheme>
+    public class OAuth2SecuritySchemeBuilder : SecuritySchemeBuilder, IOpenApiBuilder<OAuth2SecurityScheme>
     {
         #region Properties
 

--- a/src/SourceCode.Clay.OpenApi/Builders/OAuthFlowBuilder.cs
+++ b/src/SourceCode.Clay.OpenApi/Builders/OAuthFlowBuilder.cs
@@ -14,7 +14,7 @@ namespace SourceCode.Clay.OpenApi
     /// <summary>
     /// Configuration details for a supported OAuth Flow.
     /// </summary>
-    public class OAuthFlowBuilder : IBuilder<OAuthFlow>
+    public class OAuthFlowBuilder : IOpenApiBuilder<OAuthFlow>
     {
         #region Properties
 

--- a/src/SourceCode.Clay.OpenApi/Builders/OpenIdConnectSecuritySchemeBuilder.cs
+++ b/src/SourceCode.Clay.OpenApi/Builders/OpenIdConnectSecuritySchemeBuilder.cs
@@ -12,7 +12,7 @@ namespace SourceCode.Clay.OpenApi
     /// <summary>
     /// Defines an API key security scheme that can be used by the operations.
     /// </summary>
-    public class OpenIdConnectSecuritySchemeBuilder : SecuritySchemeBuilder, IBuilder<OpenIdConnectSecurityScheme>
+    public class OpenIdConnectSecuritySchemeBuilder : SecuritySchemeBuilder, IOpenApiBuilder<OpenIdConnectSecurityScheme>
     {
         #region Properties
 

--- a/src/SourceCode.Clay.OpenApi/Builders/OperationBuilder.cs
+++ b/src/SourceCode.Clay.OpenApi/Builders/OperationBuilder.cs
@@ -14,7 +14,7 @@ namespace SourceCode.Clay.OpenApi
     /// <summary>
     /// Describes a single API operation on a path.
     /// </summary>
-    public class OperationBuilder : IBuilder<Operation>
+    public class OperationBuilder : IOpenApiBuilder<Operation>
     {
         #region Properties
 

--- a/src/SourceCode.Clay.OpenApi/Builders/ParameterBodyBuilder.cs
+++ b/src/SourceCode.Clay.OpenApi/Builders/ParameterBodyBuilder.cs
@@ -15,7 +15,7 @@ namespace SourceCode.Clay.OpenApi
     /// <summary>
     /// Describes a single operation parameter.
     /// </summary>
-    public class ParameterBodyBuilder : IBuilder<ParameterBody>
+    public class ParameterBodyBuilder : IOpenApiBuilder<ParameterBody>
     {
         #region Properties
 

--- a/src/SourceCode.Clay.OpenApi/Builders/ParameterBuilder.cs
+++ b/src/SourceCode.Clay.OpenApi/Builders/ParameterBuilder.cs
@@ -14,7 +14,7 @@ namespace SourceCode.Clay.OpenApi
     /// <summary>
     /// Describes a single operation parameter.
     /// </summary>
-    public class ParameterBuilder : ParameterBodyBuilder, IBuilder<Parameter>
+    public class ParameterBuilder : ParameterBodyBuilder, IOpenApiBuilder<Parameter>
     {
         #region Properties
 

--- a/src/SourceCode.Clay.OpenApi/Builders/PathBuilder.cs
+++ b/src/SourceCode.Clay.OpenApi/Builders/PathBuilder.cs
@@ -16,7 +16,7 @@ namespace SourceCode.Clay.OpenApi
     /// The path itself is still exposed to the documentation viewer but they will not know which operations
     /// and parameters are available.
     /// </summary>
-    public class PathBuilder : IBuilder<Path>
+    public class PathBuilder : IOpenApiBuilder<Path>
     {
         #region Properties
 

--- a/src/SourceCode.Clay.OpenApi/Builders/PropertyEncodingBuilder.cs
+++ b/src/SourceCode.Clay.OpenApi/Builders/PropertyEncodingBuilder.cs
@@ -15,7 +15,7 @@ namespace SourceCode.Clay.OpenApi
     /// <summary>
     /// A single encoding definition applied to a single schema property.
     /// </summary>
-    public class PropertyEncodingBuilder : IBuilder<PropertyEncoding>
+    public class PropertyEncodingBuilder : IOpenApiBuilder<PropertyEncoding>
     {
         #region Properties
 

--- a/src/SourceCode.Clay.OpenApi/Builders/RequestBodyBuilder.cs
+++ b/src/SourceCode.Clay.OpenApi/Builders/RequestBodyBuilder.cs
@@ -15,7 +15,7 @@ namespace SourceCode.Clay.OpenApi
     /// <summary>
     /// Describes a single request body.
     /// </summary>
-    public class RequestBodyBuilder : IBuilder<RequestBody>
+    public class RequestBodyBuilder : IOpenApiBuilder<RequestBody>
     {
         #region Properties
 

--- a/src/SourceCode.Clay.OpenApi/Builders/ResponseBuilder.cs
+++ b/src/SourceCode.Clay.OpenApi/Builders/ResponseBuilder.cs
@@ -15,7 +15,7 @@ namespace SourceCode.Clay.OpenApi
     /// <summary>
     /// Describes a single response from an API Operation.
     /// </summary>
-    public class ResponseBuilder : IBuilder<Response>
+    public class ResponseBuilder : IOpenApiBuilder<Response>
     {
         #region Properties
 

--- a/src/SourceCode.Clay.OpenApi/Builders/SchemaBuilder.cs
+++ b/src/SourceCode.Clay.OpenApi/Builders/SchemaBuilder.cs
@@ -14,7 +14,7 @@ namespace SourceCode.Clay.OpenApi
     /// <summary>
     /// Allows the definition of input and output data types.
     /// </summary>
-    public class SchemaBuilder : IBuilder<Schema>
+    public class SchemaBuilder : IOpenApiBuilder<Schema>
     {
         #region Properties
 

--- a/src/SourceCode.Clay.OpenApi/Builders/ServerBuilder.cs
+++ b/src/SourceCode.Clay.OpenApi/Builders/ServerBuilder.cs
@@ -14,7 +14,7 @@ namespace SourceCode.Clay.OpenApi
     /// <summary>
     /// An object representing a Server.
     /// </summary>
-    public class ServerBuilder : IBuilder<Server>
+    public class ServerBuilder : IOpenApiBuilder<Server>
     {
         #region Properties
 

--- a/src/SourceCode.Clay.OpenApi/Builders/ServerVariableBuilder.cs
+++ b/src/SourceCode.Clay.OpenApi/Builders/ServerVariableBuilder.cs
@@ -14,7 +14,7 @@ namespace SourceCode.Clay.OpenApi
     /// <summary>
     /// An object representing a Server Variable for server URL template substitution.
     /// </summary>
-    public class ServerVariableBuilder : IBuilder<ServerVariable>
+    public class ServerVariableBuilder : IOpenApiBuilder<ServerVariable>
     {
         #region Properties
 

--- a/src/SourceCode.Clay.OpenApi/Builders/TagBuilder.cs
+++ b/src/SourceCode.Clay.OpenApi/Builders/TagBuilder.cs
@@ -12,7 +12,7 @@ namespace SourceCode.Clay.OpenApi
     /// <summary>
     /// Adds metadata to a single tag that is used by <see cref="Operation"/>.
     /// </summary>
-    public class TagBuilder : IBuilder<Tag>
+    public class TagBuilder : IOpenApiBuilder<Tag>
     {
         #region Properties
 

--- a/src/SourceCode.Clay.Tests/EnumConvertTests.cs
+++ b/src/SourceCode.Clay.Tests/EnumConvertTests.cs
@@ -1,0 +1,418 @@
+#region License
+
+// Copyright (c) K2 Workflow (SourceCode Technology Holdings Inc.). All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+#endregion
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+using Xunit;
+
+namespace SourceCode.Clay.Tests
+{
+    public static class EnumConvertTests
+    {
+        #region Enums
+
+        private enum ByteEnum : byte
+        {
+            MinValue = byte.MinValue,
+            MaxValue = byte.MaxValue,
+
+            SByteMinValue = unchecked((byte)sbyte.MinValue),
+            UInt16MaxValue = unchecked((byte)ushort.MaxValue)
+        }
+
+        private enum SByteEnum : sbyte
+        {
+            MinValue = sbyte.MinValue,
+            MaxValue = sbyte.MaxValue,
+
+            Int16MinValue = unchecked((sbyte)short.MinValue),
+            ByteMaxValue = unchecked((sbyte)byte.MaxValue)
+        }
+
+        private enum Int16Enum : short
+        {
+            MinValue = short.MinValue,
+            MaxValue = short.MaxValue,
+
+            Int32MinValue = unchecked((short)int.MinValue),
+            UInt16MaxValue = unchecked((short)ushort.MaxValue)
+        }
+
+        private enum UInt16Enum : ushort
+        {
+            MinValue = ushort.MinValue,
+            MaxValue = ushort.MaxValue,
+
+            Int16MinValue = unchecked((ushort)short.MinValue),
+            UInt32MaxValue = unchecked((ushort)uint.MaxValue)
+        }
+
+        private enum Int32Enum : int
+        {
+            MinValue = int.MinValue,
+            MaxValue = int.MaxValue,
+
+            Int64MinValue = unchecked((int)long.MinValue),
+            UInt32MaxValue = unchecked((int)uint.MaxValue)
+        }
+
+        private enum UInt32Enum : uint
+        {
+            MinValue = uint.MinValue,
+            MaxValue = uint.MaxValue,
+
+            Int32MinValue = unchecked((uint)int.MinValue),
+            UInt64MaxValue = unchecked((uint)ulong.MaxValue)
+        }
+
+        private enum Int64Enum : long
+        {
+            MinValue = long.MinValue,
+            MaxValue = long.MaxValue,
+
+            UInt64MaxValue = unchecked((long)ulong.MaxValue)
+        }
+
+        private enum UInt64Enum : ulong
+        {
+            MinValue = ulong.MinValue,
+            MaxValue = ulong.MaxValue,
+
+            Int64MinValue = unchecked((ulong)long.MinValue)
+        }
+
+        #endregion
+
+        #region Checked
+
+        [Fact(DisplayName = nameof(EnumConvert_NonEnum))]
+        public static void EnumConvert_NonEnum()
+        {
+            Assert.Throws<ArgumentOutOfRangeException>("value", () => EnumConvert.ToEnum<int>(0));
+            Assert.Throws<ArgumentOutOfRangeException>("value", () => EnumConvert.ToByte(0));
+        }
+
+        [Fact(DisplayName = nameof(EnumConvert_ToEnumCheckedOfByte))]
+        public static void EnumConvert_ToEnumCheckedOfByte()
+        {
+            Assert.Equal(ByteEnum.MinValue, EnumConvert.ToEnumChecked<ByteEnum>(byte.MinValue));
+            Assert.Equal(ByteEnum.MaxValue, EnumConvert.ToEnumChecked<ByteEnum>(byte.MaxValue));
+
+            Assert.Throws<OverflowException>(() => EnumConvert.ToEnumChecked<ByteEnum>(sbyte.MinValue));
+            Assert.Throws<OverflowException>(() => EnumConvert.ConvertToEnumChecked<ByteEnum>(ushort.MaxValue));
+        }
+
+        [Fact(DisplayName = nameof(EnumConvert_ToEnumCheckedOfSByte))]
+        public static void EnumConvert_ToEnumCheckedOfSByte()
+        {
+            Assert.Equal(SByteEnum.MinValue, EnumConvert.ToEnumChecked<SByteEnum>(sbyte.MinValue));
+            Assert.Equal(SByteEnum.MaxValue, EnumConvert.ToEnumChecked<SByteEnum>(sbyte.MaxValue));
+
+            Assert.Throws<OverflowException>(() => EnumConvert.ToEnumChecked<SByteEnum>(short.MinValue));
+            Assert.Throws<OverflowException>(() => EnumConvert.ToEnumChecked<SByteEnum>(byte.MaxValue));
+        }
+
+        [Fact(DisplayName = nameof(EnumConvert_ToEnumCheckedOfUInt16))]
+        public static void EnumConvert_ToEnumCheckedOfUInt16()
+        {
+            Assert.Equal(UInt16Enum.MinValue, EnumConvert.ConvertToEnumChecked<UInt16Enum>(ushort.MinValue));
+            Assert.Equal(UInt16Enum.MaxValue, EnumConvert.ConvertToEnumChecked<UInt16Enum>(ushort.MaxValue));
+
+            Assert.Throws<OverflowException>(() => EnumConvert.ToEnumChecked<UInt16Enum>(short.MinValue));
+            Assert.Throws<OverflowException>(() => EnumConvert.ToEnumChecked<UInt16Enum>(uint.MaxValue));
+        }
+
+        [Fact(DisplayName = nameof(EnumConvert_ToEnumCheckedOfInt16))]
+        public static void EnumConvert_ToEnumCheckedOfInt16()
+        {
+            Assert.Equal(Int16Enum.MinValue, EnumConvert.ToEnumChecked<Int16Enum>(short.MinValue));
+            Assert.Equal(Int16Enum.MaxValue, EnumConvert.ToEnumChecked<Int16Enum>(short.MaxValue));
+
+            Assert.Throws<OverflowException>(() => EnumConvert.ToEnumChecked<Int16Enum>(int.MinValue));
+            Assert.Throws<OverflowException>(() => EnumConvert.ConvertToEnumChecked<Int16Enum>(ushort.MaxValue));
+        }
+
+        [Fact(DisplayName = nameof(EnumConvert_ToEnumCheckedOfUInt32))]
+        public static void EnumConvert_ToEnumCheckedOfUInt32()
+        {
+            Assert.Equal(UInt32Enum.MinValue, EnumConvert.ToEnumChecked<UInt32Enum>(uint.MinValue));
+            Assert.Equal(UInt32Enum.MaxValue, EnumConvert.ToEnumChecked<UInt32Enum>(uint.MaxValue));
+
+            Assert.Throws<OverflowException>(() => EnumConvert.ToEnumChecked<UInt32Enum>(int.MinValue));
+            Assert.Throws<OverflowException>(() => EnumConvert.ToEnumChecked<UInt32Enum>(ulong.MaxValue));
+        }
+
+        [Fact(DisplayName = nameof(EnumConvert_ToEnumCheckedOfInt32))]
+        public static void EnumConvert_ToEnumCheckedOfInt32()
+        {
+            Assert.Equal(Int32Enum.MinValue, EnumConvert.ToEnumChecked<Int32Enum>(int.MinValue));
+            Assert.Equal(Int32Enum.MaxValue, EnumConvert.ToEnumChecked<Int32Enum>(int.MaxValue));
+
+            Assert.Throws<OverflowException>(() => EnumConvert.ToEnumChecked<Int32Enum>(long.MinValue));
+            Assert.Throws<OverflowException>(() => EnumConvert.ToEnumChecked<Int32Enum>(uint.MaxValue));
+        }
+
+        [Fact(DisplayName = nameof(EnumConvert_ToEnumCheckedOfUInt64))]
+        public static void EnumConvert_ToEnumCheckedOfUInt64()
+        {
+            Assert.Equal(UInt64Enum.MinValue, EnumConvert.ToEnumChecked<UInt64Enum>(ulong.MinValue));
+            Assert.Equal(UInt64Enum.MaxValue, EnumConvert.ToEnumChecked<UInt64Enum>(ulong.MaxValue));
+
+            Assert.Throws<OverflowException>(() => EnumConvert.ToEnumChecked<UInt64Enum>(long.MinValue));
+        }
+
+        [Fact(DisplayName = nameof(EnumConvert_ToEnumCheckedOfInt64))]
+        public static void EnumConvert_ToEnumCheckedOfInt64()
+        {
+            Assert.Equal(Int64Enum.MinValue, EnumConvert.ToEnumChecked<Int64Enum>(long.MinValue));
+            Assert.Equal(Int64Enum.MaxValue, EnumConvert.ToEnumChecked<Int64Enum>(long.MaxValue));
+
+            Assert.Throws<OverflowException>(() => EnumConvert.ToEnumChecked<Int64Enum>(ulong.MaxValue));
+        }
+
+        [Fact(DisplayName = nameof(EnumConvert_ToByteChecked))]
+        public static void EnumConvert_ToByteChecked()
+        {
+            Assert.Equal(byte.MinValue, EnumConvert.ToByteChecked(ByteEnum.MinValue));
+            Assert.Equal(byte.MaxValue, EnumConvert.ToByteChecked(ByteEnum.MaxValue));
+
+            Assert.Throws<OverflowException>(() => EnumConvert.ToByteChecked(SByteEnum.MinValue));
+            Assert.Throws<OverflowException>(() => EnumConvert.ToByteChecked(UInt16Enum.MaxValue));
+        }
+
+        [Fact(DisplayName = nameof(EnumConvert_ToSByteChecked))]
+        public static void EnumConvert_ToSByteChecked()
+        {
+            Assert.Equal(sbyte.MinValue, EnumConvert.ToSByteChecked(SByteEnum.MinValue));
+            Assert.Equal(sbyte.MaxValue, EnumConvert.ToSByteChecked(SByteEnum.MaxValue));
+
+            Assert.Throws<OverflowException>(() => EnumConvert.ToSByteChecked(Int16Enum.MinValue));
+            Assert.Throws<OverflowException>(() => EnumConvert.ToSByteChecked(ByteEnum.MaxValue));
+        }
+
+        [Fact(DisplayName = nameof(EnumConvert_ToUInt16Checked))]
+        public static void EnumConvert_ToUInt16Checked()
+        {
+            Assert.Equal(ushort.MinValue, EnumConvert.ToUInt16Checked(UInt16Enum.MinValue));
+            Assert.Equal(ushort.MaxValue, EnumConvert.ToUInt16Checked(UInt16Enum.MaxValue));
+
+            Assert.Throws<OverflowException>(() => EnumConvert.ToUInt16Checked(Int16Enum.MinValue));
+            Assert.Throws<OverflowException>(() => EnumConvert.ToUInt16Checked(UInt32Enum.MaxValue));
+        }
+
+        [Fact(DisplayName = nameof(EnumConvert_ToInt16Checked))]
+        public static void EnumConvert_ToInt16Checked()
+        {
+            Assert.Equal(short.MinValue, EnumConvert.ToInt16Checked(Int16Enum.MinValue));
+            Assert.Equal(short.MaxValue, EnumConvert.ToInt16Checked(Int16Enum.MaxValue));
+
+            Assert.Throws<OverflowException>(() => EnumConvert.ToInt16Checked(Int32Enum.MinValue));
+            Assert.Throws<OverflowException>(() => EnumConvert.ToInt16Checked(UInt16Enum.MaxValue));
+        }
+
+        [Fact(DisplayName = nameof(EnumConvert_ToUInt32Checked))]
+        public static void EnumConvert_ToUInt32Checked()
+        {
+            Assert.Equal(uint.MinValue, EnumConvert.ToUInt32Checked(UInt32Enum.MinValue));
+            Assert.Equal(uint.MaxValue, EnumConvert.ToUInt32Checked(UInt32Enum.MaxValue));
+
+            Assert.Throws<OverflowException>(() => EnumConvert.ToUInt32Checked(Int32Enum.MinValue));
+            Assert.Throws<OverflowException>(() => EnumConvert.ToUInt32Checked(UInt64Enum.MaxValue));
+        }
+
+        [Fact(DisplayName = nameof(EnumConvert_ToInt32Checked))]
+        public static void EnumConvert_ToInt32Checked()
+        {
+            Assert.Equal(int.MinValue, EnumConvert.ToInt32Checked(Int32Enum.MinValue));
+            Assert.Equal(int.MaxValue, EnumConvert.ToInt32Checked(Int32Enum.MaxValue));
+
+            Assert.Throws<OverflowException>(() => EnumConvert.ToInt32Checked(Int64Enum.MinValue));
+            Assert.Throws<OverflowException>(() => EnumConvert.ToInt32Checked(UInt32Enum.MaxValue));
+        }
+
+        [Fact(DisplayName = nameof(EnumConvert_ToUInt64Checked))]
+        public static void EnumConvert_ToUInt64Checked()
+        {
+            Assert.Equal(ulong.MinValue, EnumConvert.ToUInt64Checked(UInt64Enum.MinValue));
+            Assert.Equal(ulong.MaxValue, EnumConvert.ToUInt64Checked(UInt64Enum.MaxValue));
+
+            Assert.Throws<OverflowException>(() => EnumConvert.ToUInt64Checked(Int64Enum.MinValue));
+        }
+
+        [Fact(DisplayName = nameof(EnumConvert_ToInt64Checked))]
+        public static void EnumConvert_ToInt64Checked()
+        {
+            Assert.Equal(long.MinValue, EnumConvert.ToInt64Checked(Int64Enum.MinValue));
+            Assert.Equal(long.MaxValue, EnumConvert.ToInt64Checked(Int64Enum.MaxValue));
+
+            Assert.Throws<OverflowException>(() => EnumConvert.ToInt64Checked(UInt64Enum.MaxValue));
+        }
+
+        #endregion
+
+        #region Unchecked
+
+        [Fact(DisplayName = nameof(EnumConvert_ToEnumOfByte))]
+        public static void EnumConvert_ToEnumOfByte()
+        {
+            Assert.Equal(ByteEnum.MinValue, EnumConvert.ToEnum<ByteEnum>(byte.MinValue));
+            Assert.Equal(ByteEnum.MaxValue, EnumConvert.ToEnum<ByteEnum>(byte.MaxValue));
+
+            Assert.Equal(ByteEnum.SByteMinValue, EnumConvert.ToEnum<ByteEnum>(sbyte.MinValue));
+            Assert.Equal(ByteEnum.UInt16MaxValue, EnumConvert.ToEnum<ByteEnum>(ushort.MaxValue));
+        }
+
+        [Fact(DisplayName = nameof(EnumConvert_ToEnumOfSByte))]
+        public static void EnumConvert_ToEnumOfSByte()
+        {
+            Assert.Equal(SByteEnum.MinValue, EnumConvert.ToEnum<SByteEnum>(sbyte.MinValue));
+            Assert.Equal(SByteEnum.MaxValue, EnumConvert.ToEnum<SByteEnum>(sbyte.MaxValue));
+
+            Assert.Equal(SByteEnum.Int16MinValue, EnumConvert.ToEnum<SByteEnum>(short.MinValue));
+            Assert.Equal(SByteEnum.ByteMaxValue, EnumConvert.ToEnum<SByteEnum>(byte.MaxValue));
+        }
+
+        [Fact(DisplayName = nameof(EnumConvert_ToEnumOfUInt16))]
+        public static void EnumConvert_ToEnumOfUInt16()
+        {
+            Assert.Equal(UInt16Enum.MinValue, EnumConvert.ToEnum<UInt16Enum>(ushort.MinValue));
+            Assert.Equal(UInt16Enum.MaxValue, EnumConvert.ToEnum<UInt16Enum>(ushort.MaxValue));
+
+            Assert.Equal(UInt16Enum.Int16MinValue, EnumConvert.ToEnum<UInt16Enum>(short.MinValue));
+            Assert.Equal(UInt16Enum.UInt32MaxValue, EnumConvert.ToEnum<UInt16Enum>(uint.MaxValue));
+        }
+
+        [Fact(DisplayName = nameof(EnumConvert_ToEnumOfInt16))]
+        public static void EnumConvert_ToEnumOfInt16()
+        {
+            Assert.Equal(Int16Enum.MinValue, EnumConvert.ToEnum<Int16Enum>(short.MinValue));
+            Assert.Equal(Int16Enum.MaxValue, EnumConvert.ToEnum<Int16Enum>(short.MaxValue));
+
+            Assert.Equal(Int16Enum.Int32MinValue, EnumConvert.ToEnum<Int16Enum>(int.MinValue));
+            Assert.Equal(Int16Enum.UInt16MaxValue, EnumConvert.ToEnum<Int16Enum>(ushort.MaxValue));
+        }
+
+        [Fact(DisplayName = nameof(EnumConvert_ToEnumOfUInt32))]
+        public static void EnumConvert_ToEnumOfUInt32()
+        {
+            Assert.Equal(UInt32Enum.MinValue, EnumConvert.ToEnum<UInt32Enum>(uint.MinValue));
+            Assert.Equal(UInt32Enum.MaxValue, EnumConvert.ToEnum<UInt32Enum>(uint.MaxValue));
+
+            Assert.Equal(UInt32Enum.Int32MinValue, EnumConvert.ToEnum<UInt32Enum>(int.MinValue));
+            Assert.Equal(UInt32Enum.UInt64MaxValue, EnumConvert.ToEnum<UInt32Enum>(ulong.MaxValue));
+        }
+
+        [Fact(DisplayName = nameof(EnumConvert_ToEnumOfInt32))]
+        public static void EnumConvert_ToEnumOfInt32()
+        {
+            Assert.Equal(Int32Enum.MinValue, EnumConvert.ToEnum<Int32Enum>(int.MinValue));
+            Assert.Equal(Int32Enum.MaxValue, EnumConvert.ToEnum<Int32Enum>(int.MaxValue));
+
+            Assert.Equal(Int32Enum.Int64MinValue, EnumConvert.ToEnum<Int32Enum>(long.MinValue));
+            Assert.Equal(Int32Enum.UInt32MaxValue, EnumConvert.ToEnum<Int32Enum>(uint.MaxValue));
+        }
+
+        [Fact(DisplayName = nameof(EnumConvert_ToEnumOfUInt64))]
+        public static void EnumConvert_ToEnumOfUInt64()
+        {
+            Assert.Equal(UInt64Enum.MinValue, EnumConvert.ToEnum<UInt64Enum>(ulong.MinValue));
+            Assert.Equal(UInt64Enum.MaxValue, EnumConvert.ToEnum<UInt64Enum>(ulong.MaxValue));
+
+            Assert.Equal(UInt64Enum.Int64MinValue, EnumConvert.ToEnum<UInt64Enum>(long.MinValue));
+        }
+
+        [Fact(DisplayName = nameof(EnumConvert_ToEnumOfInt64))]
+        public static void EnumConvert_ToEnumOfInt64()
+        {
+            Assert.Equal(Int64Enum.MinValue, EnumConvert.ToEnum<Int64Enum>(long.MinValue));
+            Assert.Equal(Int64Enum.MaxValue, EnumConvert.ToEnum<Int64Enum>(long.MaxValue));
+
+            Assert.Equal(Int64Enum.UInt64MaxValue, EnumConvert.ToEnum<Int64Enum>(ulong.MaxValue));
+        }
+
+        [Fact(DisplayName = nameof(EnumConvert_ToByte))]
+        public static void EnumConvert_ToByte()
+        {
+            Assert.Equal(byte.MinValue, EnumConvert.ToByte(ByteEnum.MinValue));
+            Assert.Equal(byte.MaxValue, EnumConvert.ToByte(ByteEnum.MaxValue));
+
+            Assert.Equal(unchecked((byte)sbyte.MinValue), EnumConvert.ToByte(SByteEnum.MinValue));
+            Assert.Equal(unchecked((byte)ushort.MaxValue), EnumConvert.ToByte(UInt16Enum.MaxValue));
+        }
+
+        [Fact(DisplayName = nameof(EnumConvert_ToSByte))]
+        public static void EnumConvert_ToSByte()
+        {
+            Assert.Equal(sbyte.MinValue, EnumConvert.ToSByte(SByteEnum.MinValue));
+            Assert.Equal(sbyte.MaxValue, EnumConvert.ToSByte(SByteEnum.MaxValue));
+
+            Assert.Equal(unchecked((sbyte)short.MinValue), EnumConvert.ToSByte(Int16Enum.MinValue));
+            Assert.Equal(unchecked((sbyte)byte.MaxValue), EnumConvert.ToSByte(ByteEnum.MaxValue));
+        }
+
+        [Fact(DisplayName = nameof(EnumConvert_ToUInt16))]
+        public static void EnumConvert_ToUInt16()
+        {
+            Assert.Equal(ushort.MinValue, EnumConvert.ToUInt16(UInt16Enum.MinValue));
+            Assert.Equal(ushort.MaxValue, EnumConvert.ToUInt16(UInt16Enum.MaxValue));
+
+            Assert.Equal(unchecked((ushort)short.MinValue), EnumConvert.ToUInt16(Int16Enum.MinValue));
+            Assert.Equal(unchecked((ushort)uint.MaxValue), EnumConvert.ToUInt16(UInt32Enum.MaxValue));
+        }
+
+        [Fact(DisplayName = nameof(EnumConvert_ToInt16))]
+        public static void EnumConvert_ToInt16()
+        {
+            Assert.Equal(short.MinValue, EnumConvert.ToInt16(Int16Enum.MinValue));
+            Assert.Equal(short.MaxValue, EnumConvert.ToInt16(Int16Enum.MaxValue));
+
+            Assert.Equal(unchecked((short)int.MinValue), EnumConvert.ToInt16(Int32Enum.MinValue));
+            Assert.Equal(unchecked((short)ushort.MaxValue), EnumConvert.ToInt16(UInt16Enum.MaxValue));
+        }
+
+        [Fact(DisplayName = nameof(EnumConvert_ToUInt32))]
+        public static void EnumConvert_ToUInt32()
+        {
+            Assert.Equal(uint.MinValue, EnumConvert.ToUInt32(UInt32Enum.MinValue));
+            Assert.Equal(uint.MaxValue, EnumConvert.ToUInt32(UInt32Enum.MaxValue));
+
+            Assert.Equal(unchecked((uint)int.MinValue), EnumConvert.ToUInt32(Int32Enum.MinValue));
+            Assert.Equal(unchecked((uint)ulong.MaxValue), EnumConvert.ToUInt32(UInt64Enum.MaxValue));
+        }
+
+        [Fact(DisplayName = nameof(EnumConvert_ToInt32))]
+        public static void EnumConvert_ToInt32()
+        {
+            Assert.Equal(int.MinValue, EnumConvert.ToInt32(Int32Enum.MinValue));
+            Assert.Equal(int.MaxValue, EnumConvert.ToInt32(Int32Enum.MaxValue));
+
+            Assert.Equal(unchecked((int)long.MinValue), EnumConvert.ToInt32(Int64Enum.MinValue));
+            Assert.Equal(unchecked((int)uint.MaxValue), EnumConvert.ToInt32(UInt32Enum.MaxValue));
+        }
+
+        [Fact(DisplayName = nameof(EnumConvert_ToUInt64))]
+        public static void EnumConvert_ToUInt64()
+        {
+            Assert.Equal(ulong.MinValue, EnumConvert.ToUInt64(UInt64Enum.MinValue));
+            Assert.Equal(ulong.MaxValue, EnumConvert.ToUInt64(UInt64Enum.MaxValue));
+
+            Assert.Equal(unchecked((ulong)long.MinValue), EnumConvert.ToUInt64(Int64Enum.MinValue));
+        }
+
+        [Fact(DisplayName = nameof(EnumConvert_ToInt64))]
+        public static void EnumConvert_ToInt64()
+        {
+            Assert.Equal(long.MinValue, EnumConvert.ToInt64(Int64Enum.MinValue));
+            Assert.Equal(long.MaxValue, EnumConvert.ToInt64(Int64Enum.MaxValue));
+
+            Assert.Equal(unchecked((long)ulong.MaxValue), EnumConvert.ToInt64(UInt64Enum.MaxValue));
+        }
+
+        #endregion
+    }
+}

--- a/src/SourceCode.Clay/EnumConvert.cs
+++ b/src/SourceCode.Clay/EnumConvert.cs
@@ -1,0 +1,588 @@
+#region License
+
+// Copyright (c) K2 Workflow (SourceCode Technology Holdings Inc.). All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+#endregion
+
+using System;
+using System.Collections.Generic;
+using System.Linq.Expressions;
+
+namespace SourceCode.Clay
+{
+    /// <summary>
+    /// Allows the conversion of enum values to integral values.
+    /// </summary>
+    public static class EnumConvert
+    {
+        private sealed class Checked { }
+
+        private sealed class Unchecked { }
+
+#pragma warning disable S2436 // Classes and methods should not have too many generic parameters
+
+        private static class Converter<TEnum, TInteger, TChecked>
+#pragma warning restore S2436 // Classes and methods should not have too many generic parameters
+            where TEnum : struct, IComparable, IConvertible, IFormattable
+        {
+            private static bool _isChecked = typeof(TChecked) == typeof(Checked);
+            public static Func<TEnum, TInteger> ConvertTo { get; }
+            public static Func<TInteger, TEnum> ConvertFrom { get; }
+
+            static Converter()
+            {
+                var @enum = typeof(TEnum);
+                if (!@enum.IsEnum)
+                {
+#pragma warning disable S3928 // Parameter names used into ArgumentException constructors should match an existing one
+                    ConvertTo = _ => throw new ArgumentOutOfRangeException("value", "value is not an enum.");
+                    ConvertFrom = _ => throw new ArgumentOutOfRangeException("value", "value is not an enum.");
+                    return;
+#pragma warning restore S3928 // Parameter names used into ArgumentException constructors should match an existing one
+                }
+
+                var integer = typeof(TInteger);
+
+                try
+                {
+                    var enumParam = Expression.Parameter(@enum, "value");
+                    var integerParam = Expression.Parameter(integer, "value");
+                    var underlying = @enum.GetEnumUnderlyingType();
+
+                    var enumConv = (Expression)Expression.Convert(enumParam, underlying);
+                    if (underlying != integer) enumConv = Convert(enumConv, integer);
+
+                    var integerConv = underlying == integer
+                        ? integerParam
+                        : Convert(integerParam, underlying);
+                    integerConv = Expression.Convert(integerConv, @enum);
+
+                    ConvertTo = Expression.Lambda<Func<TEnum, TInteger>>(enumConv, enumParam).Compile();
+                    ConvertFrom = Expression.Lambda<Func<TInteger, TEnum>>(integerConv, integerParam).Compile();
+                }
+                catch (Exception e)
+                {
+                    ConvertTo = _ => throw e;
+                    ConvertFrom = _ => throw e;
+                }
+            }
+
+            private static Expression Convert(Expression value, Type type) => _isChecked
+                ? Expression.ConvertChecked(value, type)
+                : Expression.Convert(value, type);
+        }
+
+        #region Unchecked
+
+        /// <summary>
+        /// Converts the specified <typeparamref name="TEnum"/> into
+        /// a <see cref="ulong"/>.
+        /// </summary>
+        /// <remarks>
+        /// This method will fail if <typeparamref name="TEnum"/>
+        /// is not an enum.
+        /// </remarks>
+        /// <typeparam name="TEnum">The type of the enum.</typeparam>
+        /// <param name="value">The enum value to convert.</param>
+        /// <returns>The <see cref="ulong"/>.</returns>
+        public static ulong ToUInt64<TEnum>(TEnum value)
+            where TEnum : struct, IComparable, IConvertible, IFormattable
+            => Converter<TEnum, ulong, Unchecked>.ConvertTo(value);
+
+        /// <summary>
+        /// Converts the specified <see cref="ulong"/> into
+        /// a <typeparamref name="TEnum"/>.
+        /// </summary>
+        /// <remarks>
+        /// This method will fail if <typeparamref name="TEnum"/>
+        /// is not an enum.
+        /// </remarks>
+        /// <typeparam name="TEnum">The type of the enum.</typeparam>
+        /// <param name="value">The <see cref="ulong"/> to convert.</param>
+        /// <returns>The <typeparamref name="TEnum"/>.</returns>
+        public static TEnum ToEnum<TEnum>(ulong value)
+            where TEnum : struct, IComparable, IConvertible, IFormattable
+            => Converter<TEnum, ulong, Unchecked>.ConvertFrom(value);
+
+        /// <summary>
+        /// Converts the specified <typeparamref name="TEnum"/> into
+        /// a <see cref="long"/>.
+        /// </summary>
+        /// <remarks>
+        /// This method will fail if <typeparamref name="TEnum"/>
+        /// is not an enum.
+        /// </remarks>
+        /// <typeparam name="TEnum">The type of the enum.</typeparam>
+        /// <param name="value">The enum value to convert.</param>
+        /// <returns>The <see cref="long"/>.</returns>
+        public static long ToInt64<TEnum>(TEnum value)
+            where TEnum : struct, IComparable, IConvertible, IFormattable
+            => Converter<TEnum, long, Unchecked>.ConvertTo(value);
+
+        /// <summary>
+        /// Converts the specified <see cref="long"/> into
+        /// a <typeparamref name="TEnum"/>.
+        /// </summary>
+        /// <remarks>
+        /// This method will fail if <typeparamref name="TEnum"/>
+        /// is not an enum.
+        /// </remarks>
+        /// <typeparam name="TEnum">The type of the enum.</typeparam>
+        /// <param name="value">The <see cref="long"/> to convert.</param>
+        /// <returns>The <typeparamref name="TEnum"/>.</returns>
+        public static TEnum ToEnum<TEnum>(long value)
+            where TEnum : struct, IComparable, IConvertible, IFormattable
+            => Converter<TEnum, long, Unchecked>.ConvertFrom(value);
+
+        /// <summary>
+        /// Converts the specified <typeparamref name="TEnum"/> into
+        /// a <see cref="uint"/>.
+        /// </summary>
+        /// <remarks>
+        /// This method will fail if <typeparamref name="TEnum"/>
+        /// is not an enum.
+        /// </remarks>
+        /// <typeparam name="TEnum">The type of the enum.</typeparam>
+        /// <param name="value">The enum value to convert.</param>
+        /// <returns>The <see cref="uint"/>.</returns>
+        public static uint ToUInt32<TEnum>(TEnum value)
+            where TEnum : struct, IComparable, IConvertible, IFormattable
+            => Converter<TEnum, uint, Unchecked>.ConvertTo(value);
+
+        /// <summary>
+        /// Converts the specified <see cref="uint"/> into
+        /// a <typeparamref name="TEnum"/>.
+        /// </summary>
+        /// <remarks>
+        /// This method will fail if <typeparamref name="TEnum"/>
+        /// is not an enum.
+        /// </remarks>
+        /// <typeparam name="TEnum">The type of the enum.</typeparam>
+        /// <param name="value">The <see cref="uint"/> to convert.</param>
+        /// <returns>The <typeparamref name="TEnum"/>.</returns>
+        public static TEnum ToEnum<TEnum>(uint value)
+            where TEnum : struct, IComparable, IConvertible, IFormattable
+            => Converter<TEnum, uint, Unchecked>.ConvertFrom(value);
+
+        /// <summary>
+        /// Converts the specified <typeparamref name="TEnum"/> into
+        /// a <see cref="int"/>.
+        /// </summary>
+        /// <remarks>
+        /// This method will fail if <typeparamref name="TEnum"/>
+        /// is not an enum.
+        /// </remarks>
+        /// <typeparam name="TEnum">The type of the enum.</typeparam>
+        /// <param name="value">The enum value to convert.</param>
+        /// <returns>The <see cref="int"/>.</returns>
+        public static int ToInt32<TEnum>(TEnum value)
+            where TEnum : struct, IComparable, IConvertible, IFormattable
+            => Converter<TEnum, int, Unchecked>.ConvertTo(value);
+
+        /// <summary>
+        /// Converts the specified <see cref="int"/> into
+        /// a <typeparamref name="TEnum"/>.
+        /// </summary>
+        /// <remarks>
+        /// This method will fail if <typeparamref name="TEnum"/>
+        /// is not an enum.
+        /// </remarks>
+        /// <typeparam name="TEnum">The type of the enum.</typeparam>
+        /// <param name="value">The <see cref="int"/> to convert.</param>
+        /// <returns>The <typeparamref name="TEnum"/>.</returns>
+        public static TEnum ToEnum<TEnum>(int value)
+            where TEnum : struct, IComparable, IConvertible, IFormattable
+            => Converter<TEnum, int, Unchecked>.ConvertFrom(value);
+
+        /// <summary>
+        /// Converts the specified <typeparamref name="TEnum"/> into
+        /// a <see cref="ushort"/>.
+        /// </summary>
+        /// <remarks>
+        /// This method will fail if <typeparamref name="TEnum"/>
+        /// is not an enum.
+        /// </remarks>
+        /// <typeparam name="TEnum">The type of the enum.</typeparam>
+        /// <param name="value">The enum value to convert.</param>
+        /// <returns>The <see cref="ushort"/>.</returns>
+        public static ushort ToUInt16<TEnum>(TEnum value)
+            where TEnum : struct, IComparable, IConvertible, IFormattable
+            => Converter<TEnum, ushort, Unchecked>.ConvertTo(value);
+
+        /// <summary>
+        /// Converts the specified <see cref="ushort"/> into
+        /// a <typeparamref name="TEnum"/>.
+        /// </summary>
+        /// <remarks>
+        /// This method will fail if <typeparamref name="TEnum"/>
+        /// is not an enum.
+        /// </remarks>
+        /// <typeparam name="TEnum">The type of the enum.</typeparam>
+        /// <param name="value">The <see cref="ushort"/> to convert.</param>
+        /// <returns>The <typeparamref name="TEnum"/>.</returns>
+        public static TEnum ToEnum<TEnum>(ushort value)
+            where TEnum : struct, IComparable, IConvertible, IFormattable
+            => Converter<TEnum, ushort, Unchecked>.ConvertFrom(value);
+
+        /// <summary>
+        /// Converts the specified <typeparamref name="TEnum"/> into
+        /// a <see cref="short"/>.
+        /// </summary>
+        /// <remarks>
+        /// This method will fail if <typeparamref name="TEnum"/>
+        /// is not an enum.
+        /// </remarks>
+        /// <typeparam name="TEnum">The type of the enum.</typeparam>
+        /// <param name="value">The enum value to convert.</param>
+        /// <returns>The <see cref="short"/>.</returns>
+        public static short ToInt16<TEnum>(TEnum value)
+            where TEnum : struct, IComparable, IConvertible, IFormattable
+            => Converter<TEnum, short, Unchecked>.ConvertTo(value);
+
+        /// <summary>
+        /// Converts the specified <see cref="short"/> into
+        /// a <typeparamref name="TEnum"/>.
+        /// </summary>
+        /// <remarks>
+        /// This method will fail if <typeparamref name="TEnum"/>
+        /// is not an enum.
+        /// </remarks>
+        /// <typeparam name="TEnum">The type of the enum.</typeparam>
+        /// <param name="value">The <see cref="short"/> to convert.</param>
+        /// <returns>The <typeparamref name="TEnum"/>.</returns>
+        public static TEnum ToEnum<TEnum>(short value)
+            where TEnum : struct, IComparable, IConvertible, IFormattable
+            => Converter<TEnum, short, Unchecked>.ConvertFrom(value);
+
+        /// <summary>
+        /// Converts the specified <typeparamref name="TEnum"/> into
+        /// a <see cref="byte"/>.
+        /// </summary>
+        /// <remarks>
+        /// This method will fail if <typeparamref name="TEnum"/>
+        /// is not an enum.
+        /// </remarks>
+        /// <typeparam name="TEnum">The type of the enum.</typeparam>
+        /// <param name="value">The enum value to convert.</param>
+        /// <returns>The <see cref="byte"/>.</returns>
+        public static byte ToByte<TEnum>(TEnum value)
+            where TEnum : struct, IComparable, IConvertible, IFormattable
+            => Converter<TEnum, byte, Unchecked>.ConvertTo(value);
+
+        /// <summary>
+        /// Converts the specified <see cref="byte"/> into
+        /// a <typeparamref name="TEnum"/>.
+        /// </summary>
+        /// <remarks>
+        /// This method will fail if <typeparamref name="TEnum"/>
+        /// is not an enum.
+        /// </remarks>
+        /// <typeparam name="TEnum">The type of the enum.</typeparam>
+        /// <param name="value">The <see cref="byte"/> to convert.</param>
+        /// <returns>The <typeparamref name="TEnum"/>.</returns>
+        public static TEnum ToEnum<TEnum>(byte value)
+            where TEnum : struct, IComparable, IConvertible, IFormattable
+            => Converter<TEnum, byte, Unchecked>.ConvertFrom(value);
+
+        /// <summary>
+        /// Converts the specified <typeparamref name="TEnum"/> into
+        /// a <see cref="sbyte"/>.
+        /// </summary>
+        /// <remarks>
+        /// This method will fail if <typeparamref name="TEnum"/>
+        /// is not an enum.
+        /// </remarks>
+        /// <typeparam name="TEnum">The type of the enum.</typeparam>
+        /// <param name="value">The enum value to convert.</param>
+        /// <returns>The <see cref="sbyte"/>.</returns>
+        public static sbyte ToSByte<TEnum>(TEnum value)
+            where TEnum : struct, IComparable, IConvertible, IFormattable
+            => Converter<TEnum, sbyte, Unchecked>.ConvertTo(value);
+
+        /// <summary>
+        /// Converts the specified <see cref="sbyte"/> into
+        /// a <typeparamref name="TEnum"/>.
+        /// </summary>
+        /// <remarks>
+        /// This method will fail if <typeparamref name="TEnum"/>
+        /// is not an enum.
+        /// </remarks>
+        /// <typeparam name="TEnum">The type of the enum.</typeparam>
+        /// <param name="value">The <see cref="sbyte"/> to convert.</param>
+        /// <returns>The <typeparamref name="TEnum"/>.</returns>
+        public static TEnum ToEnum<TEnum>(sbyte value)
+            where TEnum : struct, IComparable, IConvertible, IFormattable
+            => Converter<TEnum, sbyte, Unchecked>.ConvertFrom(value);
+
+        #endregion
+
+        #region Checked
+
+        /// <summary>
+        /// Converts the specified <typeparamref name="TEnum"/> into
+        /// a <see cref="ulong"/>.
+        /// </summary>
+        /// <remarks>
+        /// This method will fail if the enum value is less than
+        /// <see cref="ulong.MinValue"/>, or if <typeparamref name="TEnum"/>
+        /// is not an enum.
+        /// </remarks>
+        /// <typeparam name="TEnum">The type of the enum.</typeparam>
+        /// <param name="value">The enum value to convert.</param>
+        /// <returns>The <see cref="ulong"/>.</returns>
+        public static ulong ToUInt64Checked<TEnum>(TEnum value)
+            where TEnum : struct, IComparable, IConvertible, IFormattable
+            => Converter<TEnum, ulong, Checked>.ConvertTo(value);
+
+        /// <summary>
+        /// Converts the specified <see cref="ulong"/> into
+        /// a <typeparamref name="TEnum"/>.
+        /// </summary>
+        /// <remarks>
+        /// This method will fail if the <paramref name="value"/> is outside
+        /// the range of valid values for the underlying type of
+        /// <typeparamref name="TEnum"/>, or if <typeparamref name="TEnum"/>
+        /// is not an enum.
+        /// </remarks>
+        /// <typeparam name="TEnum">The type of the enum.</typeparam>
+        /// <param name="value">The <see cref="ulong"/> to convert.</param>
+        /// <returns>The <typeparamref name="TEnum"/>.</returns>
+        public static TEnum ToEnumChecked<TEnum>(ulong value)
+            where TEnum : struct, IComparable, IConvertible, IFormattable
+            => Converter<TEnum, ulong, Checked>.ConvertFrom(value);
+
+        /// <summary>
+        /// Converts the specified <typeparamref name="TEnum"/> into
+        /// a <see cref="long"/>.
+        /// </summary>
+        /// <remarks>
+        /// This method will fail if the enum value is larger than
+        /// <see cref="long.MaxValue"/>, or if <typeparamref name="TEnum"/> is
+        /// not an enum.
+        /// </remarks>
+        /// <typeparam name="TEnum">The type of the enum.</typeparam>
+        /// <param name="value">The enum value to convert.</param>
+        /// <returns>The <see cref="long"/>.</returns>
+        public static long ToInt64Checked<TEnum>(TEnum value)
+            where TEnum : struct, IComparable, IConvertible, IFormattable
+            => Converter<TEnum, long, Checked>.ConvertTo(value);
+
+        /// <summary>
+        /// Converts the specified <see cref="long"/> into
+        /// a <typeparamref name="TEnum"/>.
+        /// </summary>
+        /// <remarks>
+        /// This method will fail if the <paramref name="value"/> is outside
+        /// the range of valid values for the underlying type of
+        /// <typeparamref name="TEnum"/>, or if <typeparamref name="TEnum"/>
+        /// is not an enum.
+        /// </remarks>
+        /// <typeparam name="TEnum">The type of the enum.</typeparam>
+        /// <param name="value">The <see cref="long"/> to convert.</param>
+        /// <returns>The <typeparamref name="TEnum"/>.</returns>
+        public static TEnum ToEnumChecked<TEnum>(long value)
+            where TEnum : struct, IComparable, IConvertible, IFormattable
+            => Converter<TEnum, long, Checked>.ConvertFrom(value);
+
+        /// <summary>
+        /// Converts the specified <typeparamref name="TEnum"/> into
+        /// a <see cref="uint"/>.
+        /// </summary>
+        /// <remarks>
+        /// This method will fail if the enum value is less than
+        /// <see cref="uint.MinValue"/> or larger than <see cref="uint.MaxValue"/>,
+        /// or if <typeparamref name="TEnum"/> is not an enum.
+        /// </remarks>
+        /// <typeparam name="TEnum">The type of the enum.</typeparam>
+        /// <param name="value">The enum value to convert.</param>
+        /// <returns>The <see cref="uint"/>.</returns>
+        public static uint ToUInt32Checked<TEnum>(TEnum value)
+            where TEnum : struct, IComparable, IConvertible, IFormattable
+            => Converter<TEnum, uint, Checked>.ConvertTo(value);
+
+        /// <summary>
+        /// Converts the specified <see cref="uint"/> into
+        /// a <typeparamref name="TEnum"/>.
+        /// </summary>
+        /// <remarks>
+        /// This method will fail if the <paramref name="value"/> is outside
+        /// the range of valid values for the underlying type of
+        /// <typeparamref name="TEnum"/>, or if <typeparamref name="TEnum"/>
+        /// is not an enum.
+        /// </remarks>
+        /// <typeparam name="TEnum">The type of the enum.</typeparam>
+        /// <param name="value">The <see cref="uint"/> to convert.</param>
+        /// <returns>The <typeparamref name="TEnum"/>.</returns>
+        public static TEnum ToEnumChecked<TEnum>(uint value)
+            where TEnum : struct, IComparable, IConvertible, IFormattable
+            => Converter<TEnum, uint, Checked>.ConvertFrom(value);
+
+        /// <summary>
+        /// Converts the specified <typeparamref name="TEnum"/> into
+        /// a <see cref="int"/>.
+        /// </summary>
+        /// <remarks>
+        /// This method will fail if the enum value is less than
+        /// <see cref="int.MinValue"/> or larger than <see cref="int.MaxValue"/>,
+        /// or if <typeparamref name="TEnum"/> is not an enum.
+        /// </remarks>
+        /// <typeparam name="TEnum">The type of the enum.</typeparam>
+        /// <param name="value">The enum value to convert.</param>
+        /// <returns>The <see cref="int"/>.</returns>
+        public static int ToInt32Checked<TEnum>(TEnum value)
+            where TEnum : struct, IComparable, IConvertible, IFormattable
+            => Converter<TEnum, int, Checked>.ConvertTo(value);
+
+        /// <summary>
+        /// Converts the specified <see cref="int"/> into
+        /// a <typeparamref name="TEnum"/>.
+        /// </summary>
+        /// <remarks>
+        /// This method will fail if the <paramref name="value"/> is outside
+        /// the range of valid values for the underlying type of
+        /// <typeparamref name="TEnum"/>, or if <typeparamref name="TEnum"/>
+        /// is not an enum.
+        /// </remarks>
+        /// <typeparam name="TEnum">The type of the enum.</typeparam>
+        /// <param name="value">The <see cref="int"/> to convert.</param>
+        /// <returns>The <typeparamref name="TEnum"/>.</returns>
+        public static TEnum ToEnumChecked<TEnum>(int value)
+            where TEnum : struct, IComparable, IConvertible, IFormattable
+            => Converter<TEnum, int, Checked>.ConvertFrom(value);
+
+        /// <summary>
+        /// Converts the specified <typeparamref name="TEnum"/> into
+        /// a <see cref="ushort"/>.
+        /// </summary>
+        /// <remarks>
+        /// This method will fail if the enum value is less than
+        /// <see cref="ushort.MinValue"/> or larger than <see cref="ushort.MaxValue"/>,
+        /// or if <typeparamref name="TEnum"/> is not an enum.
+        /// </remarks>
+        /// <typeparam name="TEnum">The type of the enum.</typeparam>
+        /// <param name="value">The enum value to convert.</param>
+        /// <returns>The <see cref="ushort"/>.</returns>
+        public static ushort ToUInt16Checked<TEnum>(TEnum value)
+            where TEnum : struct, IComparable, IConvertible, IFormattable
+            => Converter<TEnum, ushort, Checked>.ConvertTo(value);
+
+        /// <summary>
+        /// Converts the specified <see cref="ushort"/> into
+        /// a <typeparamref name="TEnum"/>.
+        /// </summary>
+        /// <remarks>
+        /// This method will fail if the <paramref name="value"/> is outside
+        /// the range of valid values for the underlying type of
+        /// <typeparamref name="TEnum"/>, or if <typeparamref name="TEnum"/>
+        /// is not an enum.
+        /// </remarks>
+        /// <typeparam name="TEnum">The type of the enum.</typeparam>
+        /// <param name="value">The <see cref="ushort"/> to convert.</param>
+        /// <returns>The <typeparamref name="TEnum"/>.</returns>
+        public static TEnum ConvertToEnumChecked<TEnum>(ushort value)
+            where TEnum : struct, IComparable, IConvertible, IFormattable
+            => Converter<TEnum, ushort, Checked>.ConvertFrom(value);
+
+        /// <summary>
+        /// Converts the specified <typeparamref name="TEnum"/> into
+        /// a <see cref="short"/>.
+        /// </summary>
+        /// <remarks>
+        /// This method will fail if the enum value is less than
+        /// <see cref="short.MinValue"/> or larger than <see cref="ushort.MaxValue"/>,
+        /// or if <typeparamref name="TEnum"/> is not an enum.
+        /// </remarks>
+        /// <typeparam name="TEnum">The type of the enum.</typeparam>
+        /// <param name="value">The enum value to convert.</param>
+        /// <returns>The <see cref="short"/>.</returns>
+        public static short ToInt16Checked<TEnum>(TEnum value)
+            where TEnum : struct, IComparable, IConvertible, IFormattable
+            => Converter<TEnum, short, Checked>.ConvertTo(value);
+
+        /// <summary>
+        /// Converts the specified <see cref="short"/> into
+        /// a <typeparamref name="TEnum"/>.
+        /// </summary>
+        /// <remarks>
+        /// This method will fail if the <paramref name="value"/> is outside
+        /// the range of valid values for the underlying type of
+        /// <typeparamref name="TEnum"/>, or if <typeparamref name="TEnum"/>
+        /// is not an enum.
+        /// </remarks>
+        /// <typeparam name="TEnum">The type of the enum.</typeparam>
+        /// <param name="value">The <see cref="short"/> to convert.</param>
+        /// <returns>The <typeparamref name="TEnum"/>.</returns>
+        public static TEnum ToEnumChecked<TEnum>(short value)
+            where TEnum : struct, IComparable, IConvertible, IFormattable
+            => Converter<TEnum, short, Checked>.ConvertFrom(value);
+
+        /// <summary>
+        /// Converts the specified <typeparamref name="TEnum"/> into
+        /// a <see cref="byte"/>.
+        /// </summary>
+        /// <remarks>
+        /// This method will fail if the enum value is less than
+        /// <see cref="byte.MinValue"/> or larger than <see cref="byte.MaxValue"/>,
+        /// or if <typeparamref name="TEnum"/> is not an enum.
+        /// </remarks>
+        /// <typeparam name="TEnum">The type of the enum.</typeparam>
+        /// <param name="value">The enum value to convert.</param>
+        /// <returns>The <see cref="byte"/>.</returns>
+        public static byte ToByteChecked<TEnum>(TEnum value)
+            where TEnum : struct, IComparable, IConvertible, IFormattable
+            => Converter<TEnum, byte, Checked>.ConvertTo(value);
+
+        /// <summary>
+        /// Converts the specified <see cref="byte"/> into
+        /// a <typeparamref name="TEnum"/>.
+        /// </summary>
+        /// <remarks>
+        /// This method will fail if the <paramref name="value"/> is outside
+        /// the range of valid values for the underlying type of
+        /// <typeparamref name="TEnum"/>, or if <typeparamref name="TEnum"/>
+        /// is not an enum.
+        /// </remarks>
+        /// <typeparam name="TEnum">The type of the enum.</typeparam>
+        /// <param name="value">The <see cref="byte"/> to convert.</param>
+        /// <returns>The <typeparamref name="TEnum"/>.</returns>
+        public static TEnum ToEnumChecked<TEnum>(byte value)
+            where TEnum : struct, IComparable, IConvertible, IFormattable
+            => Converter<TEnum, byte, Checked>.ConvertFrom(value);
+
+        /// <summary>
+        /// Converts the specified <typeparamref name="TEnum"/> into
+        /// a <see cref="sbyte"/>.
+        /// </summary>
+        /// <remarks>
+        /// This method will fail if the enum value is less than
+        /// <see cref="sbyte.MinValue"/> or larger than <see cref="sbyte.MaxValue"/>,
+        /// or if <typeparamref name="TEnum"/> is not an enum.
+        /// </remarks>
+        /// <typeparam name="TEnum">The type of the enum.</typeparam>
+        /// <param name="value">The enum value to convert.</param>
+        /// <returns>The <see cref="sbyte"/>.</returns>
+        public static sbyte ToSByteChecked<TEnum>(TEnum value)
+            where TEnum : struct, IComparable, IConvertible, IFormattable
+            => Converter<TEnum, sbyte, Checked>.ConvertTo(value);
+
+        /// <summary>
+        /// Converts the specified <see cref="sbyte"/> into
+        /// a <typeparamref name="TEnum"/>.
+        /// </summary>
+        /// <remarks>
+        /// This method will fail if the <paramref name="value"/> is outside
+        /// the range of valid values for the underlying type of
+        /// <typeparamref name="TEnum"/>, or if <typeparamref name="TEnum"/>
+        /// is not an enum.
+        /// </remarks>
+        /// <typeparam name="TEnum">The type of the enum.</typeparam>
+        /// <param name="value">The <see cref="sbyte"/> to convert.</param>
+        /// <returns>The <typeparamref name="TEnum"/>.</returns>
+        public static TEnum ToEnumChecked<TEnum>(sbyte value)
+            where TEnum : struct, IComparable, IConvertible, IFormattable
+            => Converter<TEnum, sbyte, Checked>.ConvertFrom(value);
+
+        #endregion
+    }
+}


### PR DESCRIPTION
Adding EnumConvert class that allows you to cast enums to integers. Both Checked and unchecked variants are provided. The C# `where Enum` trick is NOT used as it can crash the compiler.

Also renaming IBuilder to IOpenApiBuilder as this can conflict with interfaces from other assemblies easily.

Fixes #90.