### PR TITLE
Simplify & rename JsonValueComparer

### DIFF
--- a/src/SourceCode.Clay.Json.Tests/JsonExtensionsTests.cs
+++ b/src/SourceCode.Clay.Json.Tests/JsonExtensionsTests.cs
@@ -22,6 +22,14 @@ namespace SourceCode.Clay.Json.Tests
         {
             ReadOnlyJsonObject json = null;
 
+            // Repros for: https://github.com/dotnet/corefx/issues/25005
+            //var a = new JsonArray(new JsonValue[] { "abc", 123, null });
+            //var b = new JsonArray(new JsonValue[] { "abc", 123 }); b.Add(null);
+            //var x = new JsonArray(new JsonValue[] { "abc", 123 }); x.Add(new JsonPrimitive((string)null));
+            //var p = new JsonPrimitive(Guid.NewGuid());
+            //var t = p.JsonType;
+            //var s = p.ToString();
+
             Assert.True(json == null);
             Assert.False(json != null);
         }
@@ -55,7 +63,7 @@ namespace SourceCode.Clay.Json.Tests
             Assert.Equal(ar1.ToString(), ar2.ToString());
 
             var pr1 = expected.GetPrimitive("Bar");
-            Assert.Equal(new JsonPrimitive(123), pr1, JsonComparer.Default);
+            Assert.Equal(new JsonPrimitive(123), pr1, JsonValueComparer.Default);
 
             var pr2 = pr1.ToString().ParseJsonPrimitive();
             Assert.Equal(pr1.ToString(), pr2.ToString());
@@ -70,7 +78,7 @@ namespace SourceCode.Clay.Json.Tests
             var expected = new ReadOnlyJsonObject(exp);
 
             var actual = new ReadOnlyJsonObject(expected.ToString().ParseJsonObject());
-            Assert.Equal(expected, actual, JsonComparer.Default);
+            Assert.Equal(expected, actual, JsonValueComparer.Default);
         }
 
         [Trait("Type", "Unit")]
@@ -134,7 +142,7 @@ namespace SourceCode.Clay.Json.Tests
             Assert.Equal(jobj.ToString(), json.ToString());
 
             var clone = json.Clone();
-            Assert.Equal(json, clone, JsonComparer.Default);
+            Assert.Equal(json, clone, JsonValueComparer.Default);
 
             Assert.Equal(json.Count, clone.Count);
             Assert.Equal(json.Keys.Count(), clone.Keys.Count());
@@ -259,13 +267,13 @@ namespace SourceCode.Clay.Json.Tests
 
                     if (i == j)
                     {
-                        Assert.Equal(ic, jc, JsonComparer.Default);
-                        Assert.Equal(primitives[i], primitives[j], JsonComparer.Default);
+                        Assert.Equal(ic, jc, JsonValueComparer.Default);
+                        Assert.Equal(primitives[i], primitives[j], JsonValueComparer.Default);
                     }
                     else
                     {
-                        Assert.NotEqual(ic, jc, JsonComparer.Default);
-                        Assert.NotEqual(primitives[i], primitives[j], JsonComparer.Default);
+                        Assert.NotEqual(ic, jc, JsonValueComparer.Default);
+                        Assert.NotEqual(primitives[i], primitives[j], JsonValueComparer.Default);
                     }
                 }
             }

--- a/src/SourceCode.Clay.Json/JsonExtensions.cs
+++ b/src/SourceCode.Clay.Json/JsonExtensions.cs
@@ -433,6 +433,8 @@ namespace SourceCode.Clay.Json
 
         #region Value
 
+        // These helpers would not be necessary if JsonPrimitive.Value was public
+
         internal static readonly Func<JsonPrimitive, object> GetValueFromPrimitive = GetValueFromPrimitiveImpl();
 
         private static Func<JsonPrimitive, object> GetValueFromPrimitiveImpl()

--- a/src/SourceCode.Clay.Json/JsonValueComparer.cs
+++ b/src/SourceCode.Clay.Json/JsonValueComparer.cs
@@ -15,28 +15,26 @@ namespace SourceCode.Clay.Json
     /// <summary>
     /// Represents a way to compare <see cref="JsonValue"/> and <see cref="ReadOnlyJsonObject"/> values.
     /// </summary>
-    public abstract class JsonComparer :
-        IEqualityComparer<JsonArray>, // We use specific logic for each JsonValue subtype
-        IEqualityComparer<JsonObject>,
-        IEqualityComparer<JsonPrimitive>,
+    public abstract class JsonValueComparer :
+        IEqualityComparer<JsonValue>,
         IEqualityComparer<ReadOnlyJsonObject>
     {
         #region Constants
 
         /// <summary>
-        /// Gets a <see cref="JsonComparer"/> that compares all fields of a <see cref="JsonValue"/>
+        /// Gets a <see cref="JsonValueComparer"/> that compares all fields of a <see cref="JsonValue"/>
         /// value in a strict manner (ordinal string comparisons, determinisitc ordering of members).
         /// </summary>
-        public static JsonComparer Default { get; } = new JsonStrictComparer();
+        public static JsonValueComparer Default { get; } = new JsonStrictComparer();
 
         #endregion
 
         #region Constructors
 
         /// <summary>
-        /// Creates a new instance of the <see cref="JsonComparer"/> class.
+        /// Creates a new instance of the <see cref="JsonValueComparer"/> class.
         /// </summary>
-        protected JsonComparer()
+        protected JsonValueComparer()
         { }
 
         #endregion
@@ -51,27 +49,7 @@ namespace SourceCode.Clay.Json
         /// <returns>
         /// true if the specified objects are equal; otherwise, false.
         /// </returns>
-        public abstract bool Equals(JsonArray x, JsonArray y);
-
-        /// <summary>
-        /// Determines whether the specified objects are equal.
-        /// </summary>
-        /// <param name="x">The first object to compare.</param>
-        /// <param name="y">The second object to compare.</param>
-        /// <returns>
-        /// true if the specified objects are equal; otherwise, false.
-        /// </returns>
-        public abstract bool Equals(JsonObject x, JsonObject y);
-
-        /// <summary>
-        /// Determines whether the specified objects are equal.
-        /// </summary>
-        /// <param name="x">The first object to compare.</param>
-        /// <param name="y">The second object to compare.</param>
-        /// <returns>
-        /// true if the specified objects are equal; otherwise, false.
-        /// </returns>
-        public abstract bool Equals(JsonPrimitive x, JsonPrimitive y);
+        public abstract bool Equals(JsonValue x, JsonValue y);
 
         /// <summary>
         /// Determines whether the specified objects are equal.
@@ -90,25 +68,7 @@ namespace SourceCode.Clay.Json
         /// <returns>
         /// A hash code for this instance, suitable for use in hashing algorithms and data structures like a hash table.
         /// </returns>
-        public abstract int GetHashCode(JsonArray obj);
-
-        /// <summary>
-        /// Returns a hash code for this instance.
-        /// </summary>
-        /// <param name="obj">The object.</param>
-        /// <returns>
-        /// A hash code for this instance, suitable for use in hashing algorithms and data structures like a hash table.
-        /// </returns>
-        public abstract int GetHashCode(JsonObject obj);
-
-        /// <summary>
-        /// Returns a hash code for this instance.
-        /// </summary>
-        /// <param name="obj">The object.</param>
-        /// <returns>
-        /// A hash code for this instance, suitable for use in hashing algorithms and data structures like a hash table.
-        /// </returns>
-        public abstract int GetHashCode(JsonPrimitive obj);
+        public abstract int GetHashCode(JsonValue obj);
 
         /// <summary>
         /// Returns a hash code for this instance.
@@ -135,7 +95,7 @@ namespace SourceCode.Clay.Json
             // For example a JsonArray(n) would incur at least n allocs, while a
             // JsonPrimitive would incur at least 1.
             // So instead we walk the tree, comparing each item. Note that ToString()
-            // walks the tree regardless, so we can be sure this is not significantly
+            // walks the tree regardless, so should not be significantly
             // more expensive than the latter method.
 
             // Heuristic: Check for most common first
@@ -247,9 +207,10 @@ namespace SourceCode.Clay.Json
         #region Concrete
 
         /// <summary>
-        /// Represents a way to compare two <see cref="JsonValue"/> instances in an case and order-sensitive manner.
+        /// Represents a way to compare two <see cref="JsonValue"/> or <see cref="ReadOnlyJsonObject"/> instances
+        /// in a case-sensitive and order-sensitive manner.
         /// </summary>
-        private sealed class JsonStrictComparer : JsonComparer
+        private sealed class JsonStrictComparer : JsonValueComparer
         {
             #region Constructors
 
@@ -259,28 +220,16 @@ namespace SourceCode.Clay.Json
 
             #endregion
 
-            #region IEqualityComparer
+            #region Methods
 
             /// <inheritdoc/>
-            public override bool Equals(JsonArray x, JsonArray y) => EqualsImpl(x, y);
-
-            /// <inheritdoc/>
-            public override bool Equals(JsonObject x, JsonObject y) => EqualsImpl(x, y);
-
-            /// <inheritdoc/>
-            public override bool Equals(JsonPrimitive x, JsonPrimitive y) => EqualsImpl(x, y);
+            public override bool Equals(JsonValue x, JsonValue y) => EqualsImpl(x, y);
 
             /// <inheritdoc/>
             public override bool Equals(ReadOnlyJsonObject x, ReadOnlyJsonObject y) => EqualsImpl(x?._json, y?._json);
 
             /// <inheritdoc/>
-            public override int GetHashCode(JsonArray obj) => GetHashCodeImpl(obj);
-
-            /// <inheritdoc/>
-            public override int GetHashCode(JsonObject obj) => GetHashCodeImpl(obj);
-
-            /// <inheritdoc/>
-            public override int GetHashCode(JsonPrimitive obj) => GetHashCodeImpl(obj);
+            public override int GetHashCode(JsonValue obj) => GetHashCodeImpl(obj);
 
             /// <inheritdoc/>
             public override int GetHashCode(ReadOnlyJsonObject obj) => GetHashCodeImpl(obj?._json);

--- a/src/SourceCode.Clay.Json/ReadOnlyJsonObject.cs
+++ b/src/SourceCode.Clay.Json/ReadOnlyJsonObject.cs
@@ -153,7 +153,7 @@ namespace SourceCode.Clay.Json
 
         public override bool Equals(object obj)
             => obj is ReadOnlyJsonObject other
-            && JsonComparer.Default.Equals(this, other);
+            && JsonValueComparer.Default.Equals(this, other);
 
         public override int GetHashCode() => _json.GetHashCode();
 


### PR DESCRIPTION
`JsonComparer` is unnecessarily complex, this PR tightens the code.