### PR TITLE
HashCode Parity

### DIFF
--- a/src/SourceCode.Clay.Buffers.Tests/BufferComparerTests.cs
+++ b/src/SourceCode.Clay.Buffers.Tests/BufferComparerTests.cs
@@ -38,22 +38,22 @@ namespace SourceCode.Clay.Buffers.Tests
         [Fact(DisplayName = nameof(BufferComparer_GetHashCode_Null_Array))]
         public static void BufferComparer_GetHashCode_Null_Array()
         {
-            Assert.Equal(HashCode.FnvNull, BufferComparer.Array.GetHashCode(default));
+            Assert.Equal(BinaryHashCode.FnvNull, BufferComparer.Array.GetHashCode(default));
         }
 
         [Trait("Type", "Unit")]
         [Fact(DisplayName = nameof(BufferComparer_GetHashCode_Empty_Array))]
         public static void BufferComparer_GetHashCode_Empty_Array()
         {
-            Assert.Equal(HashCode.FnvEmpty, BufferComparer.Array.GetHashCode(Array.Empty<byte>()));
-            Assert.Equal(HashCode.FnvEmpty, BufferComparer.Memory.GetHashCode(Array.Empty<byte>()));
+            Assert.Equal(BinaryHashCode.FnvEmpty, BufferComparer.Array.GetHashCode(Array.Empty<byte>()));
+            Assert.Equal(BinaryHashCode.FnvEmpty, BufferComparer.Memory.GetHashCode(Array.Empty<byte>()));
         }
 
         [Trait("Type", "Unit")]
         [Fact(DisplayName = nameof(BufferComparer_GetHashCode_Empty_Memory))]
         public static void BufferComparer_GetHashCode_Empty_Memory()
         {
-            Assert.Equal(HashCode.FnvEmpty, BufferComparer.Memory.GetHashCode(Memory<byte>.Empty));
+            Assert.Equal(BinaryHashCode.FnvEmpty, BufferComparer.Memory.GetHashCode(Memory<byte>.Empty));
         }
 
         [Trait("Type", "Unit")]

--- a/src/SourceCode.Clay.Buffers/ArrayBufferComparer.cs
+++ b/src/SourceCode.Clay.Buffers/ArrayBufferComparer.cs
@@ -66,15 +66,15 @@ namespace SourceCode.Clay.Buffers
         {
             // Fnv has consistent handling for Null
             if (obj == null)
-                return HashCode.Fnv(obj);
+                return BinaryHashCode.Fnv(obj);
 
             // Calculate on full length
             if (HashCodeFidelity == 0 || obj.Length <= HashCodeFidelity) // Also handles Empty
-                return HashCode.Fnv(obj);
+                return BinaryHashCode.Fnv(obj);
 
             // Calculate on prefix
             var span = new ReadOnlySpan<byte>(obj, 0, HashCodeFidelity);
-            var hc = HashCode.Fnv(span);
+            var hc = BinaryHashCode.Fnv(span);
             return hc;
         }
 

--- a/src/SourceCode.Clay.Buffers/BinaryHashCode.Fnv.cs
+++ b/src/SourceCode.Clay.Buffers/BinaryHashCode.Fnv.cs
@@ -16,7 +16,7 @@ namespace SourceCode.Clay.Buffers
     /// <summary>
     /// Represents a way to calculate hash codes.
     /// </summary>
-    public static partial class HashCode // .Fnv
+    public static partial class BinaryHashCode // .Fnv
     {
         #region Constants
 

--- a/src/SourceCode.Clay.Buffers/MemoryBufferComparer.cs
+++ b/src/SourceCode.Clay.Buffers/MemoryBufferComparer.cs
@@ -68,11 +68,11 @@ namespace SourceCode.Clay.Buffers
 
             // Calculate on full length
             if (HashCodeFidelity == 0 || obj.Length <= HashCodeFidelity) // Also handles Empty
-                return HashCode.Fnv(obj.Span);
+                return BinaryHashCode.Fnv(obj.Span);
 
             // Calculate on prefix
             var slice = obj.Slice(0, HashCodeFidelity);
-            var hc = HashCode.Fnv(slice.Span);
+            var hc = BinaryHashCode.Fnv(slice.Span);
             return hc;
         }
 

--- a/src/SourceCode.Clay.Tests/HashCodeTests.cs
+++ b/src/SourceCode.Clay.Tests/HashCodeTests.cs
@@ -17,15 +17,41 @@ namespace SourceCode.Clay.Tests
         [Fact(DisplayName = nameof(HashCode_Add_OneValue))]
         public static void HashCode_Add_OneValue()
         {
-            var sut = new HashCode().Add(1);
+            var sut = new HashCode();
+            sut.Add(1);
             Assert.Equal(1364076727, sut.ToHashCode());
+        }
+
+        [Fact(DisplayName = nameof(HashCode_Tally_OneValue))]
+        public static void HashCode_Tally_OneValue()
+        {
+            var expected = new HashCode();
+            expected.Add(1);
+
+            var sut = new HashCode().Tally(1);
+
+            Assert.Equal(expected.ToHashCode(), sut.ToHashCode());
         }
 
         [Fact(DisplayName = nameof(HashCode_Add_TwoValues))]
         public static void HashCode_Add_TwoValues()
         {
-            var sut = new HashCode().Add(1).Add(1);
+            var sut = new HashCode();
+            sut.Add(1);
+            sut.Add(1);
             Assert.Equal(861615803, sut.ToHashCode());
+        }
+
+        [Fact(DisplayName = nameof(HashCode_Tally_TwoValues))]
+        public static void HashCode_Tally_TwoValues()
+        {
+            var expected = new HashCode();
+            expected.Add(1);
+            expected.Add(1);
+
+            var sut = new HashCode().Tally(1).Tally(1);
+
+            Assert.Equal(expected.ToHashCode(), sut.ToHashCode());
         }
 
         [Fact(DisplayName = nameof(HashCode_Add_256Values))]
@@ -33,55 +59,202 @@ namespace SourceCode.Clay.Tests
         {
             var sut = new HashCode();
             for (var i = 0; i < 256; i++)
-                sut = sut.Add(i);
+                sut.Add(i);
 
             Assert.Equal(974456161, sut.ToHashCode());
         }
 
-        [Fact(DisplayName = nameof(HashCode_Add_Combine))]
-        public static void HashCode_Add_Combine()
+        [Fact(DisplayName = nameof(HashCode_Tally_256Values))]
+        public static void HashCode_Tally_256Values()
         {
-            var a = new HashCode().Add(2);
-            var sut = new HashCode().Add(1).Add(a);
+            var expected = new HashCode();
+            var sut = new HashCode();
+            for (var i = 0; i < 256; i++)
+            {
+                expected.Add(i);
+                sut = sut.Tally(i);
+            }
 
-            Assert.Equal(-218950259, sut.ToHashCode());
+            Assert.Equal(expected.ToHashCode(), sut.ToHashCode());
         }
 
         [Fact(DisplayName = nameof(HashCode_Add_Generic))]
         public static void HashCode_Add_Generic()
         {
-            var sut = new HashCode().Add(1).Add(100.2);
+            var sut = new HashCode();
+            sut.Add(1);
+            sut.Add(100.2);
 
             Assert.Equal(-1261165540, sut.ToHashCode());
+        }
+
+        [Fact(DisplayName = nameof(HashCode_Tally_Generic))]
+        public static void HashCode_Tally_Generic()
+        {
+            var expected = new HashCode();
+            expected.Add(1);
+            expected.Add(100.2);
+
+            var sut = new HashCode().Tally(1).Tally(100.2);
+
+            Assert.Equal(expected.ToHashCode(), sut.ToHashCode());
         }
 
         [Fact(DisplayName = nameof(HashCode_Add_GenericEqualityComparer))]
         public static void HashCode_Add_GenericEqualityComparer()
         {
-            var a = new HashCode().Add(1).Add("Hello", StringComparer.Ordinal);
-            var b = new HashCode().Add(1).Add("Hello", StringComparer.OrdinalIgnoreCase);
+            var a = new HashCode();
+            a.Add(1);
+            a.Add("Hello", StringComparer.Ordinal);
+
+            var b = new HashCode();
+            b.Add(1);
+            b.Add("Hello", StringComparer.OrdinalIgnoreCase);
 
             Assert.NotEqual(a.ToHashCode(), b.ToHashCode());
         }
 
-        [Fact(DisplayName = nameof(HashCode_EqualsOperator))]
-        public static void HashCode_EqualsOperator()
+        [Fact(DisplayName = nameof(HashCode_Tally_GenericEqualityComparer))]
+        public static void HashCode_Tally_GenericEqualityComparer()
         {
-            var sut = new HashCode();
+            var expectedA = new HashCode();
+            expectedA.Add(1);
+            expectedA.Add("Hello", StringComparer.Ordinal);
 
-#           pragma warning disable CS1718 // Comparison made to same variable
-            Assert.True(sut == sut);
-#           pragma warning restore CS1718 // Comparison made to same variable
+            var expectedB = new HashCode();
+            expectedB.Add(1);
+            expectedB.Add("Hello", StringComparer.OrdinalIgnoreCase);
+
+            var sutA = new HashCode().Tally(1).Tally("Hello", StringComparer.Ordinal);
+            var sutB = new HashCode().Tally(1).Tally("Hello", StringComparer.OrdinalIgnoreCase);
+
+            Assert.Equal(expectedA.ToHashCode(), sutA.ToHashCode());
+            Assert.Equal(expectedB.ToHashCode(), sutB.ToHashCode());
         }
 
-        [Fact(DisplayName = nameof(HashCode_NotEqualsOperator))]
-        public static void HashCode_NotEqualsOperator()
+        [Fact(DisplayName = nameof(HashCode_AddRange))]
+        public static void HashCode_AddRange()
         {
-            var sut = new HashCode();
+            var bytes = new byte[1000];
+            for (var i = 0; i < bytes.Length; i++)
+                bytes[i] = unchecked((byte)i);
 
-#           pragma warning disable CS1718 // Comparison made to same variable
-            Assert.False(sut != sut);
-#           pragma warning restore CS1718 // Comparison made to same variable
+            var sut = new HashCode();
+            sut.AddRange(bytes);
+
+            Assert.Equal(-1861433025, sut.ToHashCode());
+        }
+
+        [Fact(DisplayName = nameof(HashCode_TallyRange))]
+        public static void HashCode_TallyRange()
+        {
+            var bytes = new byte[1000];
+            for (var i = 0; i < bytes.Length; i++)
+                bytes[i] = unchecked((byte)i);
+
+            var expected = new HashCode();
+            expected.AddRange(bytes);
+
+            var sut = new HashCode().TallyRange(bytes);
+
+            Assert.Equal(expected.ToHashCode(), sut.ToHashCode());
+        }
+
+        [Fact(DisplayName = nameof(HashCode_TallyCount_Array))]
+        public static void HashCode_TallyCount_Array()
+        {
+            var bytes = new byte[1000];
+            for (var i = 0; i < bytes.Length; i++)
+                bytes[i] = unchecked((byte)i);
+
+            var expected = new HashCode();
+            expected.Add(bytes.Length);
+
+            var sut = new HashCode().TallyCount(bytes);
+
+            Assert.Equal(expected.ToHashCode(), sut.ToHashCode());
+        }
+
+        [Fact(DisplayName = nameof(HashCode_TallyCount_Collection))]
+        public static void HashCode_TallyCount_Collection()
+        {
+            var bytes = new byte[1000];
+            for (var i = 0; i < bytes.Length; i++)
+                bytes[i] = unchecked((byte)i);
+
+            var expected = new HashCode();
+            expected.Add(bytes.Length);
+
+            var sut = new HashCode().TallyCount((System.Collections.ICollection)bytes);
+
+            Assert.Equal(expected.ToHashCode(), sut.ToHashCode());
+        }
+
+        [Fact(DisplayName = nameof(HashCode_TallyCount_GenericCollection))]
+        public static void HashCode_TallyCount_GenericCollection()
+        {
+            var bytes = new byte[1000];
+            for (var i = 0; i < bytes.Length; i++)
+                bytes[i] = unchecked((byte)i);
+
+            var expected = new HashCode();
+            expected.Add(bytes.Length);
+
+            var sut = new HashCode().TallyCount((System.Collections.Generic.ICollection<byte>)bytes);
+
+            Assert.Equal(expected.ToHashCode(), sut.ToHashCode());
+        }
+
+        [Fact(DisplayName = nameof(HashCode_TallyCount_ReadOnlyGenericCollection))]
+        public static void HashCode_TallyCount_ReadOnlyGenericCollection()
+        {
+            var bytes = new byte[1000];
+            for (var i = 0; i < bytes.Length; i++)
+                bytes[i] = unchecked((byte)i);
+
+            var expected = new HashCode();
+            expected.Add(bytes.Length);
+
+            var sut = new HashCode().TallyCount((System.Collections.Generic.IReadOnlyCollection<byte>)bytes);
+
+            Assert.Equal(expected.ToHashCode(), sut.ToHashCode());
+        }
+
+        [Fact(DisplayName = nameof(HashCode_Combine))]
+        public static void HashCode_Combine()
+        {
+            // Check that both:
+            // * All parameters are included
+            // * No parameters are duplicated
+            var hcs = new[]
+            {
+                HashCode.Combine(1),
+                HashCode.Combine(1, 2),
+                HashCode.Combine(1, 2, 3),
+                HashCode.Combine(1, 2, 3, 4),
+                HashCode.Combine(1, 2, 3, 4, 5),
+                HashCode.Combine(1, 2, 3, 4, 5, 6),
+                HashCode.Combine(1, 2, 3, 4, 5, 6, 7),
+                HashCode.Combine(1, 2, 3, 4, 5, 6, 7, 8),
+
+                HashCode.Combine(2),
+                HashCode.Combine(2, 3),
+                HashCode.Combine(2, 3, 4),
+                HashCode.Combine(2, 3, 4, 5),
+                HashCode.Combine(2, 3, 4, 5, 6),
+                HashCode.Combine(2, 3, 4, 5, 6, 7),
+                HashCode.Combine(2, 3, 4, 5, 6, 7, 8),
+                HashCode.Combine(2, 3, 4, 5, 6, 7, 8, 9),
+            };
+
+            for (var i = 0; i < hcs.Length; i++)
+            {
+                for (var j = 0; j < hcs.Length; j++)
+                {
+                    if (i == j) continue;
+                    Assert.NotEqual(hcs[i], hcs[j]);
+                }
+            }
         }
 
         #endregion

--- a/src/SourceCode.Clay/HashCodeExtensions.cs
+++ b/src/SourceCode.Clay/HashCodeExtensions.cs
@@ -1,0 +1,186 @@
+#region License
+
+// Copyright (c) K2 Workflow (SourceCode Technology Holdings Inc.). All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+#endregion
+
+using System.Collections.Generic;
+using System.Runtime;
+using System.Runtime.CompilerServices;
+
+namespace SourceCode.Clay
+{
+    /// <summary>
+    /// Represents fluent extensions for <see cref="HashCode"/>.
+    /// </summary>
+    public static class HashCodeExtensions
+    {
+        #region Methods
+
+        /// <summary>
+        /// Adds a hash code to the specified <see cref="HashCode"/> and
+        /// returns the changed <see cref="HashCode"/> value.
+        /// </summary>
+        /// <param name="hashCode">The <see cref="HashCode"/> to change.</param>
+        /// <param name="value">The hash code to add to <paramref name="hashCode"/>.</param>
+        /// <returns>The changed <see cref="HashCode"/>.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [TargetedPatchingOptOut("Performance critical for inlining across NGen images.")]
+        public static HashCode Tally(this HashCode hashCode, int value)
+        {
+            hashCode.Add(value);
+            return hashCode;
+        }
+
+        /// <summary>
+        /// Computes a hash code for the specified value and adds it to the specified
+        /// <see cref="HashCode"/>, then returns the changed <see cref="HashCode"/> value.
+        /// </summary>
+        /// <typeparam name="T">The type of value.</typeparam>
+        /// <param name="hashCode">The <see cref="HashCode"/> to change.</param>
+        /// <param name="value">The value to hash and add to <paramref name="hashCode"/>.</param>
+        /// <returns>The changed <see cref="HashCode"/>.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [TargetedPatchingOptOut("Performance critical for inlining across NGen images.")]
+        public static HashCode Tally<T>(this HashCode hashCode, T value)
+        {
+            hashCode.Add(value);
+            return hashCode;
+        }
+
+        /// <summary>
+        /// Computes a hash code for the specified value and adds it to the specified
+        /// <see cref="HashCode"/>, then returns the changed <see cref="HashCode"/> value.
+        /// </summary>
+        /// <typeparam name="T">The type of value.</typeparam>
+        /// <param name="hashCode">The <see cref="HashCode"/> to change.</param>
+        /// <param name="value">The value to hash and add to <paramref name="hashCode"/>.</param>
+        /// <param name="comparer">The comparer to use.</param>
+        /// <returns>The changed <see cref="HashCode"/>.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [TargetedPatchingOptOut("Performance critical for inlining across NGen images.")]
+        public static HashCode Tally<T>(this HashCode hashCode, T value, IEqualityComparer<T> comparer)
+        {
+            hashCode.Add(value, comparer);
+            return hashCode;
+        }
+
+        /// <summary>
+        /// Computes a hash code for the specified values and adds them to the specified
+        /// <see cref="HashCode"/>, then returns the changed <see cref="HashCode"/> value.
+        /// </summary>
+        /// <typeparam name="T">The type of value.</typeparam>
+        /// <param name="hashCode">The <see cref="HashCode"/> to change.</param>
+        /// <param name="values">The values to hash and add to <paramref name="hashCode"/>.</param>
+        /// <returns>The changed <see cref="HashCode"/>.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [TargetedPatchingOptOut("Performance critical for inlining across NGen images.")]
+        public static HashCode TallyRange<T>(this HashCode hashCode, T[] values)
+        {
+            hashCode.AddRange(values);
+            return hashCode;
+        }
+
+        /// <summary>
+        /// Computes a hash code for the specified values and adds them to the specified
+        /// <see cref="HashCode"/>, then returns the changed <see cref="HashCode"/> value.
+        /// </summary>
+        /// <typeparam name="T">The type of value.</typeparam>
+        /// <param name="hashCode">The <see cref="HashCode"/> to change.</param>
+        /// <param name="values">The values to hash and add to <paramref name="hashCode"/>.</param>
+        /// <param name="count">The number of items in <paramref name="values"/>.</param>
+        /// <returns>The changed <see cref="HashCode"/>.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [TargetedPatchingOptOut("Performance critical for inlining across NGen images.")]
+        public static HashCode TallyRange<T>(this HashCode hashCode, T[] values, int index, int count)
+        {
+            hashCode.AddRange(values, index, count);
+            return hashCode;
+        }
+
+        /// <summary>
+        /// Computes a hash code for the specified values and adds them to the specified
+        /// <see cref="HashCode"/>, then returns the changed <see cref="HashCode"/> value.
+        /// </summary>
+        /// <typeparam name="T">The type of value.</typeparam>
+        /// <param name="hashCode">The <see cref="HashCode"/> to change.</param>
+        /// <param name="values">The values to hash and add to <paramref name="hashCode"/>.</param>
+        /// <param name="index">The starting index in <paramref name="values"/>.</param>
+        /// <param name="count">The number of items in <paramref name="values"/>.</param>
+        /// <param name="comparer">The comparer to use.</param>
+        /// <returns>The changed <see cref="HashCode"/>.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [TargetedPatchingOptOut("Performance critical for inlining across NGen images.")]
+        public static HashCode TallyRange<T>(this HashCode hashCode, T[] values, int index, int count, IEqualityComparer<T> comparer)
+        {
+            hashCode.AddRange(values, index, count, comparer);
+            return hashCode;
+        }
+
+        /// <summary>
+        /// Adds the number of items in the specified collection to the specified <see cref="HashCode"/>.
+        /// </summary>
+        /// <param name="hashCode">The <see cref="HashCode"/> to change.</param>
+        /// <param name="collection">The collection to add.</param>
+        /// <returns>The changed <see cref="HashCode"/>.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [TargetedPatchingOptOut("Performance critical for inlining across NGen images.")]
+        public static HashCode TallyCount(this HashCode hashCode, System.Collections.ICollection collection)
+        {
+            if (collection == null) hashCode.Add(0);
+            else hashCode.Add(collection.Count);
+            return hashCode;
+        }
+
+        /// <summary>
+        /// Adds the number of items in the specified array to the specified <see cref="HashCode"/>.
+        /// </summary>
+        /// <typeparam name="T">The type of items in the collection.</typeparam>
+        /// <param name="hashCode">The <see cref="HashCode"/> to change.</param>
+        /// <param name="array">The array to add.</param>
+        /// <returns>The changed <see cref="HashCode"/>.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [TargetedPatchingOptOut("Performance critical for inlining across NGen images.")]
+        public static HashCode TallyCount<T>(this HashCode hashCode, T[] array)
+        {
+            if (array == null) hashCode.Add(0);
+            else hashCode.Add(array.Length);
+            return hashCode;
+        }
+
+        /// <summary>
+        /// Adds the number of items in the specified collection to the specified <see cref="HashCode"/>.
+        /// </summary>
+        /// <typeparam name="T">The type of items in the collection.</typeparam>
+        /// <param name="hashCode">The <see cref="HashCode"/> to change.</param>
+        /// <param name="collection">The collection to add.</param>
+        /// <returns>The changed <see cref="HashCode"/>.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [TargetedPatchingOptOut("Performance critical for inlining across NGen images.")]
+        public static HashCode TallyCount<T>(this HashCode hashCode, ICollection<T> collection)
+        {
+            if (collection == null) hashCode.Add(0);
+            else hashCode.Add(collection.Count);
+            return hashCode;
+        }
+
+        /// <summary>
+        /// Adds the number of items in the specified collection to the specified <see cref="HashCode"/>.
+        /// </summary>
+        /// <typeparam name="T">The type of items in the collection.</typeparam>
+        /// <param name="hashCode">The <see cref="HashCode"/> to change.</param>
+        /// <param name="collection">The collection to add.</param>
+        /// <returns>The changed <see cref="HashCode"/>.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [TargetedPatchingOptOut("Performance critical for inlining across NGen images.")]
+        public static HashCode TallyCount<T>(this HashCode hashCode, IReadOnlyCollection<T> collection)
+        {
+            if (collection == null) hashCode.Add(0);
+            else hashCode.Add(collection.Count);
+            return hashCode;
+        }
+
+        #endregion
+    }
+}


### PR DESCRIPTION
Fix #142: Align the interface with the proposal. Add extension methods because the proposal lacks DRY.

Fix #141: Rename HashCode.Fnv to BinaryHashCode.Fnv.