### PR TITLE
System.IO Extensions

### DIFF
--- a/src/SourceCode.Clay.Buffers.Tests/BufferComparerTests.cs
+++ b/src/SourceCode.Clay.Buffers.Tests/BufferComparerTests.cs
@@ -15,7 +15,7 @@ namespace SourceCode.Clay.Buffers.Tests
     {
         #region Helpers
 
-        private static ArraySegment<byte> GenerateSegment(ushort offset, ushort length, int delta = 0)
+        public static ArraySegment<byte> GenerateSegment(ushort offset, ushort length, int delta = 0)
         {
             var result = new byte[length + offset * 2]; // Add extra space at start and end
             for (var i = 1 + offset; i < length + offset; i++)
@@ -24,10 +24,10 @@ namespace SourceCode.Clay.Buffers.Tests
             return new ArraySegment<byte>(result, offset, length);
         }
 
-        private static ReadOnlyMemory<byte> AsReadOnlyMemory(this ArraySegment<byte> seg)
+        public static ReadOnlyMemory<byte> AsReadOnlyMemory(this ArraySegment<byte> seg)
             => (ReadOnlyMemory<byte>)seg;
 
-        private static ReadOnlyMemory<byte> AsReadOnlyMemory(this byte[] array)
+        public static ReadOnlyMemory<byte> AsReadOnlyMemory(this byte[] array)
             => (ReadOnlyMemory<byte>)array;
 
         #endregion

--- a/src/SourceCode.Clay.Buffers.Tests/IO/StreamExtensionsTests.cs
+++ b/src/SourceCode.Clay.Buffers.Tests/IO/StreamExtensionsTests.cs
@@ -1,0 +1,63 @@
+#region License
+
+// Copyright (c) K2 Workflow (SourceCode Technology Holdings Inc.). All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+#endregion
+
+using SourceCode.Clay.Buffers.Tests;
+using SourceCode.Clay.IO;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace SourceCode.Clay.Buffers.IO.Tests
+{
+    public static class StreamExtensionsTests
+    {
+        #region Methods
+
+        [Fact(DisplayName = nameof(StreamExtensions_Write))]
+        public static void StreamExtensions_Write()
+        {
+            var buffer = BufferComparerTests.GenerateSegment(0, 64, 1);
+            var memory = new ReadOnlyMemory<byte>(buffer.Array, buffer.Offset, buffer.Count);
+
+            using (var specimen = new MemoryStream())
+            {
+                specimen.Write(memory);
+                Assert.Equal((IEnumerable<byte>)buffer, specimen.ToArray());
+            }
+
+            using (var specimen = new MemoryStream())
+            {
+                specimen.Write(memory, 13);
+                Assert.Equal((IEnumerable<byte>)buffer, specimen.ToArray());
+            }
+        }
+
+        [Fact(DisplayName = nameof(StreamExtensions_WriteAsync))]
+        public static async Task StreamExtensions_WriteAsync()
+        {
+            var buffer = BufferComparerTests.GenerateSegment(0, 64, 1);
+            var memory = new ReadOnlyMemory<byte>(buffer.Array, buffer.Offset, buffer.Count);
+
+            using (var specimen = new MemoryStream())
+            {
+                await specimen.WriteAsync(memory);
+                Assert.Equal((IEnumerable<byte>)buffer, specimen.ToArray());
+            }
+
+            using (var specimen = new MemoryStream())
+            {
+                await specimen.WriteAsync(memory, 13);
+                Assert.Equal((IEnumerable<byte>)buffer, specimen.ToArray());
+            }
+        }
+
+        #endregion
+    }
+}

--- a/src/SourceCode.Clay.Buffers/IO/StreamExtensions.cs
+++ b/src/SourceCode.Clay.Buffers/IO/StreamExtensions.cs
@@ -1,0 +1,105 @@
+#region License
+
+// Copyright (c) K2 Workflow (SourceCode Technology Holdings Inc.). All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+#endregion
+
+using System;
+using System.Buffers;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace SourceCode.Clay.IO
+{
+    /// <summary>
+    /// Represents buffer extensions for <see cref="Stream"/>.
+    /// </summary>
+    public static class StreamExtensions
+    {
+        #region Write
+
+        /// <summary>
+        /// Writes the specified <see cref="ReadOnlyMemory{T}" /> to the specified
+        /// <see cref="Stream" />.
+        /// </summary>
+        /// <param name="stream">The stream to write to.</param>
+        /// <param name="memory">The memory to write.</param>
+        /// <param name="bufferLength">The maximum length of the buffer. The default is 81920.</param>
+        public static void Write(this Stream stream, ReadOnlyMemory<byte> memory, int bufferLength = 81920)
+            => Write(stream, memory.Span, bufferLength);
+
+        /// <summary>
+        /// Writes the specified <see cref="ReadOnlySpan{T}" /> to the specified
+        /// <see cref="Stream" />.
+        /// </summary>
+        /// <param name="stream">The stream to write to.</param>
+        /// <param name="span">The span to write.</param>
+        /// <param name="bufferLength">The maximum length of the buffer. The default is 81920.</param>
+        public static void Write(this Stream stream, ReadOnlySpan<byte> span, int bufferLength = 81920)
+        {
+            if (stream == null) throw new ArgumentNullException(nameof(stream));
+            if (bufferLength < 1) throw new ArgumentOutOfRangeException(nameof(bufferLength));
+            if (span.Length == 0) return;
+
+            bufferLength = Math.Min(bufferLength, span.Length);
+            var ba = ArrayPool<byte>.Shared.Rent(bufferLength);
+            try
+            {
+                var offset = 0;
+                while (offset < span.Length)
+                {
+                    var toCopy = Math.Min(bufferLength, span.Length - offset);
+                    span.Slice(offset, toCopy).CopyTo(ba);
+                    stream.Write(ba, 0, toCopy);
+                    offset += toCopy;
+                }
+            }
+            finally
+            {
+                ArrayPool<byte>.Shared.Return(ba);
+            }
+        }
+
+        /// <summary>
+        /// Asynchronously writes the specified <see cref="ReadOnlyMemory{T}{T}" /> to the specified
+        /// <see cref="Stream" />.
+        /// </summary>
+        /// <param name="stream">The stream to write to.</param>
+        /// <param name="memory">The memory to write.</param>
+        /// <param name="bufferLength">The maximum length of the buffer. The default is 81920.</param>
+        /// <param name="cancellationToken">The cancellation token.</param>
+        public static Task WriteAsync(this Stream stream, ReadOnlyMemory<byte> memory, int bufferLength = 81920, CancellationToken cancellationToken = default)
+        {
+            if (stream == null) throw new ArgumentNullException(nameof(stream));
+            if (bufferLength < 1) throw new ArgumentOutOfRangeException(nameof(bufferLength));
+
+            async Task Impl()
+            {
+                bufferLength = Math.Min(bufferLength, memory.Length);
+                var ba = ArrayPool<byte>.Shared.Rent(bufferLength);
+                try
+                {
+                    var offset = 0;
+                    while (offset < memory.Length)
+                    {
+                        var toCopy = Math.Min(bufferLength, memory.Length - offset);
+                        memory.Span.Slice(offset, toCopy).CopyTo(ba);
+                        await stream.WriteAsync(ba, 0, toCopy, cancellationToken);
+                        offset += toCopy;
+                    }
+                }
+                finally
+                {
+                    ArrayPool<byte>.Shared.Return(ba);
+                }
+            }
+
+            if (memory.Length == 0) return Task.CompletedTask;
+            return Impl();
+        }
+
+        #endregion
+    }
+}

--- a/src/SourceCode.Clay/IO/FileLock.cs
+++ b/src/SourceCode.Clay/IO/FileLock.cs
@@ -1,0 +1,77 @@
+#region License
+
+// Copyright (c) K2 Workflow (SourceCode Technology Holdings Inc.). All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+#endregion
+
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace SourceCode.Clay.IO
+{
+    /// <summary>
+    /// Represents methods for file locking.
+    /// </summary>
+    public static class FileLock
+    {
+        #region Methods
+
+        /// <summary>
+        /// Asynchronously waits for a lock on a file.
+        /// </summary>
+        /// <param name="path">The path to the file to lock.</param>
+        /// <param name="mode">The mode for opening the file.</param>
+        /// <param name="access">The access to request on the file.</param>
+        /// <param name="share">The lock sharing option.</param>
+        /// <param name="bufferSize">The size of the buffer. The default is 81920.</param>
+        /// <param name="pollInterval">The interval in milliseconds at which the filesystem is polled. The default is the timer resolution on the system.</param>
+        /// <param name="timeout">The maximum interval in milliseconds that the method will wait.</param>
+        /// <param name="cancellationToken">The cancellation token. The default is <see cref="CancellationToken.None" />.</param>
+        /// <returns>A <see cref="Task{TResult}" /> that represents the pending file. The value of <see cref="Task{TResult}" /> will contain
+        /// the locked file when the operation completes.</returns>
+        public static async ValueTask<FileStream> WaitForFileAsync(
+            string path,
+            FileMode mode,
+            FileAccess access = FileAccess.ReadWrite,
+            FileShare share = FileShare.None,
+            int bufferSize = 81920,
+            int pollInterval = 1,
+            int timeout = 1000,
+            CancellationToken cancellationToken = default)
+        {
+            if (string.IsNullOrEmpty(path)) throw new ArgumentNullException(nameof(path));
+            if (pollInterval < 1) throw new ArgumentOutOfRangeException(nameof(pollInterval));
+            if (timeout < pollInterval) throw new ArgumentOutOfRangeException(nameof(timeout));
+
+#           pragma warning disable S1854 // Dead stores should be removed
+            // Not a dead store
+
+            var tickEnd = Environment.TickCount + timeout;
+#           pragma warning restore S1854 // Dead stores should be removed
+
+            while (true)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+
+                FileStream fs = null;
+                try
+                {
+                    fs = new FileStream(path, mode, access, share, bufferSize);
+                    return fs;
+                }
+                catch (IOException) when (
+                    !cancellationToken.IsCancellationRequested &&
+                    Environment.TickCount < tickEnd)
+                {
+                    fs?.Dispose();
+                    await Task.Delay(pollInterval, cancellationToken).ConfigureAwait(false);
+                }
+            }
+        }
+
+        #endregion
+    }
+}


### PR DESCRIPTION
Adding FileLock and StreamExtensions. FileLock is for acquiring locks on files, while StreamExtensions helps with working with ReadOnlyMemory and Span on Streams.

Fixes #130 and fixes #131.