### PR TITLE
Serialize Jump Table

### DIFF
--- a/src/SourceCode.Clay.OpenApi/Serialization/OpenApiSerializer.Serialize.cs
+++ b/src/SourceCode.Clay.OpenApi/Serialization/OpenApiSerializer.Serialize.cs
@@ -685,43 +685,16 @@ namespace SourceCode.Clay.OpenApi.Serialization
         {
             if (ReferenceEquals(value, null)) return null;
 
-            if (typeof(T) == typeof(ApiKeySecurityScheme)) return SerializeApiKeySecurityScheme((ApiKeySecurityScheme)(object)value);
-            if (typeof(T) == typeof(Callback)) return SerializeCallback((Callback)(object)value);
-            if (typeof(T) == typeof(Components)) return SerializeComponents((Components)(object)value);
-            if (typeof(T) == typeof(Contact)) return SerializeContact((Contact)(object)value);
-            if (typeof(T) == typeof(Document)) return SerializeDocument((Document)(object)value);
-            if (typeof(T) == typeof(Example)) return SerializeExample((Example)(object)value);
-            if (typeof(T) == typeof(ExternalDocumentation)) return SerializeExternalDocumentation((ExternalDocumentation)(object)value);
-            if (typeof(T) == typeof(HttpSecurityScheme)) return SerializeHttpSecurityScheme((HttpSecurityScheme)(object)value);
-            if (typeof(T) == typeof(Information)) return SerializeInformation((Information)(object)value);
-            if (typeof(T) == typeof(License)) return SerializeLicense((License)(object)value);
-            if (typeof(T) == typeof(Link)) return SerializeLink((Link)(object)value);
-            if (typeof(T) == typeof(MediaType)) return SerializeMediaType((MediaType)(object)value);
-            if (typeof(T) == typeof(OAuth2SecurityScheme)) return SerializeOAuth2SecurityScheme((OAuth2SecurityScheme)(object)value);
-            if (typeof(T) == typeof(OAuthFlow)) return SerializeOAuthFlow((OAuthFlow)(object)value);
-            if (typeof(T) == typeof(OpenIdConnectSecurityScheme)) return SerializeOpenIdConnectSecurityScheme((OpenIdConnectSecurityScheme)(object)value);
-            if (typeof(T) == typeof(Operation)) return SerializeOperation((Operation)(object)value);
-            if (typeof(T) == typeof(Parameter)) return SerializeParameter((Parameter)(object)value);
-            if (typeof(T) == typeof(ParameterBody)) return SerializeParameterBody((ParameterBody)(object)value);
-            if (typeof(T) == typeof(Path)) return SerializePath((Path)(object)value);
-            if (typeof(T) == typeof(PropertyEncoding)) return SerializePropertyEncoding((PropertyEncoding)(object)value);
-            if (typeof(T) == typeof(RequestBody)) return SerializeRequestBody((RequestBody)(object)value);
-            if (typeof(T) == typeof(Response)) return SerializeResponse((Response)(object)value);
-            if (typeof(T) == typeof(Schema)) return SerializeSchema((Schema)(object)value);
-            if (typeof(T) == typeof(SecurityScheme)) return SerializeSecurityScheme((SecurityScheme)(object)value);
-            if (typeof(T) == typeof(Server)) return SerializeServer((Server)(object)value);
-            if (typeof(T) == typeof(ServerVariable)) return SerializeServerVariable((ServerVariable)(object)value);
-            if (typeof(T) == typeof(Tag)) return SerializeTag((Tag)(object)value);
-            if (typeof(T) == typeof(Reference)) return SerializeReference((Reference)(object)value);
-
             if (typeof(T) == typeof(string)) return (string)(object)value;
 
             if (value is IReferable referable) return SerializeReferable(referable);
+
             if (typeof(T) == typeof(KeyValuePair<ParameterKey, ParameterBody>))
             {
                 var kvp = (KeyValuePair<ParameterKey, ParameterBody>)(object)value;
                 return SerializeParameter(kvp.Key, kvp.Value);
             }
+
             if (typeof(T) == typeof(KeyValuePair<ParameterKey, Referable<ParameterBody>>))
             {
                 var kvp = (KeyValuePair<ParameterKey, Referable<ParameterBody>>)(object)value;


### PR DESCRIPTION
Turns out that the .Net JITter does not optimize `typeof(T) == typeof(Foo)`. Using the jump table that already exists in SerializeUnknown.

## Results

``` ini

BenchmarkDotNet=v0.10.9.321-nightly, OS=Windows 10 Redstone 2 [1703, Creators Update] (10.0.15063.674)
Processor=Intel Core i7-4800MQ CPU 2.70GHz (Haswell), ProcessorCount=8
Frequency=2630626 Hz, Resolution=380.1377 ns, Timer=TSC
  [Host]     : .NET Framework 4.6.2 (CLR 4.0.30319.42000), 64bit RyuJIT-v4.7.2115.0
  DefaultJob : .NET Framework 4.6.2 (CLR 4.0.30319.42000), 64bit RyuJIT-v4.7.2115.0


```
|             Method |     Mean |     Error |    StdDev |
|------------------- |---------:|----------:|----------:|
|       IfStatements | 906.7 ns | 17.918 ns | 16.761 ns |
| CachedIfStatements | 596.7 ns |  5.664 ns |  5.298 ns |
|          JumpTable | 531.6 ns | 10.165 ns |  9.011 ns |

## Benchmark

```c#
    public class TypeCheckBenchmarks
    {
        private static readonly Type String = typeof(string);
        private static readonly Type Byte = typeof(byte);
        private static readonly Type SByte = typeof(sbyte);
        private static readonly Type UInt16 = typeof(ushort);
        private static readonly Type Int16 = typeof(short);
        private static readonly Type UInt32 = typeof(uint);
        private static readonly Type Int32 = typeof(int);
        private static readonly Type UInt64 = typeof(ulong);
        private static readonly Type Int64 = typeof(long);
        private static readonly Type Guid = typeof(Guid);
        private static readonly Type TimeSpan = typeof(TimeSpan);
        private static readonly Type DateTime = typeof(DateTime);
        private static readonly Type DateTimeOffset = typeof(DateTimeOffset);

        private static readonly Dictionary<RuntimeTypeHandle, Action> _jumpTable = new Dictionary<RuntimeTypeHandle, Action>()
        {
            [String.TypeHandle] = () => Stream.ToString(),
            [Byte.TypeHandle] = () => Stream.ToString(),
            [SByte.TypeHandle] = () => Stream.ToString(),
            [UInt16.TypeHandle] = () => Stream.ToString(),
            [Int16.TypeHandle] = () => Stream.ToString(),
            [UInt32.TypeHandle] = () => Stream.ToString(),
            [Int32.TypeHandle] = () => Stream.ToString(),
            [UInt64.TypeHandle] = () => Stream.ToString(),
            [Int64.TypeHandle] = () => Stream.ToString(),
            [Guid.TypeHandle] = () => Stream.ToString(),
            [TimeSpan.TypeHandle] = () => Stream.ToString(),
            [DateTime.TypeHandle] = () => Stream.ToString(),
            [DateTimeOffset.TypeHandle] = () => Stream.ToString(),
        };

        private static volatile Stream Stream = Stream.Null;
        private static volatile Byte[] Empty = Array.Empty<Byte>();

        [Benchmark]
        public static void IfStatements()
        {
            IfStatements<string>();
            IfStatements<byte>();
            IfStatements<sbyte>();
            IfStatements<ushort>();
            IfStatements<short>();
            IfStatements<uint>();
            IfStatements<int>();
            IfStatements<ulong>();
            IfStatements<long>();
            IfStatements<Guid>();
            IfStatements<TimeSpan>();
            IfStatements<DateTime>();
            IfStatements<DateTimeOffset>();
        }

        [Benchmark]
        public static void CachedIfStatements()
        {
            CachedIfStatements<string>();
            CachedIfStatements<byte>();
            CachedIfStatements<sbyte>();
            CachedIfStatements<ushort>();
            CachedIfStatements<short>();
            CachedIfStatements<uint>();
            CachedIfStatements<int>();
            CachedIfStatements<ulong>();
            CachedIfStatements<long>();
            CachedIfStatements<Guid>();
            CachedIfStatements<TimeSpan>();
            CachedIfStatements<DateTime>();
            CachedIfStatements<DateTimeOffset>();
        }

        [Benchmark]
        public static void JumpTable()
        {
            JumpTable<string>();
            JumpTable<byte>();
            JumpTable<sbyte>();
            JumpTable<ushort>();
            JumpTable<short>();
            JumpTable<uint>();
            JumpTable<int>();
            JumpTable<ulong>();
            JumpTable<long>();
            JumpTable<Guid>();
            JumpTable<TimeSpan>();
            JumpTable<DateTime>();
            JumpTable<DateTimeOffset>();
        }

        public static void IfStatements<T>()
        {
            if (typeof(T) == typeof(string)) Stream.ToString();
            if (typeof(T) == typeof(byte)) Stream.ToString();
            if (typeof(T) == typeof(sbyte)) Stream.ToString();
            if (typeof(T) == typeof(ushort)) Stream.ToString();
            if (typeof(T) == typeof(short)) Stream.ToString();
            if (typeof(T) == typeof(uint)) Stream.ToString();
            if (typeof(T) == typeof(int)) Stream.ToString();
            if (typeof(T) == typeof(ulong)) Stream.ToString();
            if (typeof(T) == typeof(long)) Stream.ToString();
            if (typeof(T) == typeof(Guid)) Stream.ToString();
            if (typeof(T) == typeof(TimeSpan)) Stream.ToString();
            if (typeof(T) == typeof(DateTime)) Stream.ToString();
            if (typeof(T) == typeof(DateTimeOffset)) Stream.ToString();
        }

        public static void CachedIfStatements<T>()
        {
            if (typeof(T) == String) Stream.ToString();
            if (typeof(T) == Byte) Stream.ToString();
            if (typeof(T) == SByte) Stream.ToString();
            if (typeof(T) == UInt16) Stream.ToString();
            if (typeof(T) == Int16) Stream.ToString();
            if (typeof(T) == UInt32) Stream.ToString();
            if (typeof(T) == Int32) Stream.ToString();
            if (typeof(T) == UInt64) Stream.ToString();
            if (typeof(T) == Int64) Stream.ToString();
            if (typeof(T) == Guid) Stream.ToString();
            if (typeof(T) == TimeSpan) Stream.ToString();
            if (typeof(T) == DateTime) Stream.ToString();
            if (typeof(T) == DateTimeOffset) Stream.ToString();
        }

        public static void JumpTable<T>()
        {
            _jumpTable[typeof(T).TypeHandle]();
        }
    }
```