### PR TITLE
Grant eq

### DIFF
--- a/src/SourceCode.Clay.Json.Bench/EqualsBench.cs
+++ b/src/SourceCode.Clay.Json.Bench/EqualsBench.cs
@@ -11,8 +11,6 @@ using Newtonsoft.Json.Linq;
 using SourceCode.Clay.Json.Bench.Properties;
 using System;
 
-//using System.Json;
-
 namespace SourceCode.Clay.Json.Bench
 {
     [MemoryDiagnoser]
@@ -21,9 +19,6 @@ namespace SourceCode.Clay.Json.Bench
         #region Fields
 
         private const int InvokeCount = 1;
-
-        //private readonly JsonObject _json1;
-        //private readonly JsonObject _json2;
 
         private readonly JObject _newton1;
         private readonly JObject _newton2;
@@ -36,9 +31,6 @@ namespace SourceCode.Clay.Json.Bench
         {
             var str1 = Resources.AdventureWorks;
             var str2 = Resources.AdventureWorks + "\n"; // Mitigate interning
-
-            //_json1 = (JsonObject)JsonValue.Parse(str1);
-            //_json2 = (JsonObject)JsonValue.Parse(str2);
 
             _newton1 = JObject.Parse(str1);
             _newton2 = JObject.Parse(str2);
@@ -54,9 +46,6 @@ namespace SourceCode.Clay.Json.Bench
             var total = 0L;
             for (var j = 0; j < InvokeCount; j++)
             {
-                //var str1 = _json1.ToString();
-                //var str2 = _json2.ToString();
-
                 var str2 = _newton1.ToString();
                 var str1 = _newton2.ToString();
 

--- a/src/SourceCode.Clay.OpenApi/OasHttpSecurityScheme.cs
+++ b/src/SourceCode.Clay.OpenApi/OasHttpSecurityScheme.cs
@@ -36,6 +36,9 @@ namespace SourceCode.Clay.OpenApi
 
         #region Properties
 
+        /// <inheritdoc/>
+        //protected override Type EqualityContract => typeof(OasHttpSecurityScheme);
+
         /// <summary>Gets the type of the security scheme.</summary>
         public override OasSecuritySchemeType SchemeType => OasSecuritySchemeType.Http;
 
@@ -87,6 +90,10 @@ namespace SourceCode.Clay.OpenApi
         public bool Equals(OasHttpSecurityScheme other)
         {
             if (!base.Equals(other)) return false;
+
+            // https://github.com/dotnet/csharplang/issues/39#issuecomment-291602520
+            //if (EqualityContract != other.EqualityContract) return false;
+
             if (!StringComparer.Ordinal.Equals(Scheme, other.Scheme)) return false;
             if (!StringComparer.Ordinal.Equals(BearerFormat, other.BearerFormat)) return false;
 

--- a/src/SourceCode.Clay.OpenApi/OasPropertyEncoding.cs
+++ b/src/SourceCode.Clay.OpenApi/OasPropertyEncoding.cs
@@ -102,7 +102,7 @@ namespace SourceCode.Clay.OpenApi
             if (other is null) return false;
             if (ReferenceEquals(this, other)) return true;
 
-            if (!StringComparer.Ordinal.Equals(ContentType, other.ContentType)) return false;
+            if (!Equals(ContentType, other.ContentType)) return false;
             if (!Headers.NullableDictionaryEquals(other.Headers)) return false;
             if (Style != other.Style) return false;
             if (Options != other.Options) return false;

--- a/src/SourceCode.Clay.OpenApi/OasSecurityScheme.cs
+++ b/src/SourceCode.Clay.OpenApi/OasSecurityScheme.cs
@@ -31,6 +31,12 @@ namespace SourceCode.Clay.OpenApi
         #region Properties
 
         /// <summary>
+        /// Used for equality checking in inheritance schemes.
+        /// Ensure that this returns the delcared type of the class.
+        /// </summary>
+        //protected virtual Type EqualityContract => typeof(OasSecurityScheme);
+
+        /// <summary>
         /// Gets the type of the security scheme.
         /// </summary>
         public abstract OasSecuritySchemeType SchemeType { get; }
@@ -79,6 +85,9 @@ namespace SourceCode.Clay.OpenApi
         {
             if (ReferenceEquals(this, other)) return true;
             if (other is null) return false;
+
+            // https://github.com/dotnet/csharplang/issues/39#issuecomment-291602520
+            //if (EqualityContract != other.EqualityContract) return false;
 
             if (SchemeType != other.SchemeType) return false;
             if (!StringComparer.Ordinal.Equals(Description, other.Description)) return false;

--- a/src/SourceCode.Clay/SemanticVersion.cs
+++ b/src/SourceCode.Clay/SemanticVersion.cs
@@ -330,7 +330,7 @@ namespace SourceCode.Clay
                 compatability |= SemanticVersionCompatabilities.Incompatible | SemanticVersionCompatabilities.PreReleaseRemoved;
             else if (baseline.PreRelease != null && comparand.PreRelease != null)
             {
-                var cmp = StringComparer.Ordinal.Compare(baseline.PreRelease, comparand.PreRelease);
+                var cmp = string.CompareOrdinal(baseline.PreRelease, comparand.PreRelease);
                 if (cmp == -1) compatability |= SemanticVersionCompatabilities.Incompatible | SemanticVersionCompatabilities.NewerPreRelease;
                 else if (cmp == 1) compatability |= SemanticVersionCompatabilities.Incompatible | SemanticVersionCompatabilities.OlderPreRelease;
             }

--- a/src/SourceCode.Clay/SemanticVersionComparer.cs
+++ b/src/SourceCode.Clay/SemanticVersionComparer.cs
@@ -80,10 +80,10 @@ namespace SourceCode.Clay
                 cmp = x.Patch.CompareTo(y.Patch);
                 if (cmp != 0) return cmp;
 
-                cmp = StringComparer.Ordinal.Compare(x.PreRelease, y.PreRelease);
+                cmp = string.CompareOrdinal(x.PreRelease, y.PreRelease);
                 if (cmp != 0) return cmp;
 
-                cmp = StringComparer.Ordinal.Compare(x.BuildMetadata, y.BuildMetadata);
+                cmp = string.CompareOrdinal(x.BuildMetadata, y.BuildMetadata);
                 return cmp;
             }
 
@@ -141,7 +141,7 @@ namespace SourceCode.Clay
                 cmp = x.Patch.CompareTo(y.Patch);
                 if (cmp != 0) return cmp;
 
-                cmp = StringComparer.Ordinal.Compare(x.PreRelease, y.PreRelease);
+                cmp = string.CompareOrdinal(x.PreRelease, y.PreRelease);
                 return cmp;
             }
 

--- a/src/SourceCode.Clay/StringExtensions.cs
+++ b/src/SourceCode.Clay/StringExtensions.cs
@@ -110,12 +110,7 @@ namespace SourceCode.Clay
         /// <returns></returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool EqualsOrdinal(this string x, string y)
-        {
-            if (x == y) return true; // (null, null) or (s, s)
-            if (x == null || y == null) return false; // (s, null) or (null, t)
-
-            return StringComparer.Ordinal.Equals(x, y); // (s, t)
-        }
+            => StringComparer.Ordinal.Equals(x, y);
 
         #endregion
     }


### PR DESCRIPTION
* Fix an equality bug in `OasPropertyEncoding`
* `string.CompareOrdinal` is called by `StringComparer.Ordinal.Compare` so can be used instead (perf)

