### PR TITLE
OpenAPI Bugs

### DIFF
--- a/src/SourceCode.Clay.OpenApi.Tests/SerializeTests.cs
+++ b/src/SourceCode.Clay.OpenApi.Tests/SerializeTests.cs
@@ -638,7 +638,7 @@ namespace SourceCode.Clay.OpenApi.Tests
                                 }
                             },
                             ["description"] = "Description",
-                            ["requestBodies"] = true
+                            ["required"] = true
                         }
                     },
                     ["responses"] = new JsonObject()

--- a/src/SourceCode.Clay.OpenApi/Builders/DocumentBuilder.cs
+++ b/src/SourceCode.Clay.OpenApi/Builders/DocumentBuilder.cs
@@ -71,6 +71,7 @@ namespace SourceCode.Clay.OpenApi
             Paths = new Dictionary<string, Referable<Path>>();
             Security = new List<Referable<SecurityScheme>>();
             Tags = new List<Tag>();
+            Version = new SemanticVersion(3, 0, 0);
         }
 
         /// <summary>

--- a/src/SourceCode.Clay.OpenApi/Serialization/OpenApiSerializer.Serialize.cs
+++ b/src/SourceCode.Clay.OpenApi/Serialization/OpenApiSerializer.Serialize.cs
@@ -58,7 +58,7 @@ namespace SourceCode.Clay.OpenApi.Serialization
 
             SetJsonValue(json, PropertyConstants.Description, value.Description);
             SetJsonMap(json, PropertyConstants.Content, content);
-            SetJsonFlag(json, PropertyConstants.RequestBodies, value.Options, RequestBodyOptions.Required);
+            SetJsonFlag(json, PropertyConstants.Required, value.Options, RequestBodyOptions.Required);
 
             return json;
         }


### PR DESCRIPTION
Fixing some bugs

- DocumentBuilder defaults to version 3.0.0 now.
- RequestBody.Required was serializing as "requestBodies"