### PR TITLE
OpenAPI JSON Serialization

### DIFF
--- a/src/SourceCode.Clay.OpenApi.Tests/DtoTests.cs
+++ b/src/SourceCode.Clay.OpenApi.Tests/DtoTests.cs
@@ -294,7 +294,7 @@ namespace SourceCode.Clay.OpenApi.Tests
         [Fact(DisplayName = nameof(Operation_Equals))]
         public static void Operation_Equals()
         {
-            var param = new Dictionary<ParameterKey, Referable<Parameter>>()
+            var param = new Dictionary<ParameterKey, Referable<ParameterBody>>()
             {
                 [new ParameterKey("param1", ParameterLocation.Header)] = "#/components/parameters/param1"
             };

--- a/src/SourceCode.Clay.OpenApi.Tests/SerializeTests.cs
+++ b/src/SourceCode.Clay.OpenApi.Tests/SerializeTests.cs
@@ -1,0 +1,794 @@
+#region License
+
+// Copyright (c) K2 Workflow (SourceCode Technology Holdings Inc.). All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+#endregion
+
+using SourceCode.Clay.OpenApi.Expressions;
+using SourceCode.Clay.OpenApi.Serialization;
+using System;
+using System.CodeDom.Compiler;
+using System.IO;
+using System.Json;
+using System.Net.Mail;
+using System.Net.Mime;
+using Xunit;
+
+namespace SourceCode.Clay.OpenApi.Tests
+{
+    public static class SerializeTests
+    {
+        #region Helpers
+
+        // Actually check that the values are correct when using this.
+
+#if DEBUG
+
+        private static string GenerateExpectedCode(JsonValue value)
+        {
+            using (var sw = new StringWriter())
+            using (var iw = new IndentedTextWriter(sw))
+            {
+                GenerateExpectedCode(value, iw);
+                return sw.ToString();
+            }
+        }
+
+        private static void GenerateExpectedCode(JsonValue value, IndentedTextWriter writer)
+        {
+            if (value == null)
+            {
+                writer.Write("null");
+            }
+            else if (value is JsonPrimitive)
+            {
+                writer.Write(value.ToString());
+            }
+            else if (value is JsonArray a)
+            {
+                if (a.Count == 0)
+                    writer.Write("new JsonArray()");
+                else
+                {
+                    writer.WriteLine("new JsonArray() {");
+                    writer.Indent++;
+
+                    for (var i = 0; i < a.Count; i++)
+                    {
+                        GenerateExpectedCode(a[i], writer);
+                        if (i == a.Count - 1) writer.WriteLine();
+                        else writer.WriteLine(",");
+                    }
+
+                    writer.Indent--;
+                    writer.Write("}");
+                }
+            }
+            else if (value is JsonObject o)
+            {
+                if (o.Count == 0)
+                    writer.Write("new JsonObject()");
+                else
+                {
+                    writer.WriteLine("new JsonObject() {");
+                    writer.Indent++;
+
+                    var first = true;
+                    foreach (var item in o)
+                    {
+                        if (!first) writer.WriteLine(",");
+                        first = false;
+
+                        writer.Write("[ ");
+                        GenerateExpectedCode(item.Key, writer);
+                        writer.Write(" ] = ");
+
+                        GenerateExpectedCode(item.Value, writer);
+                    }
+
+                    writer.WriteLine();
+                    writer.Indent--;
+                    writer.Write("}");
+                }
+            }
+        }
+
+#endif
+
+        #endregion
+
+        #region Methods
+
+        [Fact(DisplayName = nameof(OpenApiSerializer_Serialize))]
+        public static void OpenApiSerializer_Serialize()
+        {
+            var sut = new OpenApiSerializer();
+
+            #region Graph
+
+            var actualGraphBuilder = new DocumentBuilder()
+            {
+                Components = new ComponentsBuilder()
+                {
+                    Callbacks =
+                    {
+                        [ "callback1" ] = new CallbackBuilder()
+                        {
+                            [ CompoundExpression.Parse("http://foo{$statusCode}") ] = new PathBuilder()
+                            {
+                                Description = "path1",
+                                Delete = new OperationBuilder()
+                                {
+                                    Callbacks =
+                                    {
+                                        [ "callback1" ] = "#/components/callbacks/callback1"
+                                    },
+                                    Description = "Delete operation",
+                                    ExternalDocumentation = new ExternalDocumentationBuilder()
+                                    {
+                                        Description = "External docs 1",
+                                        Url = new Uri("http://example.org")
+                                    },
+                                    OperationIdentifier = "Operation 1",
+                                    Options = OperationOptions.Deprecated,
+                                    Parameters =
+                                    {
+                                        [ new ParameterKey("p1") ] = "#/components/parameters/parameter1"
+                                    },
+                                    RequestBody = "#/components/requestBodies/requestBody1",
+                                    Responses =
+                                    {
+                                        [ResponseKey.Default] = "#/components/responses/response1"
+                                    },
+                                    Summary = "Delete operation summary"
+                                },
+                                Get = new OperationBuilder()
+                                {
+                                    Description = "Get"
+                                },
+                                Head = new OperationBuilder()
+                                {
+                                    Description = "Head"
+                                },
+                                Options = new OperationBuilder()
+                                {
+                                    Description = "Options"
+                                },
+                                Parameters =
+                                {
+                                    [ new ParameterKey("p1") ] = "#/components/parameters/parameter1"
+                                },
+                                Patch = new OperationBuilder()
+                                {
+                                    Description = "Patch"
+                                },
+                                Post = new OperationBuilder()
+                                {
+                                    Description = "Post"
+                                },
+                                Put = new OperationBuilder()
+                                {
+                                    Description = "Put"
+                                },
+                                Summary = "Summary",
+                                Trace = new OperationBuilder()
+                                {
+                                    Description = "Trace"
+                                }
+                            }
+                        }
+                    },
+                    Examples =
+                    {
+                        [ "example1" ] = new ExampleBuilder()
+                        {
+                            Description = "Description",
+                            ExternalValue = new Uri("http://example.org/example"),
+                            Summary = "Summary"
+                        }
+                    },
+                    Headers =
+                    {
+                        [ "header1" ] = new ParameterBodyBuilder()
+                        {
+                            Content =
+                            {
+                                [ new ContentType("application/json") ] = new MediaTypeBuilder()
+                                {
+                                    Encoding =
+                                    {
+                                        [ "header1" ] = new PropertyEncodingBuilder()
+                                        {
+                                            ContentType = new ContentType("application/json"),
+                                            Headers =
+                                            {
+                                                [ "header1" ] = "#/components/headers/header1"
+                                            },
+                                            Options = PropertyEncodingOptions.AllowReserved | PropertyEncodingOptions.Explode,
+                                            Style = ParameterStyle.DeepObject
+                                        }
+                                    },
+                                    Examples =
+                                    {
+                                        [ "Main Example" ] = "#/components/examples/example1"
+                                    },
+                                    Schema = "#/components/schemas/schema1"
+                                }
+                            }
+                        }
+                    },
+                    Links =
+                    {
+                        [ "link1" ] = new LinkBuilder()
+                        {
+                            Description = "Description",
+                            OperationIdentifier = "operation1",
+                            OperationReference = "http://example.org/#/operation1",
+                            Server = new ServerBuilder()
+                            {
+                                Description = "Description",
+                                Url = new Uri("http://example.org"),
+                                Variables =
+                                {
+                                    [ "variable1" ] = new ServerVariableBuilder()
+                                    {
+                                        Default = "Value",
+                                        Description = "Description",
+                                        Enum =
+                                        {
+                                            "Value", "Value1"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    Parameters =
+                    {
+                        [ "parameter1" ] = new ParameterBuilder()
+                        {
+                            Content =
+                            {
+                                [ new ContentType("application/json")] = new MediaTypeBuilder()
+                                {
+                                    Schema = "#/components/schemas/schema1"
+                                }
+                            },
+                            Description = "Description",
+                            Examples =
+                            {
+                                [ new ContentType("application/json") ] = "#/components/examples/example1"
+                            },
+                            Location = ParameterLocation.Header,
+                            Name = "parameter1",
+                            Options = ParameterOptions.AllowEmptyValue | ParameterOptions.AllowReserved | ParameterOptions.Deprecated | ParameterOptions.Explode | ParameterOptions.Required,
+                            Schema = "#/components/schemas/schema1",
+                            Style = ParameterStyle.Matrix
+                        }
+                    },
+                    RequestBodies =
+                    {
+                        [ "requestbody1" ] = new RequestBodyBuilder()
+                        {
+                            Content =
+                            {
+                                [ new ContentType("application/json" )] = new MediaTypeBuilder()
+                                {
+                                    Schema = "#/components/schemas/schema1"
+                                }
+                            },
+                            Description = "Description",
+                            Options = RequestBodyOptions.Required
+                        }
+                    },
+                    Responses =
+                    {
+                        [ "response1" ] = new ResponseBuilder()
+                        {
+                            Content =
+                            {
+                                [ new ContentType("application/json") ] = new MediaTypeBuilder()
+                                {
+                                    Schema = "#/components/schemas/schema1"
+                                }
+                            },
+                            Description = "Description",
+                            Headers =
+                            {
+                                [ "header1" ] = "#/components/headers/header1"
+                            },
+                            Links =
+                            {
+                                [ "link1" ] = "#/components/links/link1"
+                            }
+                        }
+                    },
+                    Schemas =
+                    {
+                        [ "schema1" ] = new SchemaBuilder()
+                        {
+                            AdditionalProperties =
+                            {
+                                [ "prop1" ] = "#/components/schemas/schema1"
+                            },
+                            Description = "Description",
+                            ExternalDocumentation = new ExternalDocumentationBuilder()
+                            {
+                                Description = "Description",
+                                Url = new Uri("http://example.org/docs")
+                            },
+                            Format = "Format",
+                            Items = "#/components/schemas/schema1",
+                            ItemsRange = new CountRange(100, 200, RangeOptions.Inclusive),
+                            LengthRange = new CountRange(200, 300, RangeOptions.Exclusive),
+                            NumberRange = new NumberRange(300, 400, RangeOptions.Exclusive),
+                            Options = SchemaOptions.Deprecated | SchemaOptions.Nullable | SchemaOptions.Required | SchemaOptions.UniqueItems,
+                            Pattern = "[a-z]",
+                            Properties =
+                            {
+                                [ "prop1" ] = "#/components/schemas/schema1"
+                            },
+                            PropertiesRange = new CountRange(100, 200),
+                            Title = "Schema1",
+                            Type = SchemaType.Object
+                        }
+                    },
+                    SecuritySchemes =
+                    {
+                        [ "sec1" ] = new HttpSecuritySchemeBuilder()
+                        {
+                            BearerFormat = "Bearer",
+                            Description = "Description",
+                            Scheme = "Schema"
+                        },
+                        [ "sec2" ] = new ApiKeySecuritySchemeBuilder()
+                        {
+                            Description = "Description",
+                            Location = ParameterLocation.Cookie,
+                            Name = "Name"
+                        },
+                        [ "sec3" ] = new OpenIdConnectSecuritySchemeBuilder()
+                        {
+                            Description = "Description",
+                            Url = new Uri("http://example.org/openid")
+                        },
+                        [ "sec4" ] = new OAuth2SecuritySchemeBuilder()
+                        {
+                            AuthorizationCodeFlow = new OAuthFlowBuilder()
+                            {
+                                AuthorizationUrl = new Uri("http://example.org/auth/auth"),
+                                RefreshUrl = new Uri("http://example.org/auth/refresh"),
+                                TokenUrl = new Uri("http://example.org/auth/token"),
+                                Scopes =
+                                {
+                                    [ "user:details" ] = "Get the user details"
+                                }
+                            },
+                            ClientCredentialsFlow = new OAuthFlowBuilder()
+                            {
+                                AuthorizationUrl = new Uri("http://example.org/cli/auth")
+                            },
+                            Description = "Description",
+                            ImplicitFlow = new OAuthFlowBuilder()
+                            {
+                                AuthorizationUrl = new Uri("http://example.org/imp/auth")
+                            },
+                            PasswordFlow = new OAuthFlowBuilder()
+                            {
+                                AuthorizationUrl = new Uri("http://example.org/pwd/auth")
+                            }
+                        }
+                    }
+                },
+                ExternalDocumentation = new ExternalDocumentationBuilder()
+                {
+                    Description = "Description",
+                    Url = new Uri("http://example.org/docs")
+                },
+                Info = new InformationBuilder()
+                {
+                    Contact = new ContactBuilder()
+                    {
+                        Email = new MailAddress("jonathan@example.org"),
+                        Name = "Jonathan",
+                        Url = new Uri("http://example.org/jonathan")
+                    },
+                    Description = "Description",
+                    License = new LicenseBuilder()
+                    {
+                        Name = "MIT",
+                        Url = new Uri("https://opensource.org/licenses/MIT")
+                    },
+                    TermsOfService = new Uri("http://example.org/tos"),
+                    Title = "Title",
+                    Version = new SemanticVersion(1, 2, 3, "pre1", "build1")
+                },
+                Version = new SemanticVersion(3, 0, 1),
+                Paths =
+                {
+                    [ "path1" ] = new PathBuilder()
+                    {
+                        Description = "Description"
+                    }
+                },
+                Security =
+                {
+                    "#/components/security/sec1"
+                }
+            };
+
+            var actualJson = sut.Serialize(actualGraphBuilder.Build());
+
+            #endregion
+
+            #region JSON
+
+            var expectedJson = new JsonObject()
+            {
+                ["components"] = new JsonObject()
+                {
+                    ["callbacks"] = new JsonObject()
+                    {
+                        ["callback1"] = new JsonObject()
+                        {
+                            ["http://foo{$statusCode}"] = new JsonObject()
+                            {
+                                ["delete"] = new JsonObject()
+                                {
+                                    ["callbacks"] = new JsonObject()
+                                    {
+                                        ["callback1"] = new JsonObject()
+                                        {
+                                            ["$ref"] = "#/components/callbacks/callback1"
+                                        }
+                                    },
+                                    ["deprecated"] = true,
+                                    ["description"] = "Delete operation",
+                                    ["externalDocs"] = new JsonObject()
+                                    {
+                                        ["description"] = "External docs 1",
+                                        ["url"] = "http://example.org/"
+                                    },
+                                    ["operationId"] = "Operation 1",
+                                    ["parameters"] = new JsonArray() {
+                                        "#/components/parameters/parameter1"
+                                    },
+                                    ["requestBody"] = "#/components/requestBodies/requestBody1",
+                                    ["responses"] = new JsonObject()
+                                    {
+                                        ["default"] = new JsonObject()
+                                        {
+                                            ["$ref"] = "#/components/responses/response1"
+                                        }
+                                    },
+                                    ["summary"] = "Delete operation summary"
+                                },
+                                ["description"] = "path1",
+                                ["get"] = new JsonObject()
+                                {
+                                    ["description"] = "Get"
+                                },
+                                ["head"] = new JsonObject()
+                                {
+                                    ["description"] = "Head"
+                                },
+                                ["options"] = new JsonObject()
+                                {
+                                    ["description"] = "Options"
+                                },
+                                ["parameters"] = new JsonArray() {
+                                    "#/components/parameters/parameter1"
+                                },
+                                ["patch"] = new JsonObject()
+                                {
+                                    ["description"] = "Patch"
+                                },
+                                ["post"] = new JsonObject()
+                                {
+                                    ["description"] = "Post"
+                                },
+                                ["put"] = new JsonObject()
+                                {
+                                    ["description"] = "Put"
+                                },
+                                ["summary"] = "Summary",
+                                ["trace"] = new JsonObject()
+                                {
+                                    ["description"] = "Trace"
+                                }
+                            }
+                        }
+                    },
+                    ["examples"] = new JsonObject()
+                    {
+                        ["example1"] = new JsonObject()
+                        {
+                            ["description"] = "Description",
+                            ["externalValue"] = "http://example.org/example",
+                            ["summary"] = "Summary"
+                        }
+                    },
+                    ["headers"] = new JsonObject()
+                    {
+                        ["header1"] = new JsonObject()
+                        {
+                            ["content"] = new JsonObject()
+                            {
+                                ["application/json"] = new JsonObject()
+                                {
+                                    ["encoding"] = new JsonObject()
+                                    {
+                                        ["header1"] = new JsonObject()
+                                        {
+                                            ["allowReserved"] = true,
+                                            ["contentType"] = "application/json",
+                                            ["explode"] = true,
+                                            ["headers"] = new JsonObject()
+                                            {
+                                                ["header1"] = new JsonObject()
+                                                {
+                                                    ["$ref"] = "#/components/headers/header1"
+                                                }
+                                            },
+                                            ["style"] = "deepObject"
+                                        }
+                                    },
+                                    ["examples"] = new JsonObject()
+                                    {
+                                        ["Main Example"] = new JsonObject()
+                                        {
+                                            ["$ref"] = "#/components/examples/example1"
+                                        }
+                                    },
+                                    ["schema"] = "#/components/schemas/schema1"
+                                }
+                            }
+                        }
+                    },
+                    ["links"] = new JsonObject()
+                    {
+                        ["link1"] = new JsonObject()
+                        {
+                            ["description"] = "Description",
+                            ["operationId"] = "operation1",
+                            ["operationRef"] = "http://example.org/#/operation1",
+                            ["server"] = new JsonObject()
+                            {
+                                ["description"] = "Description",
+                                ["url"] = "http://example.org/",
+                                ["variables"] = new JsonObject()
+                                {
+                                    ["variable1"] = new JsonObject()
+                                    {
+                                        ["default"] = "Value",
+                                        ["description"] = "Description",
+                                        ["enum"] = new JsonArray() {
+                                            "Value",
+                                            "Value1"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    ["parameters"] = new JsonObject()
+                    {
+                        ["parameter1"] = new JsonObject()
+                        {
+                            ["allowEmptyValue"] = true,
+                            ["allowReserved"] = true,
+                            ["content"] = new JsonObject()
+                            {
+                                ["application/json"] = new JsonObject()
+                                {
+                                    ["schema"] = "#/components/schemas/schema1"
+                                }
+                            },
+                            ["deprecated"] = true,
+                            ["description"] = "Description",
+                            ["examples"] = new JsonObject()
+                            {
+                                ["application/json"] = new JsonObject()
+                                {
+                                    ["$ref"] = "#/components/examples/example1"
+                                }
+                            },
+                            ["explode"] = true,
+                            ["in"] = "header",
+                            ["name"] = "parameter1",
+                            ["required"] = true,
+                            ["schema"] = "#/components/schemas/schema1",
+                            ["style"] = "matrix"
+                        }
+                    },
+                    ["requestBodies"] = new JsonObject()
+                    {
+                        ["requestbody1"] = new JsonObject()
+                        {
+                            ["content"] = new JsonObject()
+                            {
+                                ["application/json"] = new JsonObject()
+                                {
+                                    ["schema"] = "#/components/schemas/schema1"
+                                }
+                            },
+                            ["description"] = "Description",
+                            ["requestBodies"] = true
+                        }
+                    },
+                    ["responses"] = new JsonObject()
+                    {
+                        ["response1"] = new JsonObject()
+                        {
+                            ["content"] = new JsonObject()
+                            {
+                                ["application/json"] = new JsonObject()
+                                {
+                                    ["schema"] = "#/components/schemas/schema1"
+                                }
+                            },
+                            ["description"] = "Description",
+                            ["headers"] = new JsonObject()
+                            {
+                                ["header1"] = new JsonObject()
+                                {
+                                    ["$ref"] = "#/components/headers/header1"
+                                }
+                            },
+                            ["links"] = new JsonObject()
+                            {
+                                ["link1"] = new JsonObject()
+                                {
+                                    ["$ref"] = "#/components/links/link1"
+                                }
+                            }
+                        }
+                    },
+                    ["schemas"] = new JsonObject()
+                    {
+                        ["schema1"] = new JsonObject()
+                        {
+                            ["additionalProperties"] = new JsonObject()
+                            {
+                                ["prop1"] = new JsonObject()
+                                {
+                                    ["$ref"] = "#/components/schemas/schema1"
+                                }
+                            },
+                            ["deprecated"] = true,
+                            ["description"] = "Description",
+                            ["exclusiveMaximum"] = true,
+                            ["exclusiveMinimum"] = true,
+                            ["externalDocs"] = new JsonObject()
+                            {
+                                ["description"] = "Description",
+                                ["url"] = "http://example.org/docs"
+                            },
+                            ["format"] = "Format",
+                            ["items"] = "#/components/schemas/schema1",
+                            ["maxLength"] = 300,
+                            ["maxProperties"] = 200,
+                            ["maximum"] = 400,
+                            ["minLength"] = 200,
+                            ["minProperties"] = 100,
+                            ["minimum"] = 300,
+                            ["nullable"] = true,
+                            ["pattern"] = "[a-z]",
+                            ["properties"] = new JsonObject()
+                            {
+                                ["prop1"] = new JsonObject()
+                                {
+                                    ["$ref"] = "#/components/schemas/schema1"
+                                }
+                            },
+                            ["required"] = true,
+                            ["title"] = "Schema1",
+                            ["type"] = "object",
+                            ["uniqueItems"] = true
+                        }
+                    },
+                    ["securitySchemes"] = new JsonObject()
+                    {
+                        ["sec1"] = new JsonObject()
+                        {
+                            ["bearerFormat"] = "Bearer",
+                            ["description"] = "Description",
+                            ["scheme"] = "Schema",
+                            ["type"] = "http"
+                        },
+                        ["sec2"] = new JsonObject()
+                        {
+                            ["description"] = "Description",
+                            ["in"] = "cookie",
+                            ["name"] = "Name",
+                            ["type"] = "apiKey"
+                        },
+                        ["sec3"] = new JsonObject()
+                        {
+                            ["description"] = "Description",
+                            ["openIdConnectUrl"] = "http://example.org/openid",
+                            ["type"] = "openIdConnect"
+                        },
+                        ["sec4"] = new JsonObject()
+                        {
+                            ["description"] = "Description",
+                            ["flows"] = new JsonObject()
+                            {
+                                ["authorizationCode"] = new JsonObject()
+                                {
+                                    ["authorizationUrl"] = "http://example.org/auth/auth",
+                                    ["refreshUrl"] = "http://example.org/auth/refresh",
+                                    ["scopes"] = new JsonObject()
+                                    {
+                                        ["user:details"] = "Get the user details"
+                                    },
+                                    ["tokenUrl"] = "http://example.org/auth/token"
+                                },
+                                ["clientCredentials"] = new JsonObject()
+                                {
+                                    ["authorizationUrl"] = "http://example.org/cli/auth",
+                                    ["tokenUrl"] = null
+                                },
+                                ["implicit"] = new JsonObject()
+                                {
+                                    ["authorizationUrl"] = "http://example.org/imp/auth",
+                                    ["tokenUrl"] = null
+                                },
+                                ["password"] = new JsonObject()
+                                {
+                                    ["authorizationUrl"] = "http://example.org/pwd/auth",
+                                    ["tokenUrl"] = null
+                                }
+                            },
+                            ["type"] = "oauth2"
+                        }
+                    }
+                },
+                ["externalDocs"] = new JsonObject()
+                {
+                    ["description"] = "Description",
+                    ["url"] = "http://example.org/docs"
+                },
+                ["info"] = new JsonObject()
+                {
+                    ["contact"] = new JsonObject()
+                    {
+                        ["email"] = "jonathan@example.org",
+                        ["name"] = "Jonathan",
+                        ["url"] = "http://example.org/jonathan"
+                    },
+                    ["description"] = "Description",
+                    ["license"] = new JsonObject()
+                    {
+                        ["name"] = "MIT",
+                        ["url"] = "https://opensource.org/licenses/MIT"
+                    },
+                    ["termsOfService"] = "http://example.org/tos",
+                    ["title"] = "Title",
+                    ["version"] = "1.2.3-pre1+build1"
+                },
+                ["openapi"] = "3.0.1",
+                ["paths"] = new JsonObject()
+                {
+                    ["path1"] = new JsonObject()
+                    {
+                        ["description"] = "Description"
+                    }
+                },
+                ["security"] = new JsonArray()
+                {
+                    new JsonObject() {
+                        [ "$ref" ] = "#/components/security/sec1"
+                    }
+                }
+            };
+
+            #endregion
+
+            Assert.Equal(expectedJson.ToString(), actualJson.ToString());
+        }
+
+        #endregion
+    }
+}

--- a/src/SourceCode.Clay.OpenApi/Builders/ApiKeySecuritySchemeBuilder.cs
+++ b/src/SourceCode.Clay.OpenApi/Builders/ApiKeySecuritySchemeBuilder.cs
@@ -55,6 +55,10 @@ namespace SourceCode.Clay.OpenApi
 
         public static implicit operator ApiKeySecurityScheme(ApiKeySecuritySchemeBuilder builder) => builder?.Build();
 
+        public static implicit operator Referable<ApiKeySecurityScheme>(ApiKeySecuritySchemeBuilder builder) => builder?.Build();
+
+        public static implicit operator Referable<SecurityScheme>(ApiKeySecuritySchemeBuilder builder) => builder?.Build();
+
         public static implicit operator ApiKeySecuritySchemeBuilder(ApiKeySecurityScheme value) => ReferenceEquals(value, null) ? null : new ApiKeySecuritySchemeBuilder(value);
 
         /// <summary>

--- a/src/SourceCode.Clay.OpenApi/Builders/CallbackBuilder.cs
+++ b/src/SourceCode.Clay.OpenApi/Builders/CallbackBuilder.cs
@@ -101,6 +101,8 @@ namespace SourceCode.Clay.OpenApi
 
         public static implicit operator Callback(CallbackBuilder builder) => builder?.Build();
 
+        public static implicit operator Referable<Callback>(CallbackBuilder builder) => builder?.Build();
+
         public static implicit operator CallbackBuilder(Callback value) => ReferenceEquals(value, null) ? null : new CallbackBuilder(value);
 
         /// <summary>

--- a/src/SourceCode.Clay.OpenApi/Builders/ComponentsBuilder.cs
+++ b/src/SourceCode.Clay.OpenApi/Builders/ComponentsBuilder.cs
@@ -74,15 +74,15 @@ namespace SourceCode.Clay.OpenApi
         /// </summary>
         public ComponentsBuilder()
         {
-            Schemas = new Dictionary<string, Referable<Schema>>();
-            Responses = new Dictionary<string, Referable<Response>>();
-            Parameters = new Dictionary<string, Referable<Parameter>>();
-            Examples = new Dictionary<string, Referable<Example>>();
-            RequestBodies = new Dictionary<string, Referable<RequestBody>>();
-            Headers = new Dictionary<string, Referable<ParameterBody>>();
-            SecuritySchemes = new Dictionary<string, Referable<SecurityScheme>>();
-            Links = new Dictionary<string, Referable<Link>>();
-            Callbacks = new Dictionary<string, Referable<Callback>>();
+            Schemas = new Dictionary<string, Referable<Schema>>(ComponentKeyStringComparer.ComponentKey);
+            Responses = new Dictionary<string, Referable<Response>>(ComponentKeyStringComparer.ComponentKey);
+            Parameters = new Dictionary<string, Referable<Parameter>>(ComponentKeyStringComparer.ComponentKey);
+            Examples = new Dictionary<string, Referable<Example>>(ComponentKeyStringComparer.ComponentKey);
+            RequestBodies = new Dictionary<string, Referable<RequestBody>>(ComponentKeyStringComparer.ComponentKey);
+            Headers = new Dictionary<string, Referable<ParameterBody>>(ComponentKeyStringComparer.ComponentKey);
+            SecuritySchemes = new Dictionary<string, Referable<SecurityScheme>>(ComponentKeyStringComparer.ComponentKey);
+            Links = new Dictionary<string, Referable<Link>>(ComponentKeyStringComparer.ComponentKey);
+            Callbacks = new Dictionary<string, Referable<Callback>>(ComponentKeyStringComparer.ComponentKey);
         }
 
         /// <summary>

--- a/src/SourceCode.Clay.OpenApi/Builders/ExampleBuilder.cs
+++ b/src/SourceCode.Clay.OpenApi/Builders/ExampleBuilder.cs
@@ -61,6 +61,8 @@ namespace SourceCode.Clay.OpenApi
 
         public static implicit operator Example(ExampleBuilder builder) => builder?.Build();
 
+        public static implicit operator Referable<Example>(ExampleBuilder builder) => builder?.Build();
+
         public static implicit operator ExampleBuilder(Example value) => ReferenceEquals(value, null) ? null : new ExampleBuilder(value);
 
         /// <summary>

--- a/src/SourceCode.Clay.OpenApi/Builders/HttpSecuritySchemeBuilder.cs
+++ b/src/SourceCode.Clay.OpenApi/Builders/HttpSecuritySchemeBuilder.cs
@@ -55,6 +55,10 @@ namespace SourceCode.Clay.OpenApi
 
         public static implicit operator HttpSecurityScheme(HttpSecuritySchemeBuilder builder) => builder?.Build();
 
+        public static implicit operator Referable<HttpSecurityScheme>(HttpSecuritySchemeBuilder builder) => builder?.Build();
+
+        public static implicit operator Referable<SecurityScheme>(HttpSecuritySchemeBuilder builder) => builder?.Build();
+
         public static implicit operator HttpSecuritySchemeBuilder(HttpSecurityScheme value) => ReferenceEquals(value, null) ? null : new HttpSecuritySchemeBuilder(value);
 
         /// <summary>

--- a/src/SourceCode.Clay.OpenApi/Builders/LinkBuilder.cs
+++ b/src/SourceCode.Clay.OpenApi/Builders/LinkBuilder.cs
@@ -69,6 +69,8 @@ namespace SourceCode.Clay.OpenApi
 
         public static implicit operator Link(LinkBuilder builder) => builder?.Build();
 
+        public static implicit operator Referable<Link>(LinkBuilder builder) => builder?.Build();
+
         public static implicit operator LinkBuilder(Link value) => ReferenceEquals(value, null) ? null : new LinkBuilder(value);
 
         /// <summary>

--- a/src/SourceCode.Clay.OpenApi/Builders/OAuth2SecuritySchemeBuilder.cs
+++ b/src/SourceCode.Clay.OpenApi/Builders/OAuth2SecuritySchemeBuilder.cs
@@ -67,6 +67,10 @@ namespace SourceCode.Clay.OpenApi
 
         public static implicit operator OAuth2SecurityScheme(OAuth2SecuritySchemeBuilder builder) => builder?.Build();
 
+        public static implicit operator Referable<OAuth2SecurityScheme>(OAuth2SecuritySchemeBuilder builder) => builder?.Build();
+
+        public static implicit operator Referable<SecurityScheme>(OAuth2SecuritySchemeBuilder builder) => builder?.Build();
+
         public static implicit operator OAuth2SecuritySchemeBuilder(OAuth2SecurityScheme value) => ReferenceEquals(value, null) ? null : new OAuth2SecuritySchemeBuilder(value);
 
         /// <summary>

--- a/src/SourceCode.Clay.OpenApi/Builders/OpenIdConnectSecuritySchemeBuilder.cs
+++ b/src/SourceCode.Clay.OpenApi/Builders/OpenIdConnectSecuritySchemeBuilder.cs
@@ -49,6 +49,10 @@ namespace SourceCode.Clay.OpenApi
 
         public static implicit operator OpenIdConnectSecurityScheme(OpenIdConnectSecuritySchemeBuilder builder) => builder?.Build();
 
+        public static implicit operator Referable<OpenIdConnectSecurityScheme>(OpenIdConnectSecuritySchemeBuilder builder) => builder?.Build();
+
+        public static implicit operator Referable<SecurityScheme>(OpenIdConnectSecuritySchemeBuilder builder) => builder?.Build();
+
         public static implicit operator OpenIdConnectSecuritySchemeBuilder(OpenIdConnectSecurityScheme value) => ReferenceEquals(value, null) ? null : new OpenIdConnectSecuritySchemeBuilder(value);
 
         /// <summary>

--- a/src/SourceCode.Clay.OpenApi/Builders/OperationBuilder.cs
+++ b/src/SourceCode.Clay.OpenApi/Builders/OperationBuilder.cs
@@ -49,7 +49,7 @@ namespace SourceCode.Clay.OpenApi
         /// <summary>
         /// Gets the list of parameters that are applicable for this operation.
         /// </summary>
-        public IDictionary<ParameterKey, Referable<Parameter>> Parameters { get; }
+        public IDictionary<ParameterKey, Referable<ParameterBody>> Parameters { get; }
 
         /// <summary>
         /// Gets or sets the request body applicable for this operation.
@@ -91,7 +91,7 @@ namespace SourceCode.Clay.OpenApi
         public OperationBuilder()
         {
             Tags = new List<string>();
-            Parameters = new Dictionary<ParameterKey, Referable<Parameter>>();
+            Parameters = new Dictionary<ParameterKey, Referable<ParameterBody>>();
             Responses = new Dictionary<ResponseKey, Referable<Response>>();
             Callbacks = new Dictionary<string, Referable<Callback>>();
             Security = new List<SecurityScheme>();
@@ -110,7 +110,7 @@ namespace SourceCode.Clay.OpenApi
             Description = value.Description;
             ExternalDocumentation = value.ExternalDocumentation;
             OperationIdentifier = value.OperationIdentifier;
-            Parameters = new Dictionary<ParameterKey, Referable<Parameter>>(value.Parameters);
+            Parameters = new Dictionary<ParameterKey, Referable<ParameterBody>>(value.Parameters);
             RequestBody = value.RequestBody;
             Responses = new Dictionary<ResponseKey, Referable<Response>>(value.Responses);
             Callbacks = new Dictionary<string, Referable<Callback>>(value.Callbacks);
@@ -137,7 +137,7 @@ namespace SourceCode.Clay.OpenApi
             description: Description,
             externalDocumentation: ExternalDocumentation,
             operationIdentifier: OperationIdentifier,
-            parameters: new ReadOnlyDictionary<ParameterKey, Referable<Parameter>>(Parameters),
+            parameters: new ReadOnlyDictionary<ParameterKey, Referable<ParameterBody>>(Parameters),
             requestBody: RequestBody,
             responses: new ReadOnlyDictionary<ResponseKey, Referable<Response>>(Responses),
             callbacks: new ReadOnlyDictionary<string, Referable<Callback>>(Callbacks),

--- a/src/SourceCode.Clay.OpenApi/Builders/ParameterBodyBuilder.cs
+++ b/src/SourceCode.Clay.OpenApi/Builders/ParameterBodyBuilder.cs
@@ -86,6 +86,8 @@ namespace SourceCode.Clay.OpenApi
 
         public static implicit operator ParameterBody(ParameterBodyBuilder builder) => builder?.Build();
 
+        public static implicit operator Referable<ParameterBody>(ParameterBodyBuilder builder) => builder?.Build();
+
         public static implicit operator ParameterBodyBuilder(ParameterBody value) => ReferenceEquals(value, null) ? null : new ParameterBodyBuilder(value);
 
         /// <summary>

--- a/src/SourceCode.Clay.OpenApi/Builders/ParameterBuilder.cs
+++ b/src/SourceCode.Clay.OpenApi/Builders/ParameterBuilder.cs
@@ -58,6 +58,8 @@ namespace SourceCode.Clay.OpenApi
 
         public static implicit operator Parameter(ParameterBuilder builder) => builder?.Build();
 
+        public static implicit operator Referable<Parameter>(ParameterBuilder builder) => builder?.Build();
+
         public static implicit operator ParameterBuilder(Parameter value) => ReferenceEquals(value, null) ? null : new ParameterBuilder(value);
 
         /// <summary>

--- a/src/SourceCode.Clay.OpenApi/Builders/PathBuilder.cs
+++ b/src/SourceCode.Clay.OpenApi/Builders/PathBuilder.cs
@@ -123,6 +123,8 @@ namespace SourceCode.Clay.OpenApi
 
         public static implicit operator Path(PathBuilder builder) => builder?.Build();
 
+        public static implicit operator Referable<Path>(PathBuilder builder) => builder?.Build();
+
         public static implicit operator PathBuilder(Path value) => ReferenceEquals(value, null) ? null : new PathBuilder(value);
 
         /// <summary>

--- a/src/SourceCode.Clay.OpenApi/Builders/RequestBodyBuilder.cs
+++ b/src/SourceCode.Clay.OpenApi/Builders/RequestBodyBuilder.cs
@@ -67,6 +67,8 @@ namespace SourceCode.Clay.OpenApi
 
         public static implicit operator RequestBody(RequestBodyBuilder builder) => builder?.Build();
 
+        public static implicit operator Referable<RequestBody>(RequestBodyBuilder builder) => builder?.Build();
+
         public static implicit operator RequestBodyBuilder(RequestBody value) => ReferenceEquals(value, null) ? null : new RequestBodyBuilder(value);
 
         /// <summary>

--- a/src/SourceCode.Clay.OpenApi/Builders/ResponseBuilder.cs
+++ b/src/SourceCode.Clay.OpenApi/Builders/ResponseBuilder.cs
@@ -72,6 +72,8 @@ namespace SourceCode.Clay.OpenApi
 
         public static implicit operator Response(ResponseBuilder builder) => builder?.Build();
 
+        public static implicit operator Referable<Response>(ResponseBuilder builder) => builder?.Build();
+
         public static implicit operator ResponseBuilder(Response value) => ReferenceEquals(value, null) ? null : new ResponseBuilder(value);
 
         /// <summary>

--- a/src/SourceCode.Clay.OpenApi/Builders/SchemaBuilder.cs
+++ b/src/SourceCode.Clay.OpenApi/Builders/SchemaBuilder.cs
@@ -168,6 +168,8 @@ namespace SourceCode.Clay.OpenApi
 
         public static implicit operator Schema(SchemaBuilder builder) => builder?.Build();
 
+        public static implicit operator Referable<Schema>(SchemaBuilder builder) => builder?.Build();
+
         public static implicit operator SchemaBuilder(Schema value) => ReferenceEquals(value, null) ? null : new SchemaBuilder(value);
 
         /// <summary>

--- a/src/SourceCode.Clay.OpenApi/ComponentKeyStringComparer.cs
+++ b/src/SourceCode.Clay.OpenApi/ComponentKeyStringComparer.cs
@@ -1,0 +1,115 @@
+#region License
+
+// Copyright (c) K2 Workflow (SourceCode Technology Holdings Inc.). All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+#endregion
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace SourceCode.Clay.OpenApi
+{
+    /// <summary>
+    /// Represents a comparer that validates values for component keys.
+    /// </summary>
+    public class ComponentKeyStringComparer : StringComparer
+    {
+        #region Properties
+
+        /// <summary>
+        /// Gets a <see cref="StringComparer"/> that validates values for component keys.
+        /// </summary>
+        public static ComponentKeyStringComparer ComponentKey { get; } = new ComponentKeyStringComparer();
+
+        #endregion
+
+        #region Fields
+
+        private readonly HashSet<char> _validCharacters;
+
+        /// <summary>
+        /// Gets the list of valid characters.
+        /// </summary>
+        public virtual IEnumerable<char> ValidCharacters => "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789.-_";
+
+        #endregion
+
+        #region Constructors
+
+        /// <summary>
+        /// Creates a new instance of the <see cref="ComponentKeyStringComparer"/> class.
+        /// </summary>
+        public ComponentKeyStringComparer()
+        {
+            _validCharacters = new HashSet<char>(ValidCharacters);
+        }
+
+        #endregion
+
+        #region Methods
+
+        /// <summary>
+        /// Validates the specified character value to determine if it is a valid
+        /// component name.
+        /// </summary>
+        /// <param name="value">The character value to validate.</param>
+        /// <returns>A value indicating whether the character value is valid.</returns>
+        public virtual bool Validate(char value) => _validCharacters.Contains(value);
+
+        /// <summary>
+        /// Validates the specified string value to determine if it is a valid
+        /// component name.
+        /// </summary>
+        /// <param name="value">The string value to validate.</param>
+        /// <returns>A value indicating whether the string value is valid.</returns>
+        public virtual bool Validate(string value)
+        {
+            if (string.IsNullOrEmpty(value)) return false;
+            for (var i = 0; i < value.Length; i++)
+            {
+                if (!Validate(value[i])) return false;
+            }
+            return true;
+        }
+
+        /// <summary>
+        /// Compares two string values and returns a value indicating sort order.
+        /// </summary>
+        /// <param name="x">The first value to compare.</param>
+        /// <param name="y">The second value to compare.</param>
+        /// <returns></returns>
+        public override int Compare(string x, string y)
+        {
+            if (!Validate(x)) throw new ArgumentOutOfRangeException(nameof(x), "The value is not a valid component name.");
+            if (!Validate(y)) throw new ArgumentOutOfRangeException(nameof(y), "The value is not a valid component name.");
+            return Ordinal.Compare(x, y);
+        }
+
+        /// <summary>Indicates whether two strings are equal.</summary>
+        /// <param name="x">A string to compare to y.</param>
+        /// <param name="y">A string to compare to x.</param>
+        /// <returns>true if <paramref name="x">x</paramref> and <paramref name="y">y</paramref> refer to the same object, or <paramref name="x">x</paramref> and <paramref name="y">y</paramref> are equal, or <paramref name="x">x</paramref> and <paramref name="y">y</paramref> are null; otherwise, false.</returns>
+        public override bool Equals(string x, string y)
+        {
+            if (!Validate(x)) throw new ArgumentOutOfRangeException(nameof(x), "The value is not a valid component name.");
+            if (!Validate(y)) throw new ArgumentOutOfRangeException(nameof(y), "The value is not a valid component name.");
+            return Ordinal.Equals(x, y);
+        }
+
+        /// <summary>Gets the hash code for the specified string.</summary>
+        /// <param name="obj">A string.</param>
+        /// <returns>A 32-bit signed hash code calculated from the value of the <paramref name="obj">obj</paramref> parameter.</returns>
+        /// <exception cref="T:System.ArgumentException">Not enough memory is available to allocate the buffer that is required to compute the hash code.</exception>
+        /// <exception cref="T:System.ArgumentNullException">
+        ///   <paramref name="obj">obj</paramref> is null.</exception>
+        public override int GetHashCode(string obj)
+        {
+            if (!Validate(obj)) throw new ArgumentOutOfRangeException(nameof(obj), "The value is not a valid component name.");
+            return Ordinal.GetHashCode(obj);
+        }
+
+        #endregion
+    }
+}

--- a/src/SourceCode.Clay.OpenApi/IReferable.cs
+++ b/src/SourceCode.Clay.OpenApi/IReferable.cs
@@ -1,0 +1,45 @@
+#region License
+
+// Copyright (c) K2 Workflow (SourceCode Technology Holdings Inc.). All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+#endregion
+
+namespace SourceCode.Clay.OpenApi
+{
+    /// <summary>
+    /// Represents either a reference object or a value.
+    /// </summary>
+    /// <typeparam name="T">The value type.</typeparam>
+    public interface IReferable
+    {
+        #region Properties
+
+        /// <summary>
+        /// Gets the contained value.
+        /// </summary>
+        object Value { get; }
+
+        /// <summary>
+        /// Gets the contained reference.
+        /// </summary>
+        Reference Reference { get; }
+
+        /// <summary>
+        /// Gets a value indicating whether the referable is a reference.
+        /// </summary>
+        bool IsReference { get; }
+
+        /// <summary>
+        /// Gets a value indicating whether the reference is a value.
+        /// </summary>
+        bool IsValue { get; }
+
+        /// <summary>
+        /// Gets a value indicating whether the reference is null.
+        /// </summary>
+        bool HasValue { get; }
+
+        #endregion
+    }
+}

--- a/src/SourceCode.Clay.OpenApi/Operation.cs
+++ b/src/SourceCode.Clay.OpenApi/Operation.cs
@@ -49,7 +49,7 @@ namespace SourceCode.Clay.OpenApi
         /// <summary>
         /// Gets the list of parameters that are applicable for this operation.
         /// </summary>
-        public IReadOnlyDictionary<ParameterKey, Referable<Parameter>> Parameters { get; }
+        public IReadOnlyDictionary<ParameterKey, Referable<ParameterBody>> Parameters { get; }
 
         /// <summary>
         /// Gets the request body applicable for this operation.
@@ -106,7 +106,7 @@ namespace SourceCode.Clay.OpenApi
             string description = default,
             ExternalDocumentation externalDocumentation = default,
             string operationIdentifier = default,
-            IReadOnlyDictionary<ParameterKey, Referable<Parameter>> parameters = default,
+            IReadOnlyDictionary<ParameterKey, Referable<ParameterBody>> parameters = default,
             Referable<RequestBody> requestBody = default,
             IReadOnlyDictionary<ResponseKey, Referable<Response>> responses = default,
             IReadOnlyDictionary<string, Referable<Callback>> callbacks = default,
@@ -119,7 +119,7 @@ namespace SourceCode.Clay.OpenApi
             Description = description;
             ExternalDocumentation = externalDocumentation;
             OperationIdentifier = operationIdentifier;
-            Parameters = parameters ?? ReadOnlyDictionary.Empty<ParameterKey, Referable<Parameter>>();
+            Parameters = parameters ?? ReadOnlyDictionary.Empty<ParameterKey, Referable<ParameterBody>>();
             RequestBody = requestBody;
             Responses = responses ?? ReadOnlyDictionary.Empty<ResponseKey, Referable<Response>>();
             Callbacks = callbacks ?? ReadOnlyDictionary.Empty<string, Referable<Callback>>();

--- a/src/SourceCode.Clay.OpenApi/ParameterOptions.cs
+++ b/src/SourceCode.Clay.OpenApi/ParameterOptions.cs
@@ -23,7 +23,7 @@ namespace SourceCode.Clay.OpenApi
         /// <summary>
         /// Indicates that the parameter is not mandatory.
         /// </summary>
-        Optional = 1,
+        Required = 1,
 
         /// <summary>
         /// Specifies that a parameter is deprecated.

--- a/src/SourceCode.Clay.OpenApi/Referable.cs
+++ b/src/SourceCode.Clay.OpenApi/Referable.cs
@@ -15,7 +15,7 @@ namespace SourceCode.Clay.OpenApi
     /// Represents either a reference object or a value.
     /// </summary>
     /// <typeparam name="T">The value type.</typeparam>
-    public struct Referable<T> : IEquatable<Referable<T>>
+    public struct Referable<T> : IEquatable<Referable<T>>, IReferable
         where T : class, IEquatable<T>
     {
         #region Properties
@@ -44,6 +44,9 @@ namespace SourceCode.Clay.OpenApi
         /// Gets a value indicating whether the reference is null.
         /// </summary>
         public bool HasValue => IsReference || IsValue;
+
+        /// <summary>Gets the contained value.</summary>
+        object IReferable.Value => Value;
 
         #endregion
 

--- a/src/SourceCode.Clay.OpenApi/Serialization/IOpenApiSerializer.cs
+++ b/src/SourceCode.Clay.OpenApi/Serialization/IOpenApiSerializer.cs
@@ -1,0 +1,37 @@
+#region License
+
+// Copyright (c) K2 Workflow (SourceCode Technology Holdings Inc.). All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+#endregion
+
+using System.Json;
+
+namespace SourceCode.Clay.OpenApi.Serialization
+{
+    /// <summary>
+    /// Represents a serializer that can convert between OpenAPI objects and JSON.
+    /// </summary>
+    public interface IOpenApiSerializer
+    {
+        #region Methods
+
+        /// <summary>
+        /// Serializes the specified OpenAPI object to a JSON value.
+        /// </summary>
+        /// <typeparam name="T">The type of the OpenAPI object.</typeparam>
+        /// <param name="value">The instance of the OpenAPI object.</param>
+        /// <returns>The serialized value.</returns>
+        JsonValue Serialize<T>(T value);
+
+        /// <summary>
+        /// Deserializes the specified OpenAPI object from a JSON value.
+        /// </summary>
+        /// <typeparam name="T">The expected type of the OpenAPI object.</typeparam>
+        /// <param name="value">The JSON value to deserialize.</param>
+        /// <returns>The OpenAPI object.</returns>
+        T Deserialize<T>(JsonValue value);
+
+        #endregion
+    }
+}

--- a/src/SourceCode.Clay.OpenApi/Serialization/NumberExtensions.cs
+++ b/src/SourceCode.Clay.OpenApi/Serialization/NumberExtensions.cs
@@ -1,0 +1,66 @@
+#region License
+
+// Copyright (c) K2 Workflow (SourceCode Technology Holdings Inc.). All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+#endregion
+
+using System;
+using System.Json;
+using System.Linq.Expressions;
+using System.Reflection;
+
+namespace SourceCode.Clay.OpenApi.Serialization
+{
+    internal static class NumberExtensions
+    {
+        #region Fields
+
+        private static readonly Func<JsonPrimitive, object> GetValueFromPrimitive = CreateGetValueFromPrimitive();
+
+        #endregion
+
+        #region Methods
+
+        private static Func<JsonPrimitive, object> CreateGetValueFromPrimitive()
+        {
+            var t = typeof(JsonPrimitive);
+            var param = Expression.Parameter(t, "primitive");
+            var prop = t.GetProperty("Value", BindingFlags.NonPublic | BindingFlags.Instance);
+            var expr = Expression.Property(param, prop);
+            return Expression.Lambda<Func<JsonPrimitive, object>>(expr, param).Compile();
+        }
+
+        public static JsonValue ToValue(this Number number)
+        {
+            switch (number.ValueTypeCode)
+            {
+                case TypeCode.Byte: return new JsonPrimitive(number.Byte);
+                case TypeCode.Double: return new JsonPrimitive(number.Double);
+                case TypeCode.Int16: return new JsonPrimitive(number.Int16);
+                case TypeCode.Int32: return new JsonPrimitive(number.Int32);
+                case TypeCode.Int64: return new JsonPrimitive(number.Int64);
+                case TypeCode.SByte: return new JsonPrimitive(number.SByte);
+                case TypeCode.Single: return new JsonPrimitive(number.Single);
+                case TypeCode.UInt16: return new JsonPrimitive(number.UInt16);
+                case TypeCode.UInt32: return new JsonPrimitive(number.UInt32);
+                case TypeCode.UInt64: return new JsonPrimitive(number.UInt64);
+#               pragma warning disable S1168 // Empty arrays and collections should be returned instead of null
+                default: return null;
+#               pragma warning restore S1168 // Empty arrays and collections should be returned instead of null
+            }
+        }
+
+        public static Number ToNumber(this JsonValue value)
+        {
+            if (value == null) return default;
+            if (value.JsonType != JsonType.Number) throw new ArgumentOutOfRangeException(nameof(value));
+            var primitive = (JsonPrimitive)value;
+            var val = GetValueFromPrimitive(primitive);
+            if (val is Decimal d) val = (double)d;
+            return Number.CreateFromObject(val);
+        }
+
+        #endregion
+    }
+}

--- a/src/SourceCode.Clay.OpenApi/Serialization/OpenApiSerializer.cs
+++ b/src/SourceCode.Clay.OpenApi/Serialization/OpenApiSerializer.cs
@@ -1,0 +1,1394 @@
+#region License
+
+// Copyright (c) K2 Workflow (SourceCode Technology Holdings Inc.). All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+#endregion
+
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Json;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Net.Mail;
+using System.Net.Mime;
+using System.Reflection;
+using System.Text;
+using System.Threading;
+
+namespace SourceCode.Clay.OpenApi.Serialization
+{
+    /// <summary>
+    /// Represents a serializer that can convert between OpenAPI objects and JSON.
+    /// </summary>
+    public class OpenApiSerializer : IOpenApiSerializer
+    {
+        #region Constants
+
+        protected static class PropertyNames
+        {
+            #region Fields
+
+            public const string Reference = "$ref";
+            public const string Name = "name";
+            public const string Tags = "tags";
+            public const string ExternalDocs = "externalDocs";
+            public const string Description = "description";
+            public const string Type = "type";
+            public const string Title = "title";
+            public const string Format = "format";
+            public const string MultipleOf = "multipleOf";
+            public const string Maximum = "maximum";
+            public const string ExclusiveMaximum = "exclusiveMaximum";
+            public const string Minimum = "minimum";
+            public const string ExclusiveMinimum = "exclusiveMinimum";
+            public const string MinLength = "minLength";
+            public const string MaxLength = "maxLength";
+            public const string MinProperties = "minProperties";
+            public const string MaxProperties = "maxProperties";
+            public const string UniqueItems = "uniqueItems";
+            public const string Required = "required";
+            public const string EnumValue = "enum";
+            public const string AllOf = "allOf";
+            public const string AnyOf = "anyOf";
+            public const string OneOf = "oneOf";
+            public const string Not = "not";
+            public const string Items = "items";
+            public const string Properties = "properties";
+            public const string AdditionalProperties = "additionalProperties";
+            public const string Nullable = "nullable";
+            public const string Deprecated = "deprecated";
+            public const string Pattern = "pattern";
+            public const string Schemas = "schemas";
+            public const string Schema = "schema";
+            public const string Responses = "responses";
+            public const string Parameters = "parameters";
+            public const string Examples = "examples";
+            public const string RequestBodies = "requestBodies";
+            public const string RequestBody = "requestBody";
+            public const string Headers = "headers";
+            public const string SecuritySchemes = "securitySchemes";
+            public const string Links = "links";
+            public const string Callbacks = "callbacks";
+            public const string Url = "url";
+            public const string Email = "email";
+            public const string OpenApi = "openapi";
+            public const string Info = "info";
+            public const string Servers = "servers";
+            public const string Server = "server";
+            public const string Paths = "paths";
+            public const string Components = "components";
+            public const string Security = "security";
+            public const string ContentType = "contentType";
+            public const string Style = "style";
+            public const string Explode = "explode";
+            public const string AllowReserved = "allowReserved";
+            public const string Summary = "summary";
+            public const string Value = "value";
+            public const string ExternalValue = "externalValue";
+            public const string TermsOfService = "termsOfService";
+            public const string Contact = "contact";
+            public const string License = "license";
+            public const string Version = "version";
+            public const string OperationId = "operationId";
+            public const string OperationRef = "operationRef";
+            public const string Encoding = "encoding";
+            public const string AllowEmptyValue = "allowEmptyValue";
+            public const string Content = "content";
+            public const string In = "in";
+            public const string Delete = "delete";
+            public const string Get = "get";
+            public const string Head = "head";
+            public const string Options = "options";
+            public const string Patch = "patch";
+            public const string Post = "post";
+            public const string Put = "put";
+            public const string Trace = "trace";
+            public const string Default = "default";
+            public const string Enum = "enum";
+            public const string Variables = "variables";
+            public const string Scheme = "scheme";
+            public const string BearerFormat = "bearerFormat";
+            public const string Flows = "flows";
+            public const string Implicit = "implicit";
+            public const string Password = "pass" + "word";
+            public const string ClientCredentials = "clientCredentials";
+            public const string AuthorizationCode = "authorizationCode";
+            public const string AuthorizationUrl = "authorizationUrl";
+            public const string TokenUrl = "tokenUrl";
+            public const string RefreshUrl = "refreshUrl";
+            public const string Scopes = "scopes";
+            public const string OpenIdConnectUrl = "openIdConnectUrl";
+
+            #endregion
+        }
+
+        protected static class EnumNames
+        {
+            #region Fields
+
+            public const string Matrix = "matrix";
+            public const string Label = "label";
+            public const string Form = "form";
+            public const string Simple = "simple";
+            public const string SpaceDelimited = "spaceDelimited";
+            public const string PipeDelimited = "pipeDelimited";
+            public const string DeepObject = "deepObject";
+
+            public const string Query = "query";
+            public const string Header = "header";
+            public const string Path = "path";
+            public const string Cookie = "cookie";
+
+            public const string Array = "array";
+            public const string Boolean = "boolean";
+            public const string Number = "number";
+            public const string Object = "object";
+            public const string String = "string";
+            public const string Integer = "integer";
+
+            public const string ApiKey = "apiKey";
+            public const string Http = "http";
+            public const string OAuth2 = "oauth2";
+            public const string OpenIdConnect = "openIdConnect";
+
+            #endregion
+        }
+
+        #endregion
+
+        #region Fields
+
+        private static readonly ConcurrentDictionary<RuntimeTypeHandle, SerializerInfo> _serializers = new ConcurrentDictionary<RuntimeTypeHandle, SerializerInfo>();
+        private SerializerInfo _mySerializers;
+
+        #endregion
+
+        #region Structs
+
+        private struct SerializerKey : IEquatable<SerializerKey>
+        {
+            #region Properties
+
+            public RuntimeTypeHandle GenericArgumentType { get; }
+            public RuntimeTypeHandle InstanceType { get; }
+
+            #endregion
+
+            #region Constructors
+
+            public SerializerKey(RuntimeTypeHandle genericArgumentType, RuntimeTypeHandle instanceType)
+            {
+                GenericArgumentType = genericArgumentType;
+                InstanceType = instanceType;
+            }
+
+            #endregion
+
+            #region Methods
+
+            public override bool Equals(object obj) => obj is SerializerKey o && Equals(o);
+
+            public bool Equals(SerializerKey other)
+                => GenericArgumentType.Equals(other.GenericArgumentType)
+                && InstanceType.Equals(other.InstanceType);
+
+            public override int GetHashCode()
+            {
+                unchecked
+                {
+                    var hc = 17L;
+                    hc = hc * 21 + GenericArgumentType.GetHashCode();
+                    hc = hc * 21 + InstanceType.GetHashCode();
+                    return ((int)(hc >> 32)) ^ (int)hc;
+                }
+            }
+
+            #endregion
+        }
+
+        #endregion
+
+        #region Classes
+
+        private sealed class SerializerInfo
+        {
+            #region Fields
+
+            private readonly ConcurrentDictionary<SerializerKey, Delegate> _delegates = new ConcurrentDictionary<SerializerKey, Delegate>();
+            private readonly Type _serializerType;
+            private readonly MethodInfo[] _methods;
+
+            #endregion
+
+            #region Constructors
+
+            public SerializerInfo(Type serializerType)
+            {
+                _serializerType = serializerType;
+                _methods = serializerType.GetMethods(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance)
+                    .Where(x => !x.IsAbstract && !x.IsGenericMethod && x.ReturnType == typeof(JsonValue) && x.GetParameters().Length == 1)
+                    .ToArray();
+            }
+
+            #endregion
+
+            #region Methods
+
+            private Delegate CreateSerializer<T>(SerializerKey key)
+            {
+                var argType = typeof(T);
+                var instType = Type.GetTypeFromHandle(key.InstanceType);
+
+                MethodInfo method = default;
+                for (; instType != typeof(ValueType) && instType != typeof(object); instType = instType.BaseType)
+                {
+                    method = _methods.FirstOrDefault(x => x.GetParameters()[0].ParameterType == instType);
+                    if (method != null) break;
+                }
+
+                if (method == default)
+                {
+                    instType = Type.GetTypeFromHandle(key.InstanceType);
+                    return new Func<OpenApiSerializer, T, JsonValue>(
+                        (x, y) => throw new NotSupportedException($"Serializing the type {instType.FullName} is not supported."));
+                }
+
+                var serParam = Expression.Parameter(_serializerType, "serializer");
+                var param = Expression.Parameter(argType, "value");
+                var conv = argType == instType
+                    ? (Expression)param
+                    : Expression.Convert(param, instType);
+                var call = Expression.Call(serParam, method, conv);
+                return Expression.Lambda<Func<OpenApiSerializer, T, JsonValue>>(call, serParam, param).Compile();
+            }
+
+            public JsonValue Serialize<T>(OpenApiSerializer serializer, T value)
+            {
+                var key = new SerializerKey(typeof(T).TypeHandle, value.GetType().TypeHandle);
+                var del = _delegates.GetOrAdd(key, CreateSerializer<T>);
+                return ((Func<OpenApiSerializer, T, JsonValue>)del)(serializer, value);
+            }
+
+            #endregion
+        }
+
+        #endregion
+
+        #region Constructors
+
+        /// <summary>
+        /// Creates a new instance of the <see cref="OpenApiSerializer"/> class.
+        /// </summary>
+        public OpenApiSerializer()
+        {
+        }
+
+        #endregion
+
+        #region Serialize
+
+        /// <summary>
+        /// Serializes a <see cref="Response"/> value.
+        /// </summary>
+        /// <param name="value">The <see cref="Response"/> value to serialize.</param>
+        /// <returns>The <see cref="JsonValue"/>.</returns>
+        private JsonValue SerializeResponse(Response value)
+        {
+            if (ReferenceEquals(value, null)) return null;
+
+            var json = new JsonObject();
+
+            var content = value.Content
+                .Select(x => ValueTuple.Create(x.Key?.ToString(), x.Value));
+
+            SetJsonValue(json, PropertyNames.Description, value.Description, true);
+            SetJsonMap(json, PropertyNames.Headers, value.Headers);
+            SetJsonMap(json, PropertyNames.Content, content);
+            SetJsonMap(json, PropertyNames.Links, value.Links);
+
+            return json;
+        }
+
+        /// <summary>
+        /// Serializes a <see cref="RequestBody"/> value.
+        /// </summary>
+        /// <param name="value">The <see cref="RequestBody"/> value to serialize.</param>
+        /// <returns>The <see cref="JsonValue"/>.</returns>
+        private JsonValue SerializeRequestBody(RequestBody value)
+        {
+            if (ReferenceEquals(value, null)) return null;
+
+            var json = new JsonObject();
+
+            var content = value.Content
+                .Select(x => ValueTuple.Create(x.Key?.ToString(), x.Value));
+
+            SetJsonValue(json, PropertyNames.Description, value.Description);
+            SetJsonMap(json, PropertyNames.Content, content);
+            SetJsonFlag(json, PropertyNames.RequestBodies, value.Options, RequestBodyOptions.Required);
+
+            return json;
+        }
+
+        /// <summary>
+        /// Serializes a <see cref="PropertyEncoding"/> value.
+        /// </summary>
+        /// <param name="value">The <see cref="PropertyEncoding"/> value to serialize.</param>
+        /// <returns>The <see cref="JsonValue"/>.</returns>
+        private JsonValue SerializePropertyEncoding(PropertyEncoding value)
+        {
+            if (ReferenceEquals(value, null)) return null;
+
+            var json = new JsonObject();
+
+            SetJsonValue(json, PropertyNames.ContentType, value.ContentType);
+            SetJsonMap(json, PropertyNames.Headers, value.Headers);
+            SetJsonValue(json, PropertyNames.Style, ToJsonValue(value.Style));
+            SetJsonFlag(json, PropertyNames.Explode, value.Options, PropertyEncodingOptions.Explode);
+            SetJsonFlag(json, PropertyNames.AllowReserved, value.Options, PropertyEncodingOptions.AllowReserved);
+
+            return json;
+        }
+
+        /// <summary>
+        /// Serializes a <see cref="Path"/> value.
+        /// </summary>
+        /// <param name="value">The <see cref="Path"/> value to serialize.</param>
+        /// <returns>The <see cref="JsonValue"/>.</returns>
+        private JsonValue SerializePath(Path value)
+        {
+            if (ReferenceEquals(value, null)) return null;
+
+            var json = new JsonObject();
+
+            SetJsonValue(json, PropertyNames.Summary, value.Summary);
+            SetJsonValue(json, PropertyNames.Description, value.Description);
+            SetJsonObject(json, PropertyNames.Get, value.Get);
+            SetJsonObject(json, PropertyNames.Put, value.Put);
+            SetJsonObject(json, PropertyNames.Post, value.Post);
+            SetJsonObject(json, PropertyNames.Delete, value.Delete);
+            SetJsonObject(json, PropertyNames.Options, value.Options);
+            SetJsonObject(json, PropertyNames.Head, value.Head);
+            SetJsonObject(json, PropertyNames.Patch, value.Patch);
+            SetJsonObject(json, PropertyNames.Trace, value.Trace);
+            SetJsonArray(json, PropertyNames.Servers, value.Servers);
+            SetJsonArray(json, PropertyNames.Parameters, value.Parameters);
+
+            return json;
+        }
+
+        /// <summary>
+        /// Serializes a <see cref="ParameterBody"/> value.
+        /// </summary>
+        /// <param name="value">The <see cref="ParameterBody"/> value to serialize.</param>
+        /// <returns>The <see cref="JsonValue"/>.</returns>
+        private JsonValue SerializeParameterBody(ParameterBody value)
+        {
+            if (ReferenceEquals(value, null)) return null;
+
+            var json = new JsonObject();
+
+            SerializeParameterBody(value, json);
+
+            return json;
+        }
+
+        /// <summary>
+        /// Serializes a <see cref="ParameterBody"/> value into an existing <see cref="JsonObject"/> instance.
+        /// </summary>
+        /// <param name="value">The <see cref="ParameterBody"/> value to serialize.</param>
+        protected virtual void SerializeParameterBody(ParameterBody value, JsonObject json)
+        {
+            if (value == null) return;
+
+            var examples = value.Examples
+                .Select(x => ValueTuple.Create(x.Key?.ToString(), x.Value));
+
+            var content = value.Content
+                .Select(x => ValueTuple.Create(x.Key?.ToString(), x.Value));
+
+            SetJsonValue(json, PropertyNames.Description, value.Description);
+            SetJsonFlag(json, PropertyNames.Required, value.Options, ParameterOptions.Required);
+            SetJsonFlag(json, PropertyNames.Deprecated, value.Options, ParameterOptions.Deprecated);
+            SetJsonFlag(json, PropertyNames.AllowEmptyValue, value.Options, ParameterOptions.AllowEmptyValue);
+
+            SetJsonValue(json, PropertyNames.Style, ToJsonValue(value.Style));
+            SetJsonFlag(json, PropertyNames.Explode, value.Options, ParameterOptions.Explode);
+            SetJsonFlag(json, PropertyNames.AllowReserved, value.Options, ParameterOptions.AllowReserved);
+            SetJsonObject(json, PropertyNames.Schema, value.Schema);
+            SetJsonMap(json, PropertyNames.Examples, examples);
+
+            SetJsonMap(json, PropertyNames.Content, content);
+        }
+
+        /// <summary>
+        /// Serializes a <see cref="Parameter"/> value.
+        /// </summary>
+        /// <param name="value">The <see cref="Parameter"/> value to serialize.</param>
+        /// <returns>The <see cref="JsonValue"/>.</returns>
+        protected virtual JsonValue SerializeParameter(Parameter value)
+        {
+            if (ReferenceEquals(value, null)) return null;
+
+            var json = new JsonObject();
+
+            SetJsonValue(json, PropertyNames.Name, value.Name, true);
+            SetJsonValue(json, PropertyNames.In, ToJsonValue(value.Location));
+            SerializeParameterBody(value, json);
+
+            return json;
+        }
+
+        /// <summary>
+        /// Serializes a <see cref="Parameter"/> value according to its components.
+        /// </summary>
+        /// <param name="key">The <see cref="ParameterKey"/> component to serialize.</param>
+        /// <param name="value">The referable <see cref="ParameterBody"/> component to serialize.</param>
+        /// <returns>The <see cref="JsonValue"/>.</returns>
+        protected virtual JsonValue SerializeParameter(ParameterKey key, Referable<ParameterBody> value)
+        {
+            if (value.IsReference) return SerializeReference(value.Reference);
+            return SerializeParameter(key, value.Value);
+        }
+
+        /// <summary>
+        /// Serializes a <see cref="Parameter"/> value according to its components.
+        /// </summary>
+        /// <param name="key">The <see cref="ParameterKey"/> component to serialize.</param>
+        /// <param name="value">The <see cref="ParameterBody"/> component to serialize.</param>
+        /// <returns>The <see cref="JsonValue"/>.</returns>
+        protected virtual JsonValue SerializeParameter(ParameterKey key, ParameterBody value)
+        {
+            if (ReferenceEquals(value, null)) return null;
+
+            var json = new JsonObject();
+
+            SetJsonValue(json, PropertyNames.Name, key.Name, true);
+            SetJsonValue(json, PropertyNames.In, ToJsonValue(key.Location));
+            SerializeParameterBody(value, json);
+
+            return json;
+        }
+
+        /// <summary>
+        /// Serializes a <see cref="Operation"/> value.
+        /// </summary>
+        /// <param name="value">The <see cref="Operation"/> value to serialize.</param>
+        /// <returns>The <see cref="JsonValue"/>.</returns>
+        protected virtual JsonValue SerializeOperation(Operation value)
+        {
+            if (ReferenceEquals(value, null)) return null;
+
+            var json = new JsonObject();
+
+            var responses = value.Responses
+                .Select(x => ValueTuple.Create(x.Key.ToString(), x.Value));
+
+            SetJsonArray(json, PropertyNames.Tags, value.Tags);
+            SetJsonValue(json, PropertyNames.Summary, value.Summary);
+            SetJsonValue(json, PropertyNames.Description, value.Description);
+            SetJsonObject(json, PropertyNames.ExternalDocs, value.ExternalDocumentation);
+            SetJsonValue(json, PropertyNames.OperationId, value.OperationIdentifier);
+            SetJsonArray(json, PropertyNames.Parameters, value.Parameters);
+            SetJsonObject(json, PropertyNames.RequestBody, value.RequestBody);
+            SetJsonMap(json, PropertyNames.Responses, responses);
+            SetJsonMap(json, PropertyNames.Callbacks, value.Callbacks);
+            SetJsonFlag(json, PropertyNames.Deprecated, value.Options, OperationOptions.Deprecated);
+            SetJsonArray(json, PropertyNames.Security, value.Security);
+            SetJsonArray(json, PropertyNames.Servers, value.Servers);
+
+            return json;
+        }
+
+        /// <summary>
+        /// Serializes a <see cref="OpenIdConnectSecurityScheme"/> value.
+        /// </summary>
+        /// <param name="value">The <see cref="OpenIdConnectSecurityScheme"/> value to serialize.</param>
+        /// <returns>The <see cref="JsonValue"/>.</returns>
+        protected virtual JsonValue SerializeOpenIdConnectSecurityScheme(OpenIdConnectSecurityScheme value)
+        {
+            if (ReferenceEquals(value, null)) return null;
+
+            var json = new JsonObject();
+
+            SetJsonValue(json, PropertyNames.Type, EnumNames.OpenIdConnect);
+            SetJsonValue(json, PropertyNames.Description, value.Description);
+            SetJsonValue(json, PropertyNames.OpenIdConnectUrl, value.Url);
+
+            return json;
+        }
+
+        /// <summary>
+        /// Serializes a <see cref="OAuthFlow"/> value.
+        /// </summary>
+        /// <param name="value">The <see cref="OAuthFlow"/> value to serialize.</param>
+        /// <returns>The <see cref="JsonValue"/>.</returns>
+        protected virtual JsonValue SerializeOAuthFlow(OAuthFlow value)
+        {
+            if (ReferenceEquals(value, null)) return null;
+
+            var json = new JsonObject();
+
+            SetJsonValue(json, PropertyNames.AuthorizationUrl, value.AuthorizationUrl, true);
+            SetJsonValue(json, PropertyNames.TokenUrl, value.TokenUrl, true);
+            SetJsonValue(json, PropertyNames.RefreshUrl, value.RefreshUrl);
+            SetJsonMap(json, PropertyNames.Scopes, value.Scopes);
+
+            return json;
+        }
+
+        /// <summary>
+        /// Serializes a <see cref="OAuth2SecurityScheme"/> value.
+        /// </summary>
+        /// <param name="value">The <see cref="OAuth2SecurityScheme"/> value to serialize.</param>
+        /// <returns>The <see cref="JsonValue"/>.</returns>
+        protected virtual JsonValue SerializeOAuth2SecurityScheme(OAuth2SecurityScheme value)
+        {
+            if (ReferenceEquals(value, null)) return null;
+
+            var json = new JsonObject();
+
+            SetJsonValue(json, PropertyNames.Type, EnumNames.OAuth2);
+            SetJsonValue(json, PropertyNames.Description, value.Description);
+
+            var flows = new JsonObject();
+
+            SetJsonObject(flows, PropertyNames.Implicit, value.ImplicitFlow);
+            SetJsonObject(flows, PropertyNames.Password, value.PasswordFlow);
+            SetJsonObject(flows, PropertyNames.ClientCredentials, value.ClientCredentialsFlow);
+            SetJsonObject(flows, PropertyNames.AuthorizationCode, value.AuthorizationCodeFlow);
+
+            json.Add(PropertyNames.Flows, flows);
+
+            return json;
+        }
+
+        /// <summary>
+        /// Serializes a <see cref="MediaType"/> value.
+        /// </summary>
+        /// <param name="value">The <see cref="MediaType"/> value to serialize.</param>
+        /// <returns>The <see cref="JsonValue"/>.</returns>
+        protected virtual JsonValue SerializeMediaType(MediaType value)
+        {
+            if (ReferenceEquals(value, null)) return null;
+
+            var json = new JsonObject();
+
+            SetJsonObject(json, PropertyNames.Schema, value.Schema);
+            SetJsonMap(json, PropertyNames.Examples, value.Examples);
+            SetJsonMap(json, PropertyNames.Encoding, value.Encoding);
+
+            return json;
+        }
+
+        /// <summary>
+        /// Serializes a <see cref="Link"/> value.
+        /// </summary>
+        /// <param name="value">The <see cref="Link"/> value to serialize.</param>
+        /// <returns>The <see cref="JsonValue"/>.</returns>
+        protected virtual JsonValue SerializeLink(Link value)
+        {
+            if (ReferenceEquals(value, null)) return null;
+
+            var json = new JsonObject();
+
+            SetJsonValue(json, PropertyNames.OperationRef, SerializeReference(value.OperationReference));
+            SetJsonValue(json, PropertyNames.OperationId, value.OperationIdentifier);
+            SetJsonValue(json, PropertyNames.Description, value.Description);
+            SetJsonObject(json, PropertyNames.Server, value.Server);
+
+            return json;
+        }
+
+        /// <summary>
+        /// Serializes a <see cref="License"/> value.
+        /// </summary>
+        /// <param name="value">The <see cref="License"/> value to serialize.</param>
+        /// <returns>The <see cref="JsonValue"/>.</returns>
+        protected virtual JsonValue SerializeLicense(License value)
+        {
+            if (ReferenceEquals(value, null)) return null;
+
+            var json = new JsonObject();
+
+            SetJsonValue(json, PropertyNames.Name, value.Name);
+            SetJsonValue(json, PropertyNames.Url, value.Url);
+
+            return json;
+        }
+
+        /// <summary>
+        /// Serializes a <see cref="Information"/> value.
+        /// </summary>
+        /// <param name="value">The <see cref="Information"/> value to serialize.</param>
+        /// <returns>The <see cref="JsonValue"/>.</returns>
+        protected virtual JsonValue SerializeInformation(Information value)
+        {
+            if (ReferenceEquals(value, null)) return null;
+
+            var json = new JsonObject();
+
+            SetJsonValue(json, PropertyNames.Title, value.Title);
+            SetJsonValue(json, PropertyNames.Description, value.Description);
+            SetJsonValue(json, PropertyNames.TermsOfService, value.TermsOfService);
+            SetJsonObject(json, PropertyNames.Contact, value.Contact);
+            SetJsonObject(json, PropertyNames.License, value.License);
+            SetJsonValue(json, PropertyNames.Version, value.Version.ToString());
+
+            return json;
+        }
+
+        /// <summary>
+        /// Serializes a <see cref="HttpSecurityScheme"/> value.
+        /// </summary>
+        /// <param name="value">The <see cref="HttpSecurityScheme"/> value to serialize.</param>
+        /// <returns>The <see cref="JsonValue"/>.</returns>
+        protected virtual JsonValue SerializeHttpSecurityScheme(HttpSecurityScheme value)
+        {
+            if (ReferenceEquals(value, null)) return null;
+
+            var json = new JsonObject();
+
+            SetJsonValue(json, PropertyNames.Type, EnumNames.Http);
+            SetJsonValue(json, PropertyNames.Description, value.Description);
+            SetJsonValue(json, PropertyNames.Scheme, value.Scheme, true);
+            SetJsonValue(json, PropertyNames.BearerFormat, value.BearerFormat);
+
+            return json;
+        }
+
+        /// <summary>
+        /// Serializes a <see cref="Reference"/> value.
+        /// </summary>
+        /// <param name="value">The <see cref="Reference"/> value to serialize.</param>
+        /// <returns>The <see cref="JsonValue"/>.</returns>
+        protected virtual JsonValue SerializeReference(Reference value)
+        {
+            if (!value.HasValue) return null;
+            return value.ToUri()?.ToString();
+        }
+
+        /// <summary>
+        /// Serializes a <see cref="Referable{T}"/> value.
+        /// </summary>
+        /// <param name="value">The <see cref="Referable{T}"/> value to serialize.</param>
+        /// <returns>The <see cref="JsonValue"/>.</returns>
+        protected virtual JsonValue SerializeReferable(IReferable referable)
+        {
+            if (!referable.HasValue) return null;
+            if (referable.IsReference)
+            {
+                var reference = Serialize(referable.Reference);
+                return new JsonObject()
+                {
+                    [PropertyNames.Reference] = reference
+                };
+            }
+            return SerializeUnknown(referable.Value);
+        }
+
+        /// <summary>
+        /// Serializes a <see cref="Contact"/> value.
+        /// </summary>
+        /// <param name="value">The <see cref="Contact"/> value to serialize.</param>
+        /// <returns>The <see cref="JsonValue"/>.</returns>
+        protected virtual JsonValue SerializeComponents(Components value)
+        {
+            if (ReferenceEquals(value, null)) return null;
+
+            var json = new JsonObject();
+
+            SetJsonMap(json, PropertyNames.Schemas, value.Schemas);
+            SetJsonMap(json, PropertyNames.Responses, value.Responses);
+            SetJsonMap(json, PropertyNames.Parameters, value.Parameters);
+            SetJsonMap(json, PropertyNames.Examples, value.Examples);
+            SetJsonMap(json, PropertyNames.RequestBodies, value.RequestBodies);
+            SetJsonMap(json, PropertyNames.Headers, value.Headers);
+            SetJsonMap(json, PropertyNames.SecuritySchemes, value.SecuritySchemes);
+            SetJsonMap(json, PropertyNames.Links, value.Links);
+            SetJsonMap(json, PropertyNames.Callbacks, value.Callbacks);
+
+            return json;
+        }
+
+        /// <summary>
+        /// Serializes a <see cref="Contact"/> value.
+        /// </summary>
+        /// <param name="value">The <see cref="Contact"/> value to serialize.</param>
+        /// <returns>The <see cref="JsonValue"/>.</returns>
+        protected virtual JsonValue SerializeContact(Contact value)
+        {
+            if (ReferenceEquals(value, null)) return null;
+
+            var json = new JsonObject();
+
+            SetJsonValue(json, PropertyNames.Name, value.Name);
+            SetJsonValue(json, PropertyNames.Url, value.Url);
+            SetJsonValue(json, PropertyNames.Email, value.Email);
+
+            return json;
+        }
+
+        /// <summary>
+        /// Serializes a <see cref="ExternalDocumentation"/> value.
+        /// </summary>
+        /// <param name="value">The <see cref="ExternalDocumentation"/> value to serialize.</param>
+        /// <returns>The <see cref="JsonValue"/>.</returns>
+        protected virtual JsonValue SerializeExternalDocumentation(ExternalDocumentation value)
+        {
+            if (ReferenceEquals(value, null)) return null;
+
+            var json = new JsonObject();
+
+            SetJsonValue(json, PropertyNames.Description, value.Description);
+            SetJsonValue(json, PropertyNames.Url, value.Url, true);
+
+            return json;
+        }
+
+        /// <summary>
+        /// Serializes a <see cref="Example"/> value.
+        /// </summary>
+        /// <param name="value">The <see cref="Example"/> value to serialize.</param>
+        /// <returns>The <see cref="JsonValue"/>.</returns>
+        protected virtual JsonValue SerializeExample(Example value)
+        {
+            if (ReferenceEquals(value, null)) return null;
+
+            var json = new JsonObject();
+
+            SetJsonValue(json, PropertyNames.Summary, value.Summary);
+            SetJsonValue(json, PropertyNames.Description, value.Description);
+            SetJsonValue(json, PropertyNames.ExternalValue, value.ExternalValue);
+
+            return json;
+        }
+
+        /// <summary>
+        /// Serializes a <see cref="Document"/> value.
+        /// </summary>
+        /// <param name="value">The <see cref="Document"/> value to serialize.</param>
+        /// <returns>The <see cref="JsonValue"/>.</returns>
+        protected virtual JsonValue SerializeDocument(Document value)
+        {
+            if (ReferenceEquals(value, null)) return null;
+
+            var json = new JsonObject();
+
+            SetJsonValue(json, PropertyNames.OpenApi, value.Version.ToString());
+            SetJsonObject(json, PropertyNames.Info, value.Info, true);
+            SetJsonArray(json, PropertyNames.Servers, value.Servers);
+            SetJsonMap(json, PropertyNames.Paths, value.Paths, true);
+            SetJsonObject(json, PropertyNames.Components, value.Components);
+            SetJsonArray(json, PropertyNames.Security, value.Security);
+            SetJsonArray(json, PropertyNames.Tags, value.Tags);
+            SetJsonObject(json, PropertyNames.ExternalDocs, value.ExternalDocumentation);
+
+            return json;
+        }
+
+        /// <summary>
+        /// Serializes a <see cref="Callback"/> value.
+        /// </summary>
+        /// <param name="value">The <see cref="Callback"/> value to serialize.</param>
+        /// <returns>The <see cref="JsonValue"/>.</returns>
+        protected virtual JsonValue SerializeCallback(Callback value)
+        {
+            if (ReferenceEquals(value, null)) return null;
+
+            var json = new JsonObject();
+
+            foreach (var item in value)
+            {
+                var k = item.Key.ToString();
+                var v = Serialize(item.Value);
+                json.Add(k, v);
+            }
+
+            return json;
+        }
+
+        /// <summary>
+        /// Serializes a <see cref="ApiKeySecurityScheme"/> value.
+        /// </summary>
+        /// <param name="value">The <see cref="ApiKeySecurityScheme"/> value to serialize.</param>
+        /// <returns>The <see cref="JsonValue"/>.</returns>
+        protected virtual JsonValue SerializeApiKeySecurityScheme(ApiKeySecurityScheme value)
+        {
+            if (ReferenceEquals(value, null)) return null;
+
+            var json = new JsonObject();
+
+            SetJsonValue(json, PropertyNames.Type, EnumNames.ApiKey);
+            SetJsonValue(json, PropertyNames.Description, value.Description);
+            SetJsonValue(json, PropertyNames.Name, value.Name);
+            SetJsonValue(json, PropertyNames.In, ToJsonValue(value.Location));
+
+            return json;
+        }
+
+        /// <summary>
+        /// Serializes a <see cref="Tag"/> value.
+        /// </summary>
+        /// <param name="value">The <see cref="Tag"/> value to serialize.</param>
+        /// <returns>The <see cref="JsonValue"/>.</returns>
+        protected virtual JsonValue SerializeTag(Tag value)
+        {
+            if (ReferenceEquals(value, null)) return null;
+
+            var json = new JsonObject();
+
+            SetJsonValue(json, PropertyNames.Name, value.Name);
+            SetJsonValue(json, PropertyNames.Description, value.Description);
+            SetJsonObject(json, PropertyNames.ExternalDocs, value.ExternalDocumentation);
+
+            return json;
+        }
+
+        /// <summary>
+        /// Serializes a <see cref="ServerVariable"/> value.
+        /// </summary>
+        /// <param name="value">The <see cref="ServerVariable"/> value to serialize.</param>
+        /// <returns>The <see cref="JsonValue"/>.</returns>
+        protected virtual JsonValue SerializeServerVariable(ServerVariable value)
+        {
+            if (ReferenceEquals(value, null)) return null;
+
+            var json = new JsonObject();
+
+            SetJsonArray(json, PropertyNames.Enum, value.Enum);
+            SetJsonValue(json, PropertyNames.Default, value.Default);
+            SetJsonValue(json, PropertyNames.Description, value.Description);
+
+            return json;
+        }
+
+        /// <summary>
+        /// Serializes a <see cref="Server"/> value.
+        /// </summary>
+        /// <param name="value">The <see cref="Server"/> value to serialize.</param>
+        /// <returns>The <see cref="JsonValue"/>.</returns>
+        protected virtual JsonValue SerializeServer(Server value)
+        {
+            if (ReferenceEquals(value, null)) return null;
+
+            var json = new JsonObject();
+
+            SetJsonValue(json, PropertyNames.Url, value.Url);
+            SetJsonValue(json, PropertyNames.Description, value.Description);
+            SetJsonMap(json, PropertyNames.Variables, value.Variables);
+
+            return json;
+        }
+
+        /// <summary>
+        /// Serializes a <see cref="SecurityScheme"/> value.
+        /// </summary>
+        /// <param name="value">The <see cref="SecurityScheme"/> value to serialize.</param>
+        /// <returns>The <see cref="JsonValue"/>.</returns>
+        protected virtual JsonValue SerializeSecurityScheme(SecurityScheme value) =>
+            SerializeUnknown(value);
+
+        /// <summary>
+        /// Serializes a <see cref="Schema"/> value.
+        /// </summary>
+        /// <param name="value">The schema value to serialize.</param>
+        /// <returns>The <see cref="JsonValue"/>.</returns>
+        protected virtual JsonValue SerializeSchema(Schema value)
+        {
+            if (ReferenceEquals(value, null)) return null;
+
+            var json = new JsonObject();
+
+            SetJsonValue(json, PropertyNames.Title, value.Title);
+            SetJsonValue(json, PropertyNames.Description, value.Description);
+            SetJsonValue(json, PropertyNames.Type, ToJsonValue(value.Type));
+            SetJsonValue(json, PropertyNames.Format, value.Format);
+
+            SetJsonValue(json, PropertyNames.Pattern, value.Pattern);
+            SetJsonArray(json, PropertyNames.EnumValue, value.Enum);
+
+            SetJsonFlag(json, PropertyNames.Deprecated, value.Options, SchemaOptions.Deprecated);
+            SetJsonFlag(json, PropertyNames.Nullable, value.Options, SchemaOptions.Nullable);
+            SetJsonFlag(json, PropertyNames.Required, value.Options, SchemaOptions.Required);
+            SetJsonFlag(json, PropertyNames.UniqueItems, value.Options, SchemaOptions.UniqueItems);
+
+            SetJsonArray(json, PropertyNames.AllOf, value.AllOf);
+            SetJsonArray(json, PropertyNames.AnyOf, value.AnyOf);
+            SetJsonArray(json, PropertyNames.OneOf, value.OneOf);
+            SetJsonArray(json, PropertyNames.Not, value.Not);
+
+            SetJsonNumber(json, PropertyNames.Minimum, value.NumberRange.Minimum);
+            if (value.NumberRange.Minimum.HasValue)
+                SetJsonFlag(json, PropertyNames.ExclusiveMinimum, value.NumberRange.RangeOptions, RangeOptions.MinimumInclusive, invert: true);
+
+            SetJsonNumber(json, PropertyNames.Maximum, value.NumberRange.Maximum);
+            if (value.NumberRange.Maximum.HasValue)
+                SetJsonFlag(json, PropertyNames.ExclusiveMaximum, value.NumberRange.RangeOptions, RangeOptions.MaximumInclusive, invert: true);
+
+            SetJsonNumber(json, PropertyNames.MultipleOf, value.NumberRange.MultipleOf);
+
+            SetJsonValue(json, PropertyNames.MinLength, value.LengthRange.Minimum);
+            SetJsonValue(json, PropertyNames.MaxLength, value.LengthRange.Maximum);
+
+            SetJsonValue(json, PropertyNames.MinProperties, value.PropertiesRange.Minimum);
+            SetJsonValue(json, PropertyNames.MaxProperties, value.PropertiesRange.Maximum);
+
+            SetJsonObject(json, PropertyNames.Items, value.Items);
+            SetJsonMap(json, PropertyNames.Properties, value.Properties);
+            SetJsonMap(json, PropertyNames.AdditionalProperties, value.AdditionalProperties);
+
+            SetJsonObject(json, PropertyNames.ExternalDocs, value.ExternalDocumentation);
+
+            return json;
+        }
+
+        /// <summary>
+        /// Serializes an unknown object type.
+        /// </summary>
+        /// <typeparam name="T">The type of the object. This may not reflect the exact object type.</typeparam>
+        /// <param name="value">The object value.</param>
+        /// <returns>The serialized <see cref="JsonValue"/>.</returns>
+        protected virtual JsonValue SerializeUnknown<T>(T value)
+        {
+            if (ReferenceEquals(value, null)) return null;
+
+            var mySerializers = _mySerializers;
+            if (mySerializers == null)
+            {
+                Thread.MemoryBarrier();
+                mySerializers = _serializers.GetOrAdd(GetType().TypeHandle, th => new SerializerInfo(Type.GetTypeFromHandle(th)));
+                _mySerializers = mySerializers;
+            }
+
+            return _mySerializers.Serialize(this, value);
+        }
+
+        /// <summary>Serializes the specified OpenAPI object to a JSON value.</summary>
+        /// <typeparam name="T">The type of the OpenAPI object.</typeparam>
+        /// <param name="value">The instance of the OpenAPI object.</param>
+        /// <returns>The serialized value.</returns>
+        public virtual JsonValue Serialize<T>(T value)
+        {
+            if (ReferenceEquals(value, null)) return null;
+
+            if (typeof(T) == typeof(ApiKeySecurityScheme)) return SerializeApiKeySecurityScheme((ApiKeySecurityScheme)(object)value);
+            if (typeof(T) == typeof(Callback)) return SerializeCallback((Callback)(object)value);
+            if (typeof(T) == typeof(Components)) return SerializeComponents((Components)(object)value);
+            if (typeof(T) == typeof(Contact)) return SerializeContact((Contact)(object)value);
+            if (typeof(T) == typeof(Document)) return SerializeDocument((Document)(object)value);
+            if (typeof(T) == typeof(Example)) return SerializeExample((Example)(object)value);
+            if (typeof(T) == typeof(ExternalDocumentation)) return SerializeExternalDocumentation((ExternalDocumentation)(object)value);
+            if (typeof(T) == typeof(HttpSecurityScheme)) return SerializeHttpSecurityScheme((HttpSecurityScheme)(object)value);
+            if (typeof(T) == typeof(Information)) return SerializeInformation((Information)(object)value);
+            if (typeof(T) == typeof(License)) return SerializeLicense((License)(object)value);
+            if (typeof(T) == typeof(Link)) return SerializeLink((Link)(object)value);
+            if (typeof(T) == typeof(MediaType)) return SerializeMediaType((MediaType)(object)value);
+            if (typeof(T) == typeof(OAuth2SecurityScheme)) return SerializeOAuth2SecurityScheme((OAuth2SecurityScheme)(object)value);
+            if (typeof(T) == typeof(OAuthFlow)) return SerializeOAuthFlow((OAuthFlow)(object)value);
+            if (typeof(T) == typeof(OpenIdConnectSecurityScheme)) return SerializeOpenIdConnectSecurityScheme((OpenIdConnectSecurityScheme)(object)value);
+            if (typeof(T) == typeof(Operation)) return SerializeOperation((Operation)(object)value);
+            if (typeof(T) == typeof(Parameter)) return SerializeParameter((Parameter)(object)value);
+            if (typeof(T) == typeof(ParameterBody)) return SerializeParameterBody((ParameterBody)(object)value);
+            if (typeof(T) == typeof(Path)) return SerializePath((Path)(object)value);
+            if (typeof(T) == typeof(PropertyEncoding)) return SerializePropertyEncoding((PropertyEncoding)(object)value);
+            if (typeof(T) == typeof(RequestBody)) return SerializeRequestBody((RequestBody)(object)value);
+            if (typeof(T) == typeof(Response)) return SerializeResponse((Response)(object)value);
+            if (typeof(T) == typeof(Schema)) return SerializeSchema((Schema)(object)value);
+            if (typeof(T) == typeof(SecurityScheme)) return SerializeSecurityScheme((SecurityScheme)(object)value);
+            if (typeof(T) == typeof(Server)) return SerializeServer((Server)(object)value);
+            if (typeof(T) == typeof(ServerVariable)) return SerializeServerVariable((ServerVariable)(object)value);
+            if (typeof(T) == typeof(Tag)) return SerializeTag((Tag)(object)value);
+            if (typeof(T) == typeof(Reference)) return SerializeReference((Reference)(object)value);
+
+            if (typeof(T) == typeof(string)) return (string)(object)value;
+
+            if (value is IReferable referable) return SerializeReferable(referable);
+            if (typeof(T) == typeof(KeyValuePair<ParameterKey, ParameterBody>))
+            {
+                var kvp = (KeyValuePair<ParameterKey, ParameterBody>)(object)value;
+                return SerializeParameter(kvp.Key, kvp.Value);
+            }
+            if (typeof(T) == typeof(KeyValuePair<ParameterKey, Referable<ParameterBody>>))
+            {
+                var kvp = (KeyValuePair<ParameterKey, Referable<ParameterBody>>)(object)value;
+                return SerializeParameter(kvp.Key, kvp.Value);
+            }
+
+            return SerializeUnknown(value);
+        }
+
+        #endregion
+
+        #region Deserialize
+
+        /// <summary>Deserializes the specified OpenAPI object from a JSON value.</summary>
+        /// <typeparam name="T">The expected type of the OpenAPI object.</typeparam>
+        /// <param name="value">The JSON value to deserialize.</param>
+        /// <returns>The OpenAPI object.</returns>
+        public T Deserialize<T>(JsonValue value)
+        {
+            throw new NotImplementedException();
+        }
+
+        #endregion
+
+        #region JsonHelpers
+
+        /// <summary>
+        /// Converts the specified dictionary into its object representation.
+        /// </summary>
+        /// <typeparam name="T">The type of value in the dictionary.</typeparam>
+        /// <param name="dictionary">The dictionary.</param>
+        /// <param name="required">A value indicating whether an empty object is required.</param>
+        /// <returns>The <see cref="JsonObject"/> representing the dictionary.</returns>
+        protected virtual JsonObject ToJsonMap<T>(IEnumerable<ValueTuple<string, T>> dictionary, bool required = false)
+        {
+            if (dictionary == null)
+            {
+                if (required) return new JsonObject();
+                return null;
+            }
+
+            using (var e = dictionary.GetEnumerator())
+            {
+                if (!e.MoveNext())
+                {
+                    if (required) return new JsonObject();
+                    return null;
+                }
+
+                var result = new JsonObject();
+                do
+                {
+                    result.Add(e.Current.Item1, Serialize(e.Current.Item2));
+                } while (e.MoveNext());
+
+                return result;
+            }
+        }
+
+        /// <summary>
+        /// Converts the specified dictionary into its object representation.
+        /// </summary>
+        /// <typeparam name="T">The type of value in the dictionary.</typeparam>
+        /// <param name="dictionary">The dictionary.</param>
+        /// <param name="required">A value indicating whether an empty object is required.</param>
+        /// <returns>The <see cref="JsonObject"/> representing the dictionary.</returns>
+        protected virtual JsonObject ToJsonMap<T>(IEnumerable<KeyValuePair<string, T>> dictionary, bool required = false)
+        {
+            if (dictionary == null)
+            {
+                if (required) return new JsonObject();
+                return null;
+            }
+
+            using (var e = dictionary.GetEnumerator())
+            {
+                if (!e.MoveNext())
+                {
+                    if (required) return new JsonObject();
+                    return null;
+                }
+
+                var result = new JsonObject();
+                do
+                {
+                    result.Add(e.Current.Key, Serialize(e.Current.Value));
+                } while (e.MoveNext());
+
+                return result;
+            }
+        }
+
+        /// <summary>
+        /// Sets a property in the specified <see cref="JsonObject"/>.
+        /// </summary>
+        /// <typeparam name="T">The type of value in the dictionary.</typeparam>
+        /// <param name="container">The object to set the property on.</param>
+        /// <param name="key">The property name in <paramref name="container"/>.</param>
+        /// <param name="dictionary">The dictionary value.</param>
+        /// <param name="required">A value indicating whether an empty object is required.</param>
+        protected virtual void SetJsonMap<T>(JsonObject container, string key, IEnumerable<ValueTuple<string, T>> dictionary, bool required = false)
+        {
+            var result = ToJsonMap(dictionary, required);
+            if (result != null) container.Add(key, result);
+        }
+
+        /// <summary>
+        /// Sets a property in the specified <see cref="JsonObject"/>.
+        /// </summary>
+        /// <typeparam name="T">The type of value in the dictionary.</typeparam>
+        /// <param name="container">The object to set the property on.</param>
+        /// <param name="key">The property name in <paramref name="container"/>.</param>
+        /// <param name="dictionary">The dictionary value.</param>
+        /// <param name="required">A value indicating whether an empty object is required.</param>
+        protected virtual void SetJsonMap<T>(JsonObject container, string key, IEnumerable<KeyValuePair<string, T>> dictionary, bool required = false)
+        {
+            var result = ToJsonMap(dictionary, required);
+            if (result != null) container.Add(key, result);
+        }
+
+        /// <summary>
+        /// Converts the specified list into its array representation.
+        /// </summary>
+        /// <typeparam name="T">The type of value in the list.</typeparam>
+        /// <param name="list">The type of elements in the list.</param>
+        /// <param name="required">A value indicating whether an empty array is required.</param>
+        /// <returns>The <see cref="JsonArray"/> containing the list.</returns>
+        protected virtual JsonArray ToJsonArray<T>(IEnumerable<T> list, bool required = false)
+        {
+            if (list == null)
+            {
+                if (required) return new JsonArray();
+                return null;
+            }
+
+            using (var e = list.GetEnumerator())
+            {
+                if (!e.MoveNext())
+                {
+                    if (required) return new JsonArray();
+                    return null;
+                }
+
+                var result = new JsonArray();
+                do
+                {
+                    result.Add(Serialize(e.Current));
+                } while (e.MoveNext());
+
+                return result;
+            }
+        }
+
+        /// <summary>
+        /// Sets a property in the specified <see cref="JsonObject"/>.
+        /// </summary>
+        /// <typeparam name="T">The type of value in the list.</typeparam>
+        /// <param name="container">The object to set the property on.</param>
+        /// <param name="key">The property name in <paramref name="container"/>.</param>
+        /// <param name="dictionary">The list value.</param>
+        /// <param name="required">A value indicating whether an empty array is required.</param>
+        protected virtual void SetJsonArray<T>(JsonObject container, string key, IEnumerable<T> list, bool required = false)
+        {
+            var result = ToJsonArray(list);
+            if (result != null) container.Add(key, result);
+        }
+
+        /// <summary>
+        /// Sets a property in the specified <see cref="JsonObject"/>.
+        /// </summary>
+        /// <typeparam name="TEnum">The type of the enum.</typeparam>
+        /// <param name="container">The object to set the property on.</param>
+        /// <param name="key">The property name in <paramref name="container"/>.</param>
+        /// <param name="value">The enum flags value.</param>
+        /// <param name="flag">The flag to search for.</param>
+        /// <param name="defaultState">The default state of the flag.</param>
+        /// <param name="required">A value indicating whether the property is required.</param>
+        /// <param name="invert">A value indicating whether to invert the flag check.</param>
+        protected virtual void SetJsonFlag<TEnum>(JsonObject container, string key, TEnum value, TEnum flag, bool defaultState = false, bool required = false, bool invert = false)
+            where TEnum : struct, IComparable, IConvertible, IFormattable
+        {
+            var v = EnumConvert.ToUInt64(value);
+            var f = EnumConvert.ToUInt64(flag);
+            var present = (v & f) == f;
+            if (invert) present = !present;
+
+            if (present != defaultState || required)
+                container.Add(key, present);
+        }
+
+        /// <summary>
+        /// Sets a property in the specified <see cref="JsonObject"/>.
+        /// </summary>
+        /// <param name="container">The object to set the property on.</param>
+        /// <param name="key">The property name in <paramref name="container"/>.</param>
+        /// <param name="value">The value.</param>
+        /// <param name="required">A value indicating whether the property is required.</param>
+        protected virtual void SetJsonValue(JsonObject container, string key, string value, bool required = false)
+        {
+            if (required && value == null)
+                container.Add(key, null);
+            else if (required || value != null)
+                container.Add(key, value);
+        }
+
+        /// <summary>
+        /// Sets a property in the specified <see cref="JsonObject"/>.
+        /// </summary>
+        /// <param name="container">The object to set the property on.</param>
+        /// <param name="key">The property name in <paramref name="container"/>.</param>
+        /// <param name="value">The value.</param>
+        /// <param name="required">A value indicating whether the property is required.</param>
+        protected virtual void SetJsonValue(JsonObject container, string key, JsonValue value, bool required = false)
+        {
+            if (required || value != null)
+                container.Add(key, value);
+        }
+
+        /// <summary>
+        /// Sets a property in the specified <see cref="JsonObject"/>.
+        /// </summary>
+        /// <param name="container">The object to set the property on.</param>
+        /// <param name="key">The property name in <paramref name="container"/>.</param>
+        /// <param name="value">The value.</param>
+        /// <param name="required">A value indicating whether the property is required.</param>
+        protected virtual void SetJsonValue(JsonObject container, string key, Uri value, bool required = false)
+        {
+            if (value == null && required)
+                container.Add(key, null);
+            else if (value != null)
+                container.Add(key, value.ToString());
+        }
+
+        /// <summary>
+        /// Sets a property in the specified <see cref="JsonObject"/>.
+        /// </summary>
+        /// <param name="container">The object to set the property on.</param>
+        /// <param name="key">The property name in <paramref name="container"/>.</param>
+        /// <param name="value">The value.</param>
+        /// <param name="required">A value indicating whether the property is required.</param>
+        protected virtual void SetJsonValue(JsonObject container, string key, ContentType value, bool required = false)
+        {
+            if (value == null && required)
+                container.Add(key, null);
+            else if (value != null)
+                container.Add(key, value.ToString());
+        }
+
+        /// <summary>
+        /// Sets a property in the specified <see cref="JsonObject"/>.
+        /// </summary>
+        /// <param name="container">The object to set the property on.</param>
+        /// <param name="key">The property name in <paramref name="container"/>.</param>
+        /// <param name="value">The value.</param>
+        /// <param name="required">A value indicating whether the property is required.</param>
+        protected virtual void SetJsonValue(JsonObject container, string key, MailAddress value, bool required = false)
+        {
+            if (value == null && required)
+                container.Add(key, null);
+            else if (value != null)
+                container.Add(key, value.ToString());
+        }
+
+        /// <summary>
+        /// Sets a property in the specified <see cref="JsonObject"/>.
+        /// </summary>
+        /// <param name="container">The object to set the property on.</param>
+        /// <param name="key">The property name in <paramref name="container"/>.</param>
+        /// <param name="value">The value.</param>
+        /// <param name="required">A value indicating whether the property is required.</param>
+        protected virtual void SetJsonNumber(JsonObject container, string key, Number? value, bool required = false)
+        {
+            if (value.HasValue)
+                container.Add(key, value.Value.ToValue());
+            else if (required)
+                container.Add(key, null);
+        }
+
+        /// <summary>
+        /// Sets a property in the specified <see cref="JsonObject"/>.
+        /// </summary>
+        /// <param name="container">The object to set the property on.</param>
+        /// <param name="key">The property name in <paramref name="container"/>.</param>
+        /// <param name="value">The value.</param>
+        /// <param name="required">A value indicating whether the property is required.</param>
+        protected virtual void SetJsonObject<T>(JsonObject container, string key, T value, bool required = false)
+        {
+            var js = Serialize(value);
+            if (js == null)
+            {
+                if (required) container.Add(key, new JsonObject());
+                return;
+            }
+
+            container.Add(key, js);
+        }
+
+        /// <summary>
+        /// Sets a property in the specified <see cref="JsonObject"/>.
+        /// </summary>
+        /// <param name="container">The object to set the property on.</param>
+        /// <param name="key">The property name in <paramref name="container"/>.</param>
+        /// <param name="value">The value.</param>
+        /// <param name="required">A value indicating whether the property is required.</param>
+        protected virtual void SetJsonObject<T>(JsonObject container, string key, Referable<T> value, bool required = false)
+            where T : class, IEquatable<T>
+        {
+            if (!value.HasValue)
+            {
+                if (required) container.Add(key, null);
+            }
+            else if (value.IsReference)
+            {
+                container.Add(key, SerializeReference(value.Reference));
+            }
+            else
+            {
+                container.Add(key, Serialize(value.Value));
+            }
+        }
+
+        /// <summary>
+        /// Converts the specified <see cref="ParameterStyle"/> to a <see cref="JsonValue"/>.
+        /// </summary>
+        /// <param name="parameterStyle">The <see cref="ParameterStyle"/> to convert.</param>
+        /// <returns>The <see cref="JsonValue"/>.</returns>
+        protected virtual JsonValue ToJsonValue(ParameterStyle parameterStyle)
+        {
+            switch (parameterStyle)
+            {
+                case ParameterStyle.Default: return null;
+                case ParameterStyle.Matrix: return EnumNames.Matrix;
+                case ParameterStyle.Label: return EnumNames.Label;
+                case ParameterStyle.Form: return EnumNames.Form;
+                case ParameterStyle.Simple: return EnumNames.Simple;
+                case ParameterStyle.SpaceDelimited: return EnumNames.SpaceDelimited;
+                case ParameterStyle.PipeDelimited: return EnumNames.PipeDelimited;
+                case ParameterStyle.DeepObject: return EnumNames.DeepObject;
+                default: throw new ArgumentOutOfRangeException(nameof(parameterStyle));
+            }
+        }
+
+        /// <summary>
+        /// Converts the specified <see cref="SchemaType"/> to a <see cref="JsonValue"/>.
+        /// </summary>
+        /// <param name="schemaType">The <see cref="SchemaType"/> to convert.</param>
+        /// <returns>The <see cref="JsonValue"/>.</returns>
+        protected virtual JsonValue ToJsonValue(SchemaType schemaType)
+        {
+            switch (schemaType)
+            {
+                case SchemaType.String: return EnumNames.String;
+                case SchemaType.Number: return EnumNames.Number;
+                case SchemaType.Object: return EnumNames.Object;
+                case SchemaType.Array: return EnumNames.Array;
+                case SchemaType.Boolean: return EnumNames.Boolean;
+                case SchemaType.Integer: return EnumNames.Integer;
+                default: throw new ArgumentOutOfRangeException(nameof(schemaType));
+            }
+        }
+
+        /// <summary>
+        /// Converts the specified <see cref="ParameterLocation"/> to a <see cref="JsonValue"/>.
+        /// </summary>
+        /// <param name="schemaType">The <see cref="ParameterLocation"/> to convert.</param>
+        /// <returns>The <see cref="JsonValue"/>.</returns>
+        protected virtual JsonValue ToJsonValue(ParameterLocation parameterLocation)
+        {
+            switch (parameterLocation)
+            {
+                case ParameterLocation.Query: return EnumNames.Query;
+                case ParameterLocation.Header: return EnumNames.Header;
+                case ParameterLocation.Path: return EnumNames.Path;
+                case ParameterLocation.Cookie: return EnumNames.Cookie;
+                default: throw new ArgumentOutOfRangeException(nameof(parameterLocation));
+            }
+        }
+
+        #endregion
+    }
+}


### PR DESCRIPTION
Implementing serialization (but not deserialization) for OpenAPI. Partial #85.

- Adding a comparer for component names (improves #80).
- Adding implicit operations for Referable<> where applicable.
- Change Parameter to ParameterBody for Operation.