### PR TITLE
SPIKE: C# 7.2 updates

### DIFF
--- a/src/SourceCode.Clay.Buffers.Tests/BufferComparerTests.cs
+++ b/src/SourceCode.Clay.Buffers.Tests/BufferComparerTests.cs
@@ -299,6 +299,20 @@ namespace SourceCode.Clay.Buffers.Tests
         #region IComparer
 
         [Trait("Type", "Unit")]
+        [Fact(DisplayName = nameof(BufferComparer_Compare_Array_Null))]
+        public static void BufferComparer_Compare_Array_Null()
+        {
+            byte[] a = null;
+            byte[] b = null;
+            var c = new byte[0]; // empty
+
+            // Array
+            Assert.True(BufferComparer.Array.Compare(a, a) == 0);
+            Assert.True(BufferComparer.Array.Compare(a, b) == 0);
+            Assert.True(BufferComparer.Array.Compare(a, c) < 0);
+        }
+
+        [Trait("Type", "Unit")]
         [Fact(DisplayName = nameof(BufferComparer_Compare_Array_Length_One))]
         public static void BufferComparer_Compare_Array_Length_One()
         {

--- a/src/SourceCode.Clay.Buffers.Tests/SourceCode.Clay.Buffers.Tests.csproj
+++ b/src/SourceCode.Clay.Buffers.Tests/SourceCode.Clay.Buffers.Tests.csproj
@@ -9,6 +9,9 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Net.Compilers" Version="2.6.0-beta3-62314-05">
+      <PrivateAssets>All</PrivateAssets>
+    </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
     <PackageReference Include="OpenCover" Version="4.6.519" />
     <PackageReference Include="xunit" Version="2.3.1" />

--- a/src/SourceCode.Clay.Buffers/BufferComparer.T.cs
+++ b/src/SourceCode.Clay.Buffers/BufferComparer.T.cs
@@ -15,7 +15,7 @@ namespace SourceCode.Clay.Buffers
     /// </summary>
     public abstract class BufferComparer<T> : IEqualityComparer<T>, IComparer<T>
     {
-        #region Fields
+        #region Properties
 
         /// <summary>
         /// The prefix of the buffer that is considered for hashcode calculation.

--- a/src/SourceCode.Clay.Buffers/BufferSession.cs
+++ b/src/SourceCode.Clay.Buffers/BufferSession.cs
@@ -44,7 +44,7 @@ namespace SourceCode.Clay.Buffers
         /// </summary>
         /// <param name="buffer">The buffer.</param>
         /// <param name="result">The result.</param>
-        public BufferSession(byte[] buffer, ArraySegment<byte> result)
+        public BufferSession(in byte[] buffer, in ArraySegment<byte> result)
         {
             Buffer = buffer ?? throw new ArgumentNullException(nameof(buffer));
             Result = result;
@@ -54,7 +54,7 @@ namespace SourceCode.Clay.Buffers
         /// Initializes a new instance of the <see cref="BufferSession"/> struct.
         /// </summary>
         /// <param name="result">The result.</param>
-        public BufferSession(ArraySegment<byte> result)
+        public BufferSession(in ArraySegment<byte> result)
         {
             Buffer = null;
             Result = result;
@@ -93,7 +93,7 @@ namespace SourceCode.Clay.Buffers
         /// Returns the buffer.
         /// </summary>
         /// <param name="buffer">The buffer.</param>
-        public static void ReturnBuffer(byte[] buffer)
+        public static void ReturnBuffer(in byte[] buffer)
         {
             if (buffer == null) throw new ArgumentNullException(nameof(buffer));
 

--- a/src/SourceCode.Clay.Buffers/IO/StreamExtensions.cs
+++ b/src/SourceCode.Clay.Buffers/IO/StreamExtensions.cs
@@ -27,7 +27,7 @@ namespace SourceCode.Clay.IO
         /// <param name="stream">The stream to write to.</param>
         /// <param name="memory">The memory to write.</param>
         /// <param name="bufferLength">The maximum length of the buffer. The default is 81920.</param>
-        public static void Write(this Stream stream, ReadOnlyMemory<byte> memory, int bufferLength = 81920)
+        public static void Write(this Stream stream, in ReadOnlyMemory<byte> memory, int bufferLength = 81920)
             => Write(stream, memory.Span, bufferLength);
 
         /// <summary>
@@ -37,7 +37,7 @@ namespace SourceCode.Clay.IO
         /// <param name="stream">The stream to write to.</param>
         /// <param name="span">The span to write.</param>
         /// <param name="bufferLength">The maximum length of the buffer. The default is 81920.</param>
-        public static void Write(this Stream stream, ReadOnlySpan<byte> span, int bufferLength = 81920)
+        public static void Write(this Stream stream, in ReadOnlySpan<byte> span, int bufferLength = 81920)
         {
             if (stream == null) throw new ArgumentNullException(nameof(stream));
             if (bufferLength < 1) throw new ArgumentOutOfRangeException(nameof(bufferLength));

--- a/src/SourceCode.Clay.Buffers/SpanExtensions.cs
+++ b/src/SourceCode.Clay.Buffers/SpanExtensions.cs
@@ -20,6 +20,16 @@ namespace SourceCode.Clay.Buffers
 
         #region Methods
 
+        public static void Sort<T>(this Span<T> span, Comparison<T> comparison)
+        {
+            if (comparison == null) throw new ArgumentNullException(nameof(comparison));
+
+            if (span.IsEmpty || span.Length <= 1) return;
+            IntrospectiveSort(span, comparison, 0, span.Length - 1, 2 * FloorLog2(span.Length));
+        }
+
+        #endregion
+
         #region IntrospectiveSort
 
         private static int FloorLog2(int n)
@@ -170,15 +180,6 @@ namespace SourceCode.Clay.Buffers
                 Swap(span, lo, lo + i - 1);
                 DownHeap(span, comparison, 1, i - 1, lo);
             }
-        }
-
-        #endregion
-
-        public static void Sort<T>(this Span<T> span, Comparison<T> comparison)
-        {
-            if (comparison == null) throw new ArgumentNullException(nameof(comparison));
-            if (span.IsEmpty || span.Length < 2) return;
-            IntrospectiveSort(span, comparison, 0, span.Length - 1, 2 * FloorLog2(span.Length));
         }
 
         #endregion

--- a/src/SourceCode.Clay.Collections.Bench/SourceCode.Clay.Collections.Bench.csproj
+++ b/src/SourceCode.Clay.Collections.Bench/SourceCode.Clay.Collections.Bench.csproj
@@ -16,6 +16,9 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Net.Compilers" Version="2.6.0-beta3-62314-05">
+      <PrivateAssets>All</PrivateAssets>
+    </PackageReference>
     <PackageReference Include="BenchmarkDotNet" Version="0.10.10" />
     <PackageReference Include="OpenCover" Version="4.6.519" />
   </ItemGroup>

--- a/src/SourceCode.Clay.Collections.Tests/SourceCode.Clay.Collections.Tests.csproj
+++ b/src/SourceCode.Clay.Collections.Tests/SourceCode.Clay.Collections.Tests.csproj
@@ -9,6 +9,9 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Net.Compilers" Version="2.6.0-beta3-62314-05">
+      <PrivateAssets>All</PrivateAssets>
+    </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
     <PackageReference Include="OpenCover" Version="4.6.519" />
     <PackageReference Include="xunit" Version="2.3.1" />

--- a/src/SourceCode.Clay.Collections/Generic/CollectionExtensions.cs
+++ b/src/SourceCode.Clay.Collections/Generic/CollectionExtensions.cs
@@ -25,7 +25,7 @@ namespace SourceCode.Clay.Collections.Generic
         /// <param name="y">Collection 2</param>
         /// <param name="comparer">The comparer to use to test for equality.</param>
         /// <returns></returns>
-        public static bool NullableCollectionEquals<TSource>(this ICollection<TSource> x, IEnumerable<TSource> y, IEqualityComparer<TSource> comparer)
+        public static bool NullableCollectionEquals<TSource>(this ICollection<TSource> x, in IEnumerable<TSource> y, in IEqualityComparer<TSource> comparer)
         {
             if (x is null) return y is null; // (null, null) or (null, y)
             if (y is null) return false; // (x, null)
@@ -58,7 +58,7 @@ namespace SourceCode.Clay.Collections.Generic
         /// <param name="x">Collection 1</param>
         /// <param name="y">Collection 2</param>
         /// <returns></returns>
-        public static bool NullableCollectionEquals<TSource>(this ICollection<TSource> x, IEnumerable<TSource> y)
+        public static bool NullableCollectionEquals<TSource>(this ICollection<TSource> x, in IEnumerable<TSource> y)
             => NullableCollectionEquals(x, y, null);
 
         /// <summary>
@@ -70,7 +70,7 @@ namespace SourceCode.Clay.Collections.Generic
         /// <param name="y">Collection 2</param>
         /// <param name="comparer">The comparer to use to test for equality.</param>
         /// <returns></returns>
-        public static bool NullableCollectionEquals<TSource>(this IReadOnlyCollection<TSource> x, IEnumerable<TSource> y, IEqualityComparer<TSource> comparer)
+        public static bool NullableCollectionEquals<TSource>(this IReadOnlyCollection<TSource> x, in IEnumerable<TSource> y, in IEqualityComparer<TSource> comparer)
         {
             if (x is null) return y is null; // (null, null) or (null, y)
             if (y is null) return false; // (x, null)
@@ -103,7 +103,7 @@ namespace SourceCode.Clay.Collections.Generic
         /// <param name="x">Collection 1</param>
         /// <param name="y">Collection 2</param>
         /// <returns></returns>
-        public static bool NullableCollectionEquals<TSource>(this IReadOnlyCollection<TSource> x, IEnumerable<TSource> y)
+        public static bool NullableCollectionEquals<TSource>(this IReadOnlyCollection<TSource> x, in IEnumerable<TSource> y)
             => NullableCollectionEquals(x, y, null);
 
         #endregion

--- a/src/SourceCode.Clay.Collections/Generic/DictionaryExtensions.cs
+++ b/src/SourceCode.Clay.Collections/Generic/DictionaryExtensions.cs
@@ -26,7 +26,7 @@ namespace SourceCode.Clay.Collections.Generic
         /// <param name="y">Dictionary 2</param>
         /// <param name="valueComparer">The comparer to use to test for Value equality.</param>
         /// <returns></returns>
-        public static bool NullableDictionaryEquals<TKey, TValue>(this IEnumerable<KeyValuePair<TKey, TValue>> x, IEnumerable<KeyValuePair<TKey, TValue>> y, IEqualityComparer<TValue> valueComparer)
+        public static bool NullableDictionaryEquals<TKey, TValue>(this IEnumerable<KeyValuePair<TKey, TValue>> x, IEnumerable<KeyValuePair<TKey, TValue>> y, in IEqualityComparer<TValue> valueComparer)
         {
             if (x is null) return y is null; // (null, null) or (null, y)
             if (y is null) return false; // (x, null)

--- a/src/SourceCode.Clay.Collections/Generic/EnumerableExtensions.cs
+++ b/src/SourceCode.Clay.Collections/Generic/EnumerableExtensions.cs
@@ -66,7 +66,7 @@ namespace SourceCode.Clay.Collections.Generic
 
         #region Helpers
 
-        internal static bool CheckEnumerable<TSource>(IEnumerable<TSource> x, IEnumerable<TSource> y, IEqualityComparer<TSource> comparer)
+        internal static bool CheckEnumerable<TSource>(in IEnumerable<TSource> x, in IEnumerable<TSource> y, in IEqualityComparer<TSource> comparer)
         {
             Debug.Assert(x != null);
             Debug.Assert(y != null);

--- a/src/SourceCode.Clay.Collections/Generic/KeyedCollectionFactory.cs
+++ b/src/SourceCode.Clay.Collections/Generic/KeyedCollectionFactory.cs
@@ -30,7 +30,7 @@ namespace SourceCode.Clay.Collections.Generic
         /// (0 creates the lookup dictionary when the first item is added), or –1 to specify that a lookup dictionary is never created.
         /// </param>
         /// <returns>An instance of the Dictionary.</returns>
-        public static KeyedCollection<TKey, TItem> Create<TKey, TItem>(IEnumerable<TItem> items, Func<TItem, TKey> keyExtractor, IEqualityComparer<TKey> comparer, int dictionaryCreationThreshold)
+        public static KeyedCollection<TKey, TItem> Create<TKey, TItem>(in IEnumerable<TItem> items, in Func<TItem, TKey> keyExtractor, in IEqualityComparer<TKey> comparer, int dictionaryCreationThreshold)
         {
             if (items == null) throw new ArgumentNullException(nameof(items));
             if (keyExtractor == null) throw new ArgumentNullException(nameof(keyExtractor));
@@ -56,7 +56,7 @@ namespace SourceCode.Clay.Collections.Generic
         /// (0 creates the lookup dictionary when the first item is added), or –1 to specify that a lookup dictionary is never created.
         /// </param>
         /// <returns>An instance of the Dictionary.</returns>
-        public static KeyedCollection<TKey, TItem> Create<TKey, TItem>(Func<TItem, TKey> keyExtractor, IEqualityComparer<TKey> comparer, int dictionaryCreationThreshold)
+        public static KeyedCollection<TKey, TItem> Create<TKey, TItem>(in Func<TItem, TKey> keyExtractor, in IEqualityComparer<TKey> comparer, int dictionaryCreationThreshold)
         {
             if (keyExtractor == null) throw new ArgumentNullException(nameof(keyExtractor));
             if (comparer == null) throw new ArgumentNullException(nameof(comparer));
@@ -76,7 +76,7 @@ namespace SourceCode.Clay.Collections.Generic
         /// <param name="comparer">The comparer to use.</param>
         /// </param>
         /// <returns>An instance of the Dictionary.</returns>
-        public static KeyedCollection<TKey, TItem> Create<TKey, TItem>(IEnumerable<TItem> items, Func<TItem, TKey> keyExtractor, IEqualityComparer<TKey> comparer)
+        public static KeyedCollection<TKey, TItem> Create<TKey, TItem>(in IEnumerable<TItem> items, in Func<TItem, TKey> keyExtractor, in IEqualityComparer<TKey> comparer)
         {
             if (items == null) throw new ArgumentNullException(nameof(items));
             if (keyExtractor == null) throw new ArgumentNullException(nameof(keyExtractor));
@@ -99,7 +99,7 @@ namespace SourceCode.Clay.Collections.Generic
         /// <param name="comparer">The comparer to use.</param>
         /// </param>
         /// <returns>An instance of the Dictionary.</returns>
-        public static KeyedCollection<TKey, TItem> Create<TKey, TItem>(Func<TItem, TKey> keyExtractor, IEqualityComparer<TKey> comparer)
+        public static KeyedCollection<TKey, TItem> Create<TKey, TItem>(in Func<TItem, TKey> keyExtractor, in IEqualityComparer<TKey> comparer)
         {
             if (keyExtractor == null) throw new ArgumentNullException(nameof(keyExtractor));
             if (comparer == null) throw new ArgumentNullException(nameof(comparer));
@@ -117,7 +117,7 @@ namespace SourceCode.Clay.Collections.Generic
         /// <param name="keyExtractor">A delegate that extracts the embedded key from each item.</param>
         /// </param>
         /// <returns>An instance of the Dictionary.</returns>
-        public static KeyedCollection<TKey, TItem> Create<TKey, TItem>(IEnumerable<TItem> items, Func<TItem, TKey> keyExtractor)
+        public static KeyedCollection<TKey, TItem> Create<TKey, TItem>(in IEnumerable<TItem> items, in Func<TItem, TKey> keyExtractor)
         {
             if (keyExtractor == null) throw new ArgumentNullException(nameof(keyExtractor));
 
@@ -137,7 +137,7 @@ namespace SourceCode.Clay.Collections.Generic
         /// <param name="keyExtractor">A delegate that extracts the embedded key from each item.</param>
         /// </param>
         /// <returns>An instance of the Dictionary.</returns>
-        public static KeyedCollection<TKey, TItem> Create<TKey, TItem>(Func<TItem, TKey> keyExtractor)
+        public static KeyedCollection<TKey, TItem> Create<TKey, TItem>(in Func<TItem, TKey> keyExtractor)
         {
             if (keyExtractor == null) throw new ArgumentNullException(nameof(keyExtractor));
 
@@ -165,7 +165,7 @@ namespace SourceCode.Clay.Collections.Generic
 
             #region Constructors
 
-            public KeyedCollectionImpl(Func<TValue, TKey> keyExtractor, IEqualityComparer<TKey> comparer, int dictionaryCreationThreshold)
+            public KeyedCollectionImpl(in Func<TValue, TKey> keyExtractor, in IEqualityComparer<TKey> comparer, int dictionaryCreationThreshold)
                 : base(comparer, dictionaryCreationThreshold)
             {
                 if (comparer == null) throw new ArgumentNullException(nameof(comparer));
@@ -174,7 +174,7 @@ namespace SourceCode.Clay.Collections.Generic
                 _keyExtractor = keyExtractor ?? throw new ArgumentNullException(nameof(keyExtractor));
             }
 
-            public KeyedCollectionImpl(Func<TValue, TKey> keyExtractor, IEqualityComparer<TKey> comparer)
+            public KeyedCollectionImpl(in Func<TValue, TKey> keyExtractor, in IEqualityComparer<TKey> comparer)
                 : base(comparer)
             {
                 if (comparer == null) throw new ArgumentNullException(nameof(comparer));
@@ -182,7 +182,7 @@ namespace SourceCode.Clay.Collections.Generic
                 _keyExtractor = keyExtractor ?? throw new ArgumentNullException(nameof(keyExtractor));
             }
 
-            public KeyedCollectionImpl(Func<TValue, TKey> keyExtractor)
+            public KeyedCollectionImpl(in Func<TValue, TKey> keyExtractor)
             {
                 _keyExtractor = keyExtractor ?? throw new ArgumentNullException(nameof(keyExtractor));
             }

--- a/src/SourceCode.Clay.Collections/Generic/ListExtensions.cs
+++ b/src/SourceCode.Clay.Collections/Generic/ListExtensions.cs
@@ -25,7 +25,7 @@ namespace SourceCode.Clay.Collections.Generic
         /// <param name="y">List 2</param>
         /// <param name="comparer">The comparer to use to test for equality.</param>
         /// <returns></returns>
-        public static bool NullableListEquals<TSource>(this IList<TSource> x, IEnumerable<TSource> y, IEqualityComparer<TSource> comparer)
+        public static bool NullableListEquals<TSource>(this IList<TSource> x, in IEnumerable<TSource> y, in IEqualityComparer<TSource> comparer)
         {
             if (x is null) return y is null; // (null, null) or (null, y)
             if (y is null) return false; // (x, null)
@@ -91,7 +91,7 @@ namespace SourceCode.Clay.Collections.Generic
         /// <param name="x">List 1</param>
         /// <param name="y">List 2</param>
         /// <returns></returns>
-        public static bool NullableListEquals<TSource>(this IList<TSource> x, IEnumerable<TSource> y)
+        public static bool NullableListEquals<TSource>(this IList<TSource> x, in IEnumerable<TSource> y)
             => NullableListEquals(x, y, null);
 
         /// <summary>
@@ -103,7 +103,7 @@ namespace SourceCode.Clay.Collections.Generic
         /// <param name="y">List 2</param>
         /// <param name="comparer">The comparer to use to test for equality.</param>
         /// <returns></returns>
-        public static bool NullableListEquals<TSource>(this IReadOnlyList<TSource> x, IEnumerable<TSource> y, IEqualityComparer<TSource> comparer)
+        public static bool NullableListEquals<TSource>(this IReadOnlyList<TSource> x, in IEnumerable<TSource> y, in IEqualityComparer<TSource> comparer)
         {
             if (x is null) return y is null; // (null, null) or (null, y)
             if (y is null) return false; // (x, null)
@@ -169,7 +169,7 @@ namespace SourceCode.Clay.Collections.Generic
         /// <param name="x">List 1</param>
         /// <param name="y">List 2</param>
         /// <returns></returns>
-        public static bool NullableListEquals<TSource>(this IReadOnlyList<TSource> x, IEnumerable<TSource> y)
+        public static bool NullableListEquals<TSource>(this IReadOnlyList<TSource> x, in IEnumerable<TSource> y)
             => NullableListEquals(x, y, null);
 
         #endregion

--- a/src/SourceCode.Clay.Collections/Generic/MemoryExtensions.cs
+++ b/src/SourceCode.Clay.Collections/Generic/MemoryExtensions.cs
@@ -25,10 +25,10 @@ namespace SourceCode.Clay.Collections.Generic
         /// <param name="y">Memory 2</param>
         /// <param name="cmpr">The comparer to use to test for equality.</param>
         /// <returns></returns>
-        public static bool MemoryEquals<TSource>(this ReadOnlyMemory<TSource> x, ReadOnlyMemory<TSource> y, IEqualityComparer<TSource> comparer)
+        public static bool MemoryEquals<TSource>(this ReadOnlyMemory<TSource> x, in ReadOnlyMemory<TSource> y, in IEqualityComparer<TSource> comparer)
         {
             if (x.Length != y.Length) return false; // (n, m)
-            if (x.IsEmpty) return true; // (0, 0)
+            if (x.Length == 0) return true; // (0, 0)
 
             var cmpr = comparer ?? EqualityComparer<TSource>.Default;
 
@@ -52,7 +52,7 @@ namespace SourceCode.Clay.Collections.Generic
         /// <param name="x">Memory 1</param>
         /// <param name="y">Memory 2</param>
         /// <returns></returns>
-        public static bool MemoryEquals<TSource>(this ReadOnlyMemory<TSource> x, ReadOnlyMemory<TSource> y)
+        public static bool MemoryEquals<TSource>(this ReadOnlyMemory<TSource> x, in ReadOnlyMemory<TSource> y)
             => MemoryEquals(x, y, null);
 
         #endregion

--- a/src/SourceCode.Clay.Collections/Generic/SetExtensions.cs
+++ b/src/SourceCode.Clay.Collections/Generic/SetExtensions.cs
@@ -24,7 +24,7 @@ namespace SourceCode.Clay.Collections.Generic
         /// <param name="y">Set 2</param>
         /// <param name="comparer">The comparer to use to test for equality.</param>
         /// <returns></returns>
-        public static bool NullableSetEquals<TSource>(this IEnumerable<TSource> x, IEnumerable<TSource> y, IEqualityComparer<TSource> comparer)
+        public static bool NullableSetEquals<TSource>(this IEnumerable<TSource> x, IEnumerable<TSource> y, in IEqualityComparer<TSource> comparer)
         {
             if (x is null) return y is null; // (null, null) or (null, y)
             if (y is null) return false; // (x, null)
@@ -78,7 +78,7 @@ namespace SourceCode.Clay.Collections.Generic
         /// <param name="x">Set 1</param>
         /// <param name="y">Set 2</param>
         /// <returns></returns>
-        public static bool NullableSetEquals<TSource>(this IEnumerable<TSource> x, IEnumerable<TSource> y)
+        public static bool NullableSetEquals<TSource>(this IEnumerable<TSource> x, in IEnumerable<TSource> y)
             => NullableSetEquals(x, y, null);
 
         #endregion

--- a/src/SourceCode.Clay.Collections/Generic/SwitchBuilderImpl.cs
+++ b/src/SourceCode.Clay.Collections/Generic/SwitchBuilderImpl.cs
@@ -92,7 +92,7 @@ namespace SourceCode.Clay.Collections.Generic
         /// </summary>
         /// <param name="cases">The cases to transform into a dynamic switch.</param>
         /// <returns>A lambda that returns an index for a specified key value.</returns>
-        private (TValue[] ar, Func<TKey, int> func) BuildSwitchExpression(IReadOnlyDictionary<TKey, TValue> cases)
+        private (TValue[] ar, Func<TKey, int> func) BuildSwitchExpression(in IReadOnlyDictionary<TKey, TValue> cases)
         {
             TValue[] values;
             Expression<Func<TKey, int>> expr;

--- a/src/SourceCode.Clay.Data.Tests/SourceCode.Clay.Data.Tests.csproj
+++ b/src/SourceCode.Clay.Data.Tests/SourceCode.Clay.Data.Tests.csproj
@@ -9,6 +9,9 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Net.Compilers" Version="2.6.0-beta3-62314-05">
+      <PrivateAssets>All</PrivateAssets>
+    </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
     <PackageReference Include="OpenCover" Version="4.6.519" />
     <PackageReference Include="xunit" Version="2.3.1" />

--- a/src/SourceCode.Clay.Data/SourceCode.Clay.Data.csproj
+++ b/src/SourceCode.Clay.Data/SourceCode.Clay.Data.csproj
@@ -14,6 +14,7 @@
     <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.3.0-beta1">
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
+    <PackageReference Include="System.Memory" Version="4.5.0-preview2-25707-02" />
     <PackageReference Include="System.Data.SqlClient" Version="4.4.0" />
   </ItemGroup>
 

--- a/src/SourceCode.Clay.Data/SqlParser/SqlParamBlockParser.cs
+++ b/src/SourceCode.Clay.Data/SqlParser/SqlParamBlockParser.cs
@@ -14,7 +14,7 @@ using System.Text;
 
 namespace SourceCode.Clay.Data.SqlParser
 {
-    public static partial class SqlParamBlockParser
+    public static class SqlParamBlockParser
     {
         #region Constants
 

--- a/src/SourceCode.Clay.Data/SqlParser/SqlParamInfo.cs
+++ b/src/SourceCode.Clay.Data/SqlParser/SqlParamInfo.cs
@@ -14,7 +14,9 @@ namespace SourceCode.Clay.Data.SqlParser
     {
         #region Constants
 
-        public static SqlParamInfo Empty { get; }
+        private static readonly SqlParamInfo _empty;
+
+        public static ref readonly SqlParamInfo Empty => ref _empty;
 
         #endregion
 

--- a/src/SourceCode.Clay.Json.Bench/SourceCode.Clay.Json.Bench.csproj
+++ b/src/SourceCode.Clay.Json.Bench/SourceCode.Clay.Json.Bench.csproj
@@ -16,10 +16,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="BenchmarkDotNet" Version="0.10.10" />
-    <PackageReference Include="Newtonsoft.Json">
-      <Version>10.0.3</Version>
+    <PackageReference Include="Microsoft.Net.Compilers" Version="2.6.0-beta3-62314-05">
+      <PrivateAssets>All</PrivateAssets>
     </PackageReference>
+    <PackageReference Include="BenchmarkDotNet" Version="0.10.10" />
     <PackageReference Include="OpenCover" Version="4.6.519" />
   </ItemGroup>
 

--- a/src/SourceCode.Clay.Json.Tests/SourceCode.Clay.Json.Tests.csproj
+++ b/src/SourceCode.Clay.Json.Tests/SourceCode.Clay.Json.Tests.csproj
@@ -9,6 +9,9 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Net.Compilers" Version="2.6.0-beta3-62314-05">
+      <PrivateAssets>All</PrivateAssets>
+    </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
     <PackageReference Include="OpenCover" Version="4.6.519" />
     <PackageReference Include="xunit" Version="2.3.1" />

--- a/src/SourceCode.Clay.Json/Validation/CountConstraint.cs
+++ b/src/SourceCode.Clay.Json/Validation/CountConstraint.cs
@@ -18,11 +18,15 @@ namespace SourceCode.Clay.Json.Validation
     {
         #region Constants
 
-        public static CountConstraint Empty { get; }
+        private static readonly CountConstraint _empty;
+        private static readonly CountConstraint _forByte = new CountConstraint(byte.MinValue, byte.MaxValue);
+        private static readonly CountConstraint _forUInt16 = new CountConstraint(ushort.MinValue, ushort.MaxValue);
 
-        public static CountConstraint ForByte { get; } = new CountConstraint(byte.MinValue, byte.MaxValue);
+        public static ref readonly CountConstraint Empty => ref _empty;
 
-        public static CountConstraint ForUInt16 { get; } = new CountConstraint(ushort.MinValue, ushort.MaxValue);
+        public static ref readonly CountConstraint ForByte => ref _forByte;
+
+        public static ref readonly CountConstraint ForUInt16 => ref _forUInt16;
 
         #endregion
 
@@ -41,7 +45,7 @@ namespace SourceCode.Clay.Json.Validation
         /// <summary>
         /// Gets a value indicating whether <see cref="Maximum"/> has a value.
         /// </summary>
-        public bool IsBounded => Maximum.HasValue;
+        public bool IsBounded => Maximum.HasValue; // Minimum is not nullable
 
         #endregion
 

--- a/src/SourceCode.Clay.Json/Validation/DecimalConstraint.cs
+++ b/src/SourceCode.Clay.Json/Validation/DecimalConstraint.cs
@@ -18,7 +18,9 @@ namespace SourceCode.Clay.Json.Validation
     {
         #region Constants
 
-        public static DecimalConstraint Empty { get; }
+        private static readonly DecimalConstraint _empty;
+
+        public static ref readonly DecimalConstraint Empty => ref _empty;
 
         #endregion
 

--- a/src/SourceCode.Clay.Json/Validation/DoubleConstraint.cs
+++ b/src/SourceCode.Clay.Json/Validation/DoubleConstraint.cs
@@ -18,7 +18,12 @@ namespace SourceCode.Clay.Json.Validation
     {
         #region Constants
 
-        public static DoubleConstraint Empty { get; }
+        private static readonly DoubleConstraint _empty;
+        private static readonly DoubleConstraint _forSingle = new DoubleConstraint(float.MinValue, float.MaxValue);
+
+        public static ref readonly DoubleConstraint Empty => ref _empty;
+
+        public static ref readonly DoubleConstraint ForSingle => ref _forSingle;
 
         #endregion
 

--- a/src/SourceCode.Clay.Json/Validation/Int64Constraint.cs
+++ b/src/SourceCode.Clay.Json/Validation/Int64Constraint.cs
@@ -18,19 +18,27 @@ namespace SourceCode.Clay.Json.Validation
     {
         #region Constants
 
-        public static Int64Constraint Empty { get; }
+        private static readonly Int64Constraint _empty;
+        private static readonly Int64Constraint _forByte = new Int64Constraint(byte.MinValue, byte.MaxValue);
+        private static readonly Int64Constraint _forSByte = new Int64Constraint(sbyte.MinValue, sbyte.MaxValue);
+        private static readonly Int64Constraint _forInt16 = new Int64Constraint(short.MinValue, short.MaxValue);
+        private static readonly Int64Constraint _forUInt16 = new Int64Constraint(ushort.MinValue, ushort.MaxValue);
+        private static readonly Int64Constraint _forInt32 = new Int64Constraint(int.MinValue, int.MaxValue);
+        private static readonly Int64Constraint _forUInt32 = new Int64Constraint(uint.MinValue, uint.MaxValue);
 
-        public static Int64Constraint ForByte { get; } = new Int64Constraint(byte.MinValue, byte.MaxValue);
+        public static ref readonly Int64Constraint Empty => ref _empty;
 
-        public static Int64Constraint ForSByte { get; } = new Int64Constraint(sbyte.MinValue, sbyte.MaxValue);
+        public static ref readonly Int64Constraint ForByte => ref _forByte;
 
-        public static Int64Constraint ForInt16 { get; } = new Int64Constraint(short.MinValue, short.MaxValue);
+        public static ref readonly Int64Constraint ForSByte => ref _forSByte;
 
-        public static Int64Constraint ForUInt16 { get; } = new Int64Constraint(ushort.MinValue, ushort.MaxValue);
+        public static ref readonly Int64Constraint ForInt16 => ref _forInt16;
 
-        public static Int64Constraint ForInt32 { get; } = new Int64Constraint(int.MinValue, int.MaxValue);
+        public static ref readonly Int64Constraint ForUInt16 => ref _forUInt16;
 
-        public static Int64Constraint ForUInt32 { get; } = new Int64Constraint(uint.MinValue, uint.MaxValue);
+        public static ref readonly Int64Constraint ForInt32 => ref _forInt32;
+
+        public static ref readonly Int64Constraint ForUInt32 => ref _forUInt32;
 
         #endregion
 

--- a/src/SourceCode.Clay.Json/Validation/NumberConstraint.cs
+++ b/src/SourceCode.Clay.Json/Validation/NumberConstraint.cs
@@ -18,23 +18,33 @@ namespace SourceCode.Clay.Json.Validation
     {
         #region Constants
 
-        public static NumberConstraint Empty { get; }
+        private static readonly NumberConstraint _empty;
+        private static readonly NumberConstraint _forByte = new NumberConstraint(byte.MinValue, byte.MaxValue);
+        private static readonly NumberConstraint _forSByte = new NumberConstraint(sbyte.MinValue, sbyte.MaxValue);
+        private static readonly NumberConstraint _forInt16 = new NumberConstraint(short.MinValue, short.MaxValue);
+        private static readonly NumberConstraint _forUInt16 = new NumberConstraint(ushort.MinValue, ushort.MaxValue);
+        private static readonly NumberConstraint _forInt32 = new NumberConstraint(int.MinValue, int.MaxValue);
+        private static readonly NumberConstraint _forUInt32 = new NumberConstraint(uint.MinValue, uint.MaxValue);
+        private static readonly NumberConstraint _forInt64 = new NumberConstraint(long.MinValue, long.MaxValue);
+        private static readonly NumberConstraint _forUInt64 = new NumberConstraint(ulong.MinValue, ulong.MaxValue);
 
-        public static NumberConstraint ForByte { get; } = new NumberConstraint(byte.MinValue, byte.MaxValue);
+        public static ref readonly NumberConstraint Empty => ref _empty;
 
-        public static NumberConstraint ForSByte { get; } = new NumberConstraint(sbyte.MinValue, sbyte.MaxValue);
+        public static ref readonly NumberConstraint ForByte => ref _forByte;
 
-        public static NumberConstraint ForInt16 { get; } = new NumberConstraint(short.MinValue, short.MaxValue);
+        public static ref readonly NumberConstraint ForSByte => ref _forSByte;
 
-        public static NumberConstraint ForUInt16 { get; } = new NumberConstraint(ushort.MinValue, ushort.MaxValue);
+        public static ref readonly NumberConstraint ForInt16 => ref _forInt16;
 
-        public static NumberConstraint ForInt32 { get; } = new NumberConstraint(int.MinValue, int.MaxValue);
+        public static ref readonly NumberConstraint ForUInt16 => ref _forUInt16;
 
-        public static NumberConstraint ForUInt32 { get; } = new NumberConstraint(uint.MinValue, uint.MaxValue);
+        public static ref readonly NumberConstraint ForInt32 => ref _forInt32;
 
-        public static NumberConstraint ForInt64 { get; } = new NumberConstraint(long.MinValue, long.MaxValue);
+        public static ref readonly NumberConstraint ForUInt32 => ref _forUInt32;
 
-        public static NumberConstraint ForUInt64 { get; } = new NumberConstraint(ulong.MinValue, ulong.MaxValue);
+        public static ref readonly NumberConstraint ForInt64 => ref _forInt64;
+
+        public static ref readonly NumberConstraint ForUInt64 => ref _forUInt64;
 
         #endregion
 

--- a/src/SourceCode.Clay.OpenApi.Tests/SourceCode.Clay.OpenApi.Tests.csproj
+++ b/src/SourceCode.Clay.OpenApi.Tests/SourceCode.Clay.OpenApi.Tests.csproj
@@ -7,6 +7,9 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Net.Compilers" Version="2.6.0-beta3-62314-05">
+      <PrivateAssets>All</PrivateAssets>
+    </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
     <PackageReference Include="OpenCover" Version="4.6.519" />
     <PackageReference Include="xunit" Version="2.3.1" />
@@ -16,5 +19,4 @@
   <ItemGroup>
     <ProjectReference Include="..\SourceCode.Clay.OpenApi\SourceCode.Clay.OpenApi.csproj" />
   </ItemGroup>
-
 </Project>

--- a/src/SourceCode.Clay.Tests/SourceCode.Clay.Tests.csproj
+++ b/src/SourceCode.Clay.Tests/SourceCode.Clay.Tests.csproj
@@ -9,6 +9,9 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Net.Compilers" Version="2.6.0-beta3-62314-05">
+      <PrivateAssets>All</PrivateAssets>
+    </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
     <PackageReference Include="OpenCover" Version="4.6.519" />
     <PackageReference Include="xunit" Version="2.3.1" />

--- a/src/SourceCode.Clay.Text.Tests/SourceCode.Clay.Text.Tests.csproj
+++ b/src/SourceCode.Clay.Text.Tests/SourceCode.Clay.Text.Tests.csproj
@@ -9,6 +9,9 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Net.Compilers" Version="2.6.0-beta3-62314-05">
+      <PrivateAssets>All</PrivateAssets>
+    </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
     <PackageReference Include="OpenCover" Version="4.6.519" />
     <PackageReference Include="xunit" Version="2.3.1" />

--- a/src/SourceCode.Clay.Threading.Tests/SourceCode.Clay.Threading.Tests.csproj
+++ b/src/SourceCode.Clay.Threading.Tests/SourceCode.Clay.Threading.Tests.csproj
@@ -9,6 +9,9 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Net.Compilers" Version="2.6.0-beta3-62314-05">
+      <PrivateAssets>All</PrivateAssets>
+    </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
     <PackageReference Include="OpenCover" Version="4.6.519" />
     <PackageReference Include="xunit" Version="2.3.1" />

--- a/src/SourceCode.Clay/SemanticVersion.cs
+++ b/src/SourceCode.Clay/SemanticVersion.cs
@@ -17,10 +17,12 @@ namespace SourceCode.Clay
     {
         #region Constants
 
+        private static readonly SemanticVersion _empty;
+
         /// <summary>
         /// Gets the default value of <see cref="SemanticVersion"/>.
         /// </summary>
-        public static SemanticVersion Empty { get; }
+        public static ref readonly SemanticVersion Empty => ref _empty;
 
         #endregion
 


### PR DESCRIPTION
* Optimize `BufferComparer`
* `in` parameters
* `ref readonly` on method returns

See [Reference semantics with value types](https://docs.microsoft.com/en-us/dotnet/csharp/whats-new/csharp-7-2#reference-semantics-with-value-types)
