### PR TITLE
Fix #192 Move Sha1 to Clay from Chasm

### DIFF
--- a/src/SourceCode.Clay.Tests/Sha1Tests.cs
+++ b/src/SourceCode.Clay.Tests/Sha1Tests.cs
@@ -1,0 +1,722 @@
+#region License
+
+// Copyright (c) K2 Workflow (SourceCode Technology Holdings Inc.). All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+#endregion
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using Xunit;
+
+namespace SourceCode.Clay.Tests
+{
+    public static class Sha1Tests
+    {
+        #region Constants
+
+        private const string _surrogatePair = "\uD869\uDE01";
+
+        #endregion
+
+        #region Methods
+
+        [Trait("Type", "Unit")]
+        [Fact(DisplayName = nameof(When_create_null_sha1))]
+        public static void When_create_null_sha1()
+        {
+            var expected = Sha1.Zero;
+
+            Assert.Throws<ArgumentOutOfRangeException>(() => new Sha1((byte[])null));
+
+            Assert.True(default == expected);
+            Assert.False(default != expected);
+            Assert.True(expected.Equals((object)expected));
+            Assert.Equal(new KeyValuePair<string, string>("", "0000000000000000000000000000000000000000"), expected.Split(0));
+            Assert.Equal(new KeyValuePair<string, string>("00", "00000000000000000000000000000000000000"), expected.Split(2));
+            Assert.Equal(new KeyValuePair<string, string>("0000000000000000000000000000000000000000", ""), expected.Split(Sha1.HexLength));
+
+            // Null string
+            var actual = Sha1.Hash((string)null);
+            Assert.Equal(expected, actual);
+            Assert.Equal(expected.GetHashCode(), actual.GetHashCode());
+            // Assert.Equal(expected.Memory, actual.Memory, BufferComparer.Memory);
+
+            // Null bytes
+            actual = Sha1.Hash((byte[])null);
+            Assert.Equal(expected, actual);
+            Assert.Equal(expected.GetHashCode(), actual.GetHashCode());
+            // Assert.Equal(expected.Memory, actual.Memory, BufferComparer.Memory);
+
+            actual = Sha1.Hash(null, 0, 0);
+            Assert.Equal(expected, actual);
+            Assert.Equal(expected.GetHashCode(), actual.GetHashCode());
+            // Assert.Equal(expected.Memory, actual.Memory, BufferComparer.Memory);
+
+            // Stream
+            actual = Sha1.Hash((Stream)null);
+            Assert.Equal(expected, actual);
+            Assert.Equal(expected.GetHashCode(), actual.GetHashCode());
+            // Assert.Equal(expected.Memory, actual.Memory, BufferComparer.Memory);
+
+            // Null segment
+            actual = Sha1.Hash(default(ArraySegment<byte>));
+            Assert.Equal(expected, actual);
+            Assert.Equal(expected.GetHashCode(), actual.GetHashCode());
+            // Assert.Equal(expected.Memory, actual.Memory, BufferComparer.Memory);
+
+            // Roundtrip string
+            actual = Sha1.Parse(expected.ToString());
+            Assert.Equal(expected, actual);
+            Assert.Equal(expected.GetHashCode(), actual.GetHashCode());
+            // Assert.Equal(expected.Memory, actual.Memory, BufferComparer.Memory);
+
+            // Roundtrip formatted
+            actual = Sha1.Parse(expected.ToString("D"));
+            Assert.Equal(expected, actual);
+            Assert.Equal(expected.GetHashCode(), actual.GetHashCode());
+            // Assert.Equal(expected.Memory, actual.Memory, BufferComparer.Memory);
+
+            actual = Sha1.Parse(expected.ToString("S"));
+            Assert.Equal(expected, actual);
+            Assert.Equal(expected.GetHashCode(), actual.GetHashCode());
+            // Assert.Equal(expected.Memory, actual.Memory, BufferComparer.Memory);
+
+            // With hex specifier
+            actual = Sha1.Parse("0x" + expected.ToString("D"));
+            Assert.Equal(expected, actual);
+            Assert.Equal(expected.GetHashCode(), actual.GetHashCode());
+            // Assert.Equal(expected.Memory, actual.Memory, BufferComparer.Memory);
+
+            actual = Sha1.Parse("0x" + expected.ToString("S"));
+            Assert.Equal(expected, actual);
+            Assert.Equal(expected.GetHashCode(), actual.GetHashCode());
+            // Assert.Equal(expected.Memory, actual.Memory, BufferComparer.Memory);
+        }
+
+        [Trait("Type", "Unit")]
+        [Fact(DisplayName = nameof(When_construct_sha1_from_Bytes))]
+        public static void When_construct_sha1_from_Bytes()
+        {
+            var expected = Sha1.Hash("abc");
+            var buffer = new byte[Sha1.ByteLength + 10];
+
+            Assert.Throws<ArgumentOutOfRangeException>(() => new Sha1(new byte[Sha1.ByteLength - 1])); // Too short
+            Assert.Throws<ArgumentOutOfRangeException>(() => new Sha1(new byte[Sha1.ByteLength].AsSpan().Slice(1))); // Bad offset
+
+            // Construct Byte[]
+            expected.CopyTo(buffer.AsSpan());
+            var actual = new Sha1(buffer);
+            Assert.Equal(expected, actual);
+            Assert.Equal(expected.GetHashCode(), actual.GetHashCode());
+            // Assert.Equal(expected.Memory, actual.Memory, BufferComparer.Memory);
+
+            // Construct Byte[] with offset 0
+            expected.CopyTo(buffer.AsSpan());
+            actual = new Sha1(buffer);
+            Assert.Equal(expected, actual);
+            Assert.Equal(expected.GetHashCode(), actual.GetHashCode());
+            // Assert.Equal(expected.Memory, actual.Memory, BufferComparer.Memory);
+
+            // Construct Byte[] with offset N
+            expected.CopyTo(buffer.AsSpan().Slice(5));
+            actual = new Sha1(buffer.AsSpan().Slice(5));
+            Assert.Equal(expected, actual);
+            Assert.Equal(expected.GetHashCode(), actual.GetHashCode());
+            // Assert.Equal(expected.Memory, actual.Memory, BufferComparer.Memory);
+        }
+
+        [Trait("Type", "Unit")]
+        [Fact(DisplayName = nameof(When_construct_sha1_from_ArraySegment))]
+        public static void When_construct_sha1_from_ArraySegment()
+        {
+            var expected = Sha1.Hash("abc");
+            var buffer = new byte[Sha1.ByteLength + 10];
+
+            // Construct Byte[] with offset N
+            expected.CopyTo(buffer.AsSpan().Slice(5));
+            var actual = new Sha1(buffer.AsSpan().Slice(5));
+            Assert.Equal(expected, actual);
+            Assert.Equal(expected.GetHashCode(), actual.GetHashCode());
+            // Assert.Equal(expected.Memory, actual.Memory, BufferComparer.Memory);
+
+            // Construct Segment
+            expected.CopyTo(buffer.AsSpan());
+            var seg = new ArraySegment<byte>(buffer);
+            actual = new Sha1(seg);
+            Assert.Equal(expected, actual);
+            Assert.Equal(expected.GetHashCode(), actual.GetHashCode());
+            // Assert.Equal(expected.Memory, actual.Memory, BufferComparer.Memory);
+
+            // Construct Segment with offset 0
+            expected.CopyTo(buffer.AsSpan());
+            seg = new ArraySegment<byte>(buffer, 0, Sha1.ByteLength);
+            actual = new Sha1(seg);
+            Assert.Equal(expected, actual);
+            Assert.Equal(expected.GetHashCode(), actual.GetHashCode());
+            // Assert.Equal(expected.Memory, actual.Memory, BufferComparer.Memory);
+
+            // Construct Segment with offset N
+            expected.CopyTo(buffer.AsSpan().Slice(5));
+            seg = new ArraySegment<byte>(buffer, 5, Sha1.ByteLength);
+            actual = new Sha1(seg);
+            Assert.Equal(expected, actual);
+            Assert.Equal(expected.GetHashCode(), actual.GetHashCode());
+            // Assert.Equal(expected.Memory, actual.Memory, BufferComparer.Memory);
+        }
+
+        [Trait("Type", "Unit")]
+        [Fact(DisplayName = nameof(When_construct_sha1_from_Memory))]
+        public static void When_construct_sha1_from_Memory()
+        {
+            var expected = Sha1.Hash("abc");
+            var buffer = new byte[Sha1.ByteLength + 10];
+
+            Assert.Throws<ArgumentOutOfRangeException>(() => new Sha1(Memory<byte>.Empty.Span)); // Empty
+            Assert.Throws<ArgumentOutOfRangeException>(() => new Sha1(new Memory<byte>(new byte[Sha1.ByteLength - 1]).Span)); // Too short
+
+            // Construct Memory
+            expected.CopyTo(buffer.AsSpan());
+            var mem = new Memory<byte>(buffer);
+            var actual = new Sha1(mem.Span);
+            Assert.Equal(expected, actual);
+            Assert.Equal(expected.GetHashCode(), actual.GetHashCode());
+            // Assert.Equal(expected.Memory, actual.Memory, BufferComparer.Memory);
+
+            // Construct Memory with offset 0
+            expected.CopyTo(buffer.AsSpan());
+            mem = new Memory<byte>(buffer, 0, Sha1.ByteLength);
+            actual = new Sha1(mem.Span);
+            Assert.Equal(expected, actual);
+            Assert.Equal(expected.GetHashCode(), actual.GetHashCode());
+            // Assert.Equal(expected.Memory, actual.Memory, BufferComparer.Memory);
+
+            // Construct Memory with offset N
+            expected.CopyTo(buffer.AsSpan().Slice(5));
+            mem = new Memory<byte>(buffer, 5, Sha1.ByteLength);
+            actual = new Sha1(mem.Span);
+            Assert.Equal(expected, actual);
+            Assert.Equal(expected.GetHashCode(), actual.GetHashCode());
+            // Assert.Equal(expected.Memory, actual.Memory, BufferComparer.Memory);
+        }
+
+        [Trait("Type", "Unit")]
+        [Fact(DisplayName = nameof(When_construct_sha1_from_ReadOnlyMemory))]
+        public static void When_construct_sha1_from_ReadOnlyMemory()
+        {
+            var expected = Sha1.Hash("abc");
+            var buffer = new byte[Sha1.ByteLength + 10];
+
+            // Construct ReadOnlyMemory
+            expected.CopyTo(buffer.AsSpan());
+            var mem = new ReadOnlyMemory<byte>(buffer);
+            var actual = new Sha1(mem.Span);
+            Assert.Equal(expected, actual);
+            Assert.Equal(expected.GetHashCode(), actual.GetHashCode());
+            // Assert.Equal(expected.Memory, actual.Memory, BufferComparer.Memory);
+
+            // Construct ReadOnlyMemory with offset 0
+            expected.CopyTo(buffer.AsSpan());
+            mem = new ReadOnlyMemory<byte>(buffer, 0, Sha1.ByteLength);
+            actual = new Sha1(mem.Span);
+            Assert.Equal(expected, actual);
+            Assert.Equal(expected.GetHashCode(), actual.GetHashCode());
+            // Assert.Equal(expected.Memory, actual.Memory, BufferComparer.Memory);
+
+            // Construct ReadOnlyMemory with offset N
+            expected.CopyTo(buffer.AsSpan().Slice(5));
+            mem = new ReadOnlyMemory<byte>(buffer, 5, Sha1.ByteLength);
+            actual = new Sha1(mem.Span);
+            Assert.Equal(expected, actual);
+            Assert.Equal(expected.GetHashCode(), actual.GetHashCode());
+            // Assert.Equal(expected.Memory, actual.Memory, BufferComparer.Memory);
+        }
+
+        [Trait("Type", "Unit")]
+        [Fact(DisplayName = nameof(When_construct_sha1_from_Stream))]
+        public static void When_construct_sha1_from_Stream()
+        {
+            var buffer = Encoding.UTF8.GetBytes(Guid.NewGuid().ToString());
+
+            // Construct MemoryStream
+            var mem = new MemoryStream(buffer);
+            var expected = Sha1.Hash(buffer);
+            var actual = Sha1.Hash(mem);
+            Assert.Equal(expected, actual);
+            Assert.Equal(expected.GetHashCode(), actual.GetHashCode());
+            // Assert.Equal(expected.Memory, actual.Memory, BufferComparer.Memory);
+
+            // Construct MemoryStream with offset 0
+            mem = new MemoryStream(buffer, 0, buffer.Length);
+            expected = Sha1.Hash(buffer, 0, buffer.Length);
+            actual = Sha1.Hash(mem);
+            Assert.Equal(expected, actual);
+            Assert.Equal(expected.GetHashCode(), actual.GetHashCode());
+            // Assert.Equal(expected.Memory, actual.Memory, BufferComparer.Memory);
+
+            // Construct MemoryStream with offset N
+            mem = new MemoryStream(buffer, 5, buffer.Length - 5);
+            expected = Sha1.Hash(buffer, 5, buffer.Length - 5);
+            actual = Sha1.Hash(mem);
+            Assert.Equal(expected, actual);
+            Assert.Equal(expected.GetHashCode(), actual.GetHashCode());
+            // Assert.Equal(expected.Memory, actual.Memory, BufferComparer.Memory);
+        }
+
+        [Trait("Type", "Unit")]
+        [Fact(DisplayName = nameof(When_construct_sha1_from_Span))]
+        public static void When_construct_sha1_from_Span()
+        {
+            var expected = Sha1.Hash("abc");
+            var buffer = new byte[Sha1.ByteLength + 10];
+
+            // Construct Span
+            expected.CopyTo(buffer.AsSpan());
+            var span = new Span<byte>(buffer);
+            var actual = new Sha1(span);
+            Assert.Equal(expected, actual);
+            Assert.Equal(expected.GetHashCode(), actual.GetHashCode());
+            // Assert.Equal(expected.Memory, actual.Memory, BufferComparer.Memory);
+
+            // Construct Span with offset 0
+            expected.CopyTo(buffer.AsSpan());
+            span = new Span<byte>(buffer, 0, Sha1.ByteLength);
+            actual = new Sha1(span);
+            Assert.Equal(expected, actual);
+            Assert.Equal(expected.GetHashCode(), actual.GetHashCode());
+            // Assert.Equal(expected.Memory, actual.Memory, BufferComparer.Memory);
+
+            // Construct Span with offset N
+            expected.CopyTo(buffer.AsSpan().Slice(5));
+            span = new Span<byte>(buffer, 5, Sha1.ByteLength);
+            actual = new Sha1(span);
+            Assert.Equal(expected, actual);
+            Assert.Equal(expected.GetHashCode(), actual.GetHashCode());
+            // Assert.Equal(expected.Memory, actual.Memory, BufferComparer.Memory);
+        }
+
+        [Trait("Type", "Unit")]
+        [Fact(DisplayName = nameof(When_copyto_with_null_buffer))]
+        public static void When_copyto_with_null_buffer()
+        {
+            // Arrange
+            var buffer = (byte[])null;
+            var sha1 = new Sha1();
+
+            // Action
+            var actual = Assert.Throws<ArgumentNullException>(() => sha1.CopyTo(buffer.AsSpan()));
+        }
+
+        [Trait("Type", "Unit")]
+        [Fact(DisplayName = nameof(When_construct_sha1_from_ReadOnlySpan))]
+        public static void When_construct_sha1_from_ReadOnlySpan()
+        {
+            var expected = Sha1.Hash("abc");
+            var buffer = new byte[Sha1.ByteLength + 10];
+
+            // Construct ReadOnlySpan
+            expected.CopyTo(buffer.AsSpan());
+            var span = new ReadOnlySpan<byte>(buffer);
+            var actual = new Sha1(span);
+            Assert.Equal(expected, actual);
+            Assert.Equal(expected.GetHashCode(), actual.GetHashCode());
+            // Assert.Equal(expected.Memory, actual.Memory, BufferComparer.Memory);
+
+            // Construct ReadOnlySpan with offset 0
+            expected.CopyTo(buffer.AsSpan());
+            span = new ReadOnlySpan<byte>(buffer, 0, Sha1.ByteLength);
+            actual = new Sha1(span);
+            Assert.Equal(expected, actual);
+            Assert.Equal(expected.GetHashCode(), actual.GetHashCode());
+            // Assert.Equal(expected.Memory, actual.Memory, BufferComparer.Memory);
+
+            // Construct ReadOnlySpan with offset N
+            expected.CopyTo(buffer.AsSpan().Slice(5));
+            span = new ReadOnlySpan<byte>(buffer, 5, Sha1.ByteLength);
+            actual = new Sha1(span);
+            Assert.Equal(expected, actual);
+            Assert.Equal(expected.GetHashCode(), actual.GetHashCode());
+            // Assert.Equal(expected.Memory, actual.Memory, BufferComparer.Memory);
+        }
+
+        [Trait("Type", "Unit")]
+        [Theory(DisplayName = nameof(When_create_test_vectors))]
+        [ClassData(typeof(TestVectors))]
+        public static void When_create_test_vectors(string input, string expected)
+        {
+            // http://www.di-mgt.com.au/sha_testvectors.html
+
+            var sha1 = Sha1.Parse(expected);
+            {
+                // String
+                var actual = Sha1.Hash(input).ToString();
+                Assert.Equal(expected, actual);
+                Assert.Equal(expected.GetHashCode(), actual.GetHashCode());
+                Assert.Equal(Sha1.HexLength, Encoding.UTF8.GetByteCount(actual));
+
+                // Bytes
+                var bytes = Encoding.UTF8.GetBytes(input);
+                actual = Sha1.Hash(bytes).ToString();
+                Assert.Equal(expected, actual);
+                Assert.Equal(expected.GetHashCode(), actual.GetHashCode());
+
+                actual = Sha1.Hash(bytes, 0, bytes.Length).ToString();
+                Assert.Equal(expected, actual);
+                Assert.Equal(expected.GetHashCode(), actual.GetHashCode());
+
+                // Object
+                Assert.True(expected.Equals((object)actual));
+
+                // Roundtrip string
+                actual = sha1.ToString();
+                Assert.Equal(expected, actual);
+                Assert.Equal(expected.GetHashCode(), actual.GetHashCode());
+
+                // Roundtrip formatted
+                actual = Sha1.Parse(sha1.ToString("D")).ToString();
+                Assert.Equal(expected, actual);
+                Assert.Equal(expected.GetHashCode(), actual.GetHashCode());
+
+                actual = Sha1.Parse(sha1.ToString("S")).ToString();
+                Assert.Equal(expected, actual);
+                Assert.Equal(expected.GetHashCode(), actual.GetHashCode());
+
+                // With hex specifier
+                actual = Sha1.Parse("0x" + sha1.ToString("D")).ToString();
+                Assert.Equal(expected, actual);
+                Assert.Equal(expected.GetHashCode(), actual.GetHashCode());
+
+                actual = Sha1.Parse("0x" + sha1.ToString("S")).ToString();
+                Assert.Equal(expected, actual);
+                Assert.Equal(expected.GetHashCode(), actual.GetHashCode());
+
+                // Get Byte[]
+                var buffer = new byte[Sha1.ByteLength];
+                sha1.CopyTo(buffer.AsSpan());
+
+                // Roundtrip Byte[]
+                actual = new Sha1(buffer).ToString();
+                Assert.Equal(expected, actual);
+                Assert.Equal(expected.GetHashCode(), actual.GetHashCode());
+
+                // Roundtrip Segment
+                actual = new Sha1(new ArraySegment<byte>(buffer)).ToString();
+                Assert.Equal(expected, actual);
+                Assert.Equal(expected.GetHashCode(), actual.GetHashCode());
+            }
+        }
+
+        [Trait("Type", "Unit")]
+        [Fact(DisplayName = nameof(When_create_sha_from_empty_string))]
+        public static void When_create_sha_from_empty_string()
+        {
+            // http://www.di-mgt.com.au/sha_testvectors.html
+
+            const string expected = "da39a3ee5e6b4b0d3255bfef95601890afd80709";
+            var sha1 = Sha1.Parse(expected);
+            {
+                const string input = "";
+
+                // String
+                var actual = Sha1.Hash(input).ToString();
+                Assert.Equal(expected, actual);
+                Assert.Equal(Sha1.HexLength, Encoding.UTF8.GetByteCount(actual));
+
+                // Empty array
+                actual = Sha1.Hash(Array.Empty<byte>()).ToString();
+                Assert.Equal(expected, actual);
+
+                actual = Sha1.Hash(Array.Empty<byte>(), 0, 0).ToString();
+                Assert.Equal(expected, actual);
+
+                // Empty segment
+                actual = Sha1.Hash(new ArraySegment<byte>(Array.Empty<byte>())).ToString();
+                Assert.Equal(expected, actual);
+
+                // Bytes
+                var bytes = Encoding.UTF8.GetBytes(input);
+                actual = Sha1.Hash(bytes).ToString();
+                Assert.Equal(expected, actual);
+
+                // Object
+                Assert.True(expected.Equals((object)actual));
+
+                // Roundtrip string
+                actual = sha1.ToString();
+                Assert.Equal(expected, actual);
+
+                // Roundtrip formatted
+                actual = Sha1.Parse(sha1.ToString("D")).ToString();
+                Assert.Equal(expected, actual);
+
+                actual = Sha1.Parse(sha1.ToString("S")).ToString();
+                Assert.Equal(expected, actual);
+
+                // With hex specifier
+                actual = Sha1.Parse("0x" + sha1.ToString("D")).ToString();
+                Assert.Equal(expected, actual);
+
+                actual = Sha1.Parse("0x" + sha1.ToString("S")).ToString();
+                Assert.Equal(expected, actual);
+
+                // Get Byte[]
+                var buffer = new byte[Sha1.ByteLength];
+                sha1.CopyTo(buffer.AsSpan());
+
+                // Roundtrip Byte[]
+                actual = new Sha1(buffer).ToString();
+                Assert.Equal(expected, actual);
+
+                // Roundtrip Segment
+                actual = new Sha1(new ArraySegment<byte>(buffer)).ToString();
+                Assert.Equal(expected, actual);
+            }
+        }
+
+        [Trait("Type", "Unit")]
+        [Fact(DisplayName = nameof(When_create_sha_from_narrow_string))]
+        public static void When_create_sha_from_narrow_string()
+        {
+            for (var i = 1; i < 200; i++)
+            {
+                var str = new string(Char.MinValue, i);
+                var sha1 = Sha1.Hash(str);
+
+                Assert.NotEqual(Sha1.Zero, sha1);
+                Assert.Equal(Sha1.HexLength, Encoding.UTF8.GetByteCount(sha1.ToString()));
+            }
+        }
+
+        [Trait("Type", "Unit")]
+        [Fact(DisplayName = nameof(When_create_sha_from_wide_string_1))]
+        public static void When_create_sha_from_wide_string_1()
+        {
+            for (var i = 1; i < 200; i++)
+            {
+                var str = new string(Char.MaxValue, i);
+                var sha1 = Sha1.Hash(str);
+
+                Assert.NotEqual(Sha1.Zero, sha1);
+                Assert.Equal(Sha1.HexLength, Encoding.UTF8.GetByteCount(sha1.ToString()));
+            }
+        }
+
+        [Trait("Type", "Unit")]
+        [Fact(DisplayName = nameof(When_create_sha_from_wide_string_2))]
+        public static void When_create_sha_from_wide_string_2()
+        {
+            var str = string.Empty;
+            for (var i = 1; i < 200; i++)
+            {
+                str += _surrogatePair;
+                var sha1 = Sha1.Hash(str);
+
+                Assert.NotEqual(Sha1.Zero, sha1);
+                Assert.Equal(Sha1.HexLength, Encoding.UTF8.GetByteCount(sha1.ToString()));
+            }
+        }
+
+        [Trait("Type", "Unit")]
+        [Fact(DisplayName = nameof(When_format_sha1))]
+        public static void When_format_sha1()
+        {
+            const string expected_N = "a9993e364706816aba3e25717850c26c9cd0d89d";
+            var sha1 = Sha1.Parse(expected_N);
+
+            // ("N")
+            {
+                var actual = sha1.ToString(); // Default format
+                Assert.Equal(expected_N, actual);
+
+                actual = sha1.ToString("N");
+                Assert.Equal(expected_N, actual);
+
+                actual = sha1.ToString("n");
+                Assert.Equal(expected_N, actual);
+            }
+
+            // ("D")
+            {
+                const string expected_D = "a9993e36-4706816a-ba3e2571-7850c26c-9cd0d89d";
+
+                var actual = sha1.ToString("D");
+                Assert.Equal(expected_D, actual);
+
+                actual = sha1.ToString("d");
+                Assert.Equal(expected_D, actual);
+            }
+
+            // ("S")
+            {
+                const string expected_S = "a9993e36 4706816a ba3e2571 7850c26c 9cd0d89d";
+
+                var actual = sha1.ToString("S");
+                Assert.Equal(expected_S, actual);
+
+                actual = sha1.ToString("s");
+                Assert.Equal(expected_S, actual);
+            }
+
+            // (null)
+            {
+                Assert.Throws<FormatException>(() => sha1.ToString(null));
+            }
+
+            // ("")
+            {
+                Assert.Throws<FormatException>(() => sha1.ToString(""));
+            }
+
+            // (" ")
+            {
+                Assert.Throws<FormatException>(() => sha1.ToString(" "));
+            }
+
+            // ("x")
+            {
+                Assert.Throws<FormatException>(() => sha1.ToString("x"));
+            }
+
+            // ("ss")
+            {
+                Assert.Throws<FormatException>(() => sha1.ToString("nn"));
+            }
+        }
+
+        [Trait("Type", "Unit")]
+        [Fact(DisplayName = nameof(When_parse_sha1))]
+        public static void When_parse_sha1()
+        {
+            const string expected_N = "a9993e364706816aba3e25717850c26c9cd0d89d";
+            var sha1 = Sha1.Parse(expected_N);
+
+            Assert.True(Sha1.TryParse(expected_N, out _));
+
+            Assert.True(Sha1.TryParse("0x" + expected_N, out _));
+            Assert.True(Sha1.TryParse("0X" + expected_N, out _));
+
+            Assert.False(Sha1.TryParse(expected_N.Substring(10), out _));
+            Assert.False(Sha1.TryParse("0x" + expected_N.Substring(10), out _));
+            Assert.False(Sha1.TryParse("0X" + expected_N.Substring(10), out _));
+
+            Assert.False(Sha1.TryParse("0x" + expected_N.Substring(Sha1.HexLength - 2), out _));
+            Assert.False(Sha1.TryParse("0X" + expected_N.Substring(Sha1.HexLength - 2), out _));
+
+            Assert.False(Sha1.TryParse(expected_N.Replace('8', 'G'), out _));
+
+            Assert.False(Sha1.TryParse($"0x{new string('1', 38)}", out _));
+            Assert.False(Sha1.TryParse($"0x{new string('1', 39)}", out _));
+            Assert.True(Sha1.TryParse($"0x{new string('1', 40)}", out _));
+
+            // "N"
+            {
+                var actual = Sha1.Parse(sha1.ToString()); // Default format
+                Assert.Equal(sha1, actual);
+
+                actual = Sha1.Parse(sha1.ToString("N"));
+                Assert.Equal(sha1, actual);
+
+                actual = Sha1.Parse("0x" + sha1.ToString("N"));
+                Assert.Equal(sha1, actual);
+
+                Assert.Throws<FormatException>(() => Sha1.Parse(sha1.ToString("N") + "a"));
+            }
+
+            // "D"
+            {
+                var actual = Sha1.Parse(sha1.ToString("D"));
+                Assert.Equal(sha1, actual);
+
+                actual = Sha1.Parse("0x" + sha1.ToString("D"));
+                Assert.Equal(sha1, actual);
+
+                Assert.Throws<FormatException>(() => Sha1.Parse(sha1.ToString("D") + "a"));
+            }
+
+            // "S"
+            {
+                var actual = Sha1.Parse(sha1.ToString("S"));
+                Assert.Equal(sha1, actual);
+
+                actual = Sha1.Parse("0x" + sha1.ToString("S"));
+                Assert.Equal(sha1, actual);
+
+                Assert.Throws<FormatException>(() => Sha1.Parse(sha1.ToString("S") + "a"));
+            }
+
+            // null
+            {
+                Assert.Throws<ArgumentNullException>(() => Sha1.Parse((string)null));
+            }
+
+            // Empty
+            {
+                Assert.Throws<FormatException>(() => Sha1.Parse(""));
+            }
+
+            // Whitespace
+            {
+                Assert.Throws<FormatException>(() => Sha1.Parse(" "));
+                Assert.Throws<FormatException>(() => Sha1.Parse("\t"));
+                Assert.Throws<FormatException>(() => Sha1.Parse(" " + expected_N));
+                Assert.Throws<FormatException>(() => Sha1.Parse(expected_N + " "));
+            }
+
+            // "0x"
+            {
+                Assert.Throws<FormatException>(() => Sha1.Parse("0x"));
+            }
+        }
+
+        [Trait("Type", "Unit")]
+        [Fact(DisplayName = nameof(When_lexographic_compare_sha1))]
+        public static void When_lexographic_compare_sha1()
+        {
+            var byt1 = new byte[20] { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19 };
+            var sha1 = new Sha1(byt1);
+            var str1 = sha1.ToString();
+            Assert.Equal(@"000102030405060708090a0b0c0d0e0f10111213", str1);
+
+            for (var n = 0; n < 20; n++)
+            {
+                for (var i = n + 1; i <= byte.MaxValue; i++)
+                {
+                    // Bump blit[n]
+                    byt1[n] = (byte)i;
+                    var sha2 = new Sha1(byt1);
+                    Assert.True(sha2 > sha1);
+                }
+
+                byt1[n] = (byte)n;
+            }
+        }
+
+        [Trait("Type", "Unit")]
+        [Fact(DisplayName = nameof(Sha1_Compare))]
+        public static void Sha1_Compare()
+        {
+            var comparer = Sha1Comparer.Default;
+
+            var sha1 = Sha1.Hash("abc");
+            var sha2 = Sha1.Hash("abc");
+            var sha3 = Sha1.Hash("def");
+
+            Assert.True(Sha1.Zero < sha1);
+            Assert.True(sha1 > Sha1.Zero);
+
+            var list = new[] { sha1, sha2, sha3 };
+
+            Assert.True(sha1.CompareTo(sha2) == 0);
+            Assert.True(sha1.CompareTo(sha3) != 0);
+
+            Array.Sort(list, comparer.Compare);
+
+            Assert.True(list[0] <= list[1]);
+            Assert.True(list[2] >= list[1]);
+        }
+
+        #endregion
+    }
+}

--- a/src/SourceCode.Clay.Tests/TestVectors.cs
+++ b/src/SourceCode.Clay.Tests/TestVectors.cs
@@ -1,0 +1,47 @@
+#region License
+
+// Copyright (c) K2 Workflow (SourceCode Technology Holdings Inc.). All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+#endregion
+
+using System.Collections;
+using System.Collections.Generic;
+
+namespace SourceCode.Clay.Tests
+{
+    internal sealed class TestVectors : IEnumerable<object[]>
+    {
+        #region Constants
+
+        // http://www.di-mgt.com.au/sha_testvectors.html
+
+        private static readonly List<object[]> _data = new List<object[]>
+        {
+            // Test Vector 1
+            new object[]{ "", "da39a3ee5e6b4b0d3255bfef95601890afd80709" },
+
+            // Test Vector 2
+            new object[]{ "abc", "a9993e364706816aba3e25717850c26c9cd0d89d" },
+
+            // Test Vector 3
+            new object[]{ "abcdbcdecdefdefgefghfghighijhijkijkljklmklmnlmnomnopnopq", "84983e441c3bd26ebaae4aa1f95129e5e54670f1" },
+
+            // Test Vector 4
+            new object[]{ "abcdefghbcdefghicdefghijdefghijkefghijklfghijklmghijklmnhijklmnoijklmnopjklmnopqklmnopqrlmnopqrsmnopqrstnopqrstu", "a49b2446a02c645bf419f995b67091253a04a259" },
+
+            // Test Vector 5
+            new object[]{ new string('a', 1000_000), "34aa973cd4c4daa4f61eeb2bdbad27316534016f" },
+        };
+
+        #endregion
+
+        #region Methods
+
+        public IEnumerator<object[]> GetEnumerator() => _data.GetEnumerator();
+
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+
+        #endregion
+    }
+}

--- a/src/SourceCode.Clay/Sha1.cs
+++ b/src/SourceCode.Clay/Sha1.cs
@@ -1,0 +1,595 @@
+#region License
+
+// Copyright (c) K2 Workflow (SourceCode Technology Holdings Inc.). All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+#endregion
+
+using System;
+using System.Buffers;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Runtime.InteropServices;
+using System.Security;
+using System.Text;
+using System.Threading;
+
+namespace SourceCode.Clay
+{
+    /// <summary>
+    /// Represents a <see cref="Sha1"/> value.
+    /// </summary>
+    /// <seealso cref="System.Security.Cryptography.SHA1" />
+    /// <seealso cref="System.IEquatable{T}" />
+    /// <seealso cref="System.IComparable{T}" />
+    [DebuggerDisplay("{ToString(\"D\"),nq,ac}")]
+    [StructLayout(LayoutKind.Sequential, Size = ByteLength)]
+    public readonly struct Sha1 : IEquatable<Sha1>, IComparable<Sha1>
+    {
+        #region Constants
+
+        // Use a thread-local instance of the underlying crypto algorithm.
+        private static readonly ThreadLocal<System.Security.Cryptography.SHA1> _sha1 = new ThreadLocal<System.Security.Cryptography.SHA1>(System.Security.Cryptography.SHA1.Create);
+
+        /// <summary>
+        /// The fixed byte length of a <see cref="Sha1"/> value.
+        /// </summary>
+        public const byte ByteLength = 20;
+
+        /// <summary>
+        /// The number of hex characters required to represent a <see cref="Sha1"/> value.
+        /// </summary>
+        public const byte HexLength = ByteLength * 2;
+
+        private static readonly Sha1 _zero;
+
+        /// <summary>
+        /// A singleton representing an <see cref="Sha1"/> value that is all zeroes.
+        /// </summary>
+        /// <value>
+        /// The zeroes <see cref="Sha1"/>.
+        /// </value>
+        public static ref readonly Sha1 Zero => ref _zero;
+
+        #endregion
+
+        #region Fields
+
+        // We choose to use value types for primary storage so that we can live on the stack
+        // Using byte[] or String means a dereference to the heap (& fixed byte would require unsafe)
+
+        private readonly byte _a0;
+        private readonly byte _a1;
+        private readonly byte _a2;
+        private readonly byte _a3;
+
+        private readonly byte _b0;
+        private readonly byte _b1;
+        private readonly byte _b2;
+        private readonly byte _b3;
+
+        private readonly byte _c0;
+        private readonly byte _c1;
+        private readonly byte _c2;
+        private readonly byte _c3;
+
+        private readonly byte _d0;
+        private readonly byte _d1;
+        private readonly byte _d2;
+        private readonly byte _d3;
+
+        private readonly byte _e0;
+        private readonly byte _e1;
+        private readonly byte _e2;
+        private readonly byte _e3;
+
+        #endregion
+
+        #region Constructors
+
+        /// <summary>
+        /// Deserializes a <see cref="Sha1"/> value from the provided <see cref="ReadOnlyMemory{T}"/>.
+        /// </summary>
+        /// <param name="span">The buffer.</param>
+        /// <exception cref="ArgumentOutOfRangeException">buffer - buffer</exception>
+        [SecuritySafeCritical]
+        public Sha1(in ReadOnlySpan<byte> span)
+            : this() // Compiler doesn't know we're indirectly setting all the fields
+        {
+            if (span.Length < ByteLength)
+                throw new ArgumentOutOfRangeException(nameof(span), $"{nameof(span)} must have length at least {ByteLength}");
+
+            unsafe
+            {
+                fixed (byte* src = &span.DangerousGetPinnableReference())
+                fixed (byte* dst = &_a0)
+                {
+                    Buffer.MemoryCopy(src, dst, ByteLength, ByteLength);
+                }
+            }
+        }
+
+        #endregion
+
+        #region Hash
+
+        /// <summary>
+        /// Hashes the specified value using utf8 encoding.
+        /// </summary>
+        /// <param name="value">The string to hash.</param>
+        /// <returns></returns>
+        public static Sha1 Hash(in string value)
+        {
+            if (value == null) return Zero;
+            // Note that length=0 should not short-circuit
+
+            // Rent buffer
+            var maxLen = Encoding.UTF8.GetMaxByteCount(value.Length); // Utf8 is 1-4 bpc
+            var rented = ArrayPool<byte>.Shared.Rent(maxLen);
+            var count = Encoding.UTF8.GetBytes(value, 0, value.Length, rented, 0);
+
+            var hash = _sha1.Value.ComputeHash(rented, 0, count);
+            var sha1 = new Sha1(hash);
+
+            // Return buffer
+            ArrayPool<byte>.Shared.Return(rented);
+
+            return sha1;
+        }
+
+        /// <summary>
+        /// Hashes the specified bytes.
+        /// </summary>
+        /// <param name="bytes">The bytes to hash.</param>
+        /// <returns></returns>
+        public static Sha1 Hash(in byte[] bytes)
+        {
+            if (bytes == null) return Zero;
+            // Note that length=0 should not short-circuit
+
+            var hash = _sha1.Value.ComputeHash(bytes); // TODO: Convert method signature to Span once ComputeHash supports Span
+
+            var sha1 = new Sha1(hash);
+            return sha1;
+        }
+
+        /// <summary>
+        /// Hashes the specified bytes, starting at the specified offset and count.
+        /// </summary>
+        /// <param name="bytes">The bytes to hash.</param>
+        /// <param name="offset">The offset.</param>
+        /// <param name="count">The count.</param>
+        /// <returns></returns>
+        public static Sha1 Hash(in byte[] bytes, int offset, int count)
+        {
+            if (bytes == null) return Zero;
+            // Note that length=0 should not short-circuit
+
+            if (count < 0)
+                throw new ArgumentOutOfRangeException(nameof(count));
+
+            if (offset < 0 || offset + count > bytes.Length)
+                throw new ArgumentOutOfRangeException(nameof(offset));
+
+            var hash = _sha1.Value.ComputeHash(bytes, offset, count);
+
+            var sha1 = new Sha1(hash);
+            return sha1;
+        }
+
+        /// <summary>
+        /// Hashes the specified bytes.
+        /// </summary>
+        /// <param name="bytes">The bytes to hash.</param>
+        /// <returns></returns>
+        public static Sha1 Hash(in ArraySegment<byte> bytes)
+        {
+            if (bytes.Array == null) return Zero;
+            // Note that length=0 should not short-circuit
+
+            var hash = _sha1.Value.ComputeHash(bytes.Array, bytes.Offset, bytes.Count);
+
+            var sha1 = new Sha1(hash);
+            return sha1;
+        }
+
+        /// <summary>
+        /// Hashes the specified stream.
+        /// </summary>
+        /// <param name="stream">The stream to hash.</param>
+        /// <returns></returns>
+        public static Sha1 Hash(Stream stream)
+        {
+            if (stream == null) return Zero;
+            // Note that length=0 should not short-circuit
+
+            var hash = _sha1.Value.ComputeHash(stream);
+
+            var sha1 = new Sha1(hash);
+            return sha1;
+        }
+
+        #endregion
+
+        #region Methods
+
+        /// <summary>
+        /// Copies the <see cref="Sha1"/> value to the provided buffer.
+        /// </summary>
+        /// <param name="buffer">The buffer to copy to.</param>
+        /// <param name="offset">The offset.</param>
+        /// <returns></returns>
+        /// <exception cref="ArgumentNullException">buffer</exception>
+        /// <exception cref="ArgumentOutOfRangeException">offset - buffer</exception>
+        [SecuritySafeCritical]
+        public int CopyTo(Span<byte> span)
+        {
+            if (span.Length < ByteLength)
+                throw new ArgumentOutOfRangeException(nameof(span), $"{nameof(span)} must have length at least {ByteLength}");
+
+            unsafe
+            {
+                fixed (byte* src = &_a0)
+                fixed (byte* dst = &span.DangerousGetPinnableReference())
+                {
+                    Buffer.MemoryCopy(src, dst, ByteLength, ByteLength);
+                }
+            }
+
+            return ByteLength;
+        }
+
+        #endregion
+
+        #region ToString
+
+        private const char FormatN = (char)0;
+
+        [SecuritySafeCritical]
+        private char[] ToChars(char separator)
+        {
+            Debug.Assert(separator == FormatN || separator == '-' || separator == ' ');
+
+            // Text is treated as 5 groups of 8 chars (4 bytes); 4 separators optional
+            var sep = 0;
+            char[] chars;
+            if (separator == FormatN)
+            {
+                chars = new char[HexLength];
+            }
+            else
+            {
+                sep = 8;
+                chars = new char[HexLength + 4];
+            }
+
+            unsafe
+            {
+                fixed (byte* src = &_a0)
+                {
+                    var pos = 0;
+                    for (var i = 0; i < ByteLength; i++) // 20
+                    {
+                        // Each byte is two hexits (convention is lowercase)
+                        var byt = src[i];
+
+                        var b = byt >> 4; // == b / 16
+                        chars[pos++] = (char)(b < 10 ? b + '0' : b - 10 + 'a');
+
+                        b = byt & 0x0F; // == b % 16
+                        chars[pos++] = (char)(b < 10 ? b + '0' : b - 10 + 'a');
+
+                        // Append a separator if required
+                        if (pos == sep) // pos >= 2, sep = 0|N
+                        {
+                            chars[pos++] = separator;
+
+                            sep = pos + 8;
+                            if (sep >= chars.Length)
+                                sep = 0;
+                        }
+                    }
+                }
+            }
+
+            return chars;
+        }
+
+        /// <summary>
+        /// Returns a string representation of the <see cref="Sha1"/> instance using the 'N' format.
+        /// </summary>
+        /// <returns></returns>
+        public override string ToString()
+        {
+            var chars = ToChars(FormatN);
+            return new string(chars);
+        }
+
+        /// <summary>
+        /// Returns a string representation of the <see cref="Sha1"/> instance.
+        /// N: a9993e364706816aba3e25717850c26c9cd0d89d,
+        /// D: a9993e36-4706816a-ba3e2571-7850c26c-9cd0d89d,
+        /// S: a9993e36 4706816a ba3e2571 7850c26c 9cd0d89d
+        /// </summary>
+        /// <param name="format"></param>
+        /// <returns></returns>
+        public string ToString(string format)
+        {
+            if (string.IsNullOrWhiteSpace(format))
+                throw new FormatException($"Empty format specification");
+
+            if (format.Length != 1)
+                throw new FormatException($"Invalid format specification length {format.Length}");
+
+            switch (format[0])
+            {
+                // a9993e364706816aba3e25717850c26c9cd0d89d
+                case 'n':
+                case 'N':
+                    {
+                        var chars = ToChars(FormatN);
+                        return new string(chars);
+                    }
+
+                // a9993e36-4706816a-ba3e2571-7850c26c-9cd0d89d
+                case 'd':
+                case 'D':
+                    {
+                        var chars = ToChars('-');
+                        return new string(chars);
+                    }
+
+                // a9993e36 4706816a ba3e2571 7850c26c 9cd0d89d
+                case 's':
+                case 'S':
+                    {
+                        var chars = ToChars(' ');
+                        return new string(chars);
+                    }
+            }
+
+            throw new FormatException($"Invalid format specification '{format}'");
+        }
+
+        /// <summary>
+        /// Converts the <see cref="Sha1"/> instance to a string using the 'N' format,
+        /// and returns the value split into two tokens.
+        /// </summary>
+        /// <param name="prefixLength">The length of the first token.</param>
+        /// <returns></returns>
+        public KeyValuePair<string, string> Split(int prefixLength)
+        {
+            var chars = ToChars(FormatN);
+
+            if (prefixLength <= 0)
+                return new KeyValuePair<string, string>(string.Empty, new string(chars));
+
+            if (prefixLength >= HexLength)
+                return new KeyValuePair<string, string>(new string(chars), string.Empty);
+
+            var key = new string(chars, 0, prefixLength);
+            var val = new string(chars, prefixLength, chars.Length - prefixLength);
+
+            var kvp = new KeyValuePair<string, string>(key, val);
+            return kvp;
+        }
+
+        #endregion
+
+        #region Parse
+
+        // Sentinel value for n/a (128)
+        private const byte __ = 0b_1000_0000;
+
+        // '0'=48, '9'=57
+        // 'A'=65, 'F'=70
+        // 'a'=97, 'f'=102
+        private static readonly byte[] Hexits = new byte['f' - '0' + 1] // 102 - 48 + 1 = 55
+        {
+            00, 01, 02, 03, 04, 05, 06, 07, 08, 09, // [00-09]       = 48..57 = '0'..'9'
+            __, __, __, __, __, __, __, 10, 11, 12, // [10-16,17-19] = 65..67 = 'A'..'C'
+            13, 14, 15, __, __, __, __, __, __, __, // [20-22,23-29] = 68..70 = 'D'..'F'
+            __, __, __, __, __, __, __, __, __, __, // [30-39]
+            __, __, __, __, __, __, __, __, __, 10, // [40-48,49]    = 97..97 = 'a'
+            11, 12, 13, 14, 15                      // [50-54]       = 98..102= 'b'..'f'
+        };
+
+        /// <summary>
+        /// Tries to parse the specified hexadecimal.
+        /// </summary>
+        /// <param name="hex">The hexadecimal.</param>
+        /// <param name="value">The value.</param>
+        /// <returns></returns>
+        [SecuritySafeCritical]
+        public static bool TryParse(in ReadOnlySpan<char> hex, out Sha1 value)
+        {
+            value = Zero;
+
+            // Length must be at least 40
+            if (hex.Length < HexLength)
+                return false;
+
+            // Check if the hex specifier '0x' is present
+            var slice = hex;
+            if (slice[0] == '0' && (slice[1] == 'x' || slice[1] == 'X'))
+            {
+                // Length must be at least 42
+                if (slice.Length < 2 + HexLength)
+                    return false;
+
+                // Skip '0x'
+                slice = slice.Slice(2);
+            }
+
+            unsafe
+            {
+                Span<byte> span = stackalloc byte[ByteLength];
+
+                // Text is treated as 5 groups of 8 chars (4 bytes); 4 separators optional
+                // "34aa973c-d4c4daa4-f61eeb2b-dbad2731-6534016f"
+                var pos = 0;
+                for (var i = 0; i < 5; i++)
+                {
+                    for (var j = 0; j < 4; j++)
+                    {
+                        // Two hexits per byte: aaaa bbbb
+                        if (!TryParseHexit(slice[pos++], out var h1)
+                            || !TryParseHexit(slice[pos++], out var h2))
+                            return false;
+
+                        span[i * 4 + j] = (byte)((h1 << 4) | h2);
+                    }
+
+                    if (pos < HexLength && (slice[pos] == '-' || slice[pos] == ' '))
+                        pos++;
+                }
+
+                // TODO: Is this correct: do we not already permit longer strings to be passed in?
+                // If the string is not fully consumed, it had an invalid length
+                if (pos != slice.Length)
+                    return false;
+
+                value = new Sha1(span);
+                return true;
+            }
+
+            // Local functions
+
+            bool TryParseHexit(char c, out byte b)
+            {
+                b = 0;
+
+                if (c < '0' || c > 'f')
+                    return false;
+
+                var bex = Hexits[c - '0'];
+                if (bex == __) // Sentinel value for n/a (128)
+                    return false;
+
+                b = bex;
+                return true;
+            }
+        }
+
+        /// <summary>
+        /// Tries to parse the specified hexadecimal.
+        /// </summary>
+        /// <param name="hex">The hexadecimal.</param>
+        /// <param name="value">The value.</param>
+        /// <returns></returns>
+        public static bool TryParse(string hex, out Sha1 value)
+        {
+            value = Zero;
+            if (hex == null)
+                return false;
+
+            var span = hex.AsReadOnlySpan();
+            return TryParse(span, out value);
+        }
+
+        /// <summary>
+        /// Parses the specified hexadecimal.
+        /// </summary>
+        /// <param name="hex">The hexadecimal.</param>
+        /// <returns></returns>
+        /// <exception cref="FormatException">Sha1</exception>
+        public static Sha1 Parse(in ReadOnlySpan<char> hex)
+        {
+            if (!TryParse(hex, out var sha1))
+                throw new FormatException($"Input was not recognized as a valid {nameof(Sha1)}");
+
+            return sha1;
+        }
+
+        /// <summary>
+        /// Parses the specified hexadecimal.
+        /// </summary>
+        /// <param name="hex">The hexadecimal.</param>
+        /// <returns></returns>
+        /// <exception cref="FormatException">Sha1</exception>
+        public static Sha1 Parse(string hex)
+        {
+            if (hex == null) throw new ArgumentNullException(nameof(hex));
+
+            var span = hex.AsReadOnlySpan();
+            return Parse(span);
+        }
+
+        #endregion
+
+        #region IEquatable
+
+        public bool Equals(Sha1 other)
+        {
+            unsafe
+            {
+                fixed (byte* src = &_a0)
+                {
+                    var dst = &other._a0;
+
+                    for (var i = 0; i < ByteLength; i++)
+                        if (src[i] != dst[i])
+                            return false;
+                }
+
+                return true;
+            }
+        }
+
+        public override bool Equals(object obj)
+            => obj is Sha1 other
+            && Equals(other);
+
+        public override int GetHashCode()
+        {
+            var hc = HashCode.Combine(_a0, _a1, _a2, _a3, _b0, _b1, _b2, _b3);
+            hc = HashCode.Combine(hc, _c0, _c1, _c2, _c3, _d0, _d1);
+            hc = HashCode.Combine(hc, _d2, _d3, _e0, _e1, _e2, _e3);
+
+            return hc;
+        }
+
+        #endregion
+
+        #region IComparable
+
+        public int CompareTo(Sha1 other)
+        {
+            unsafe
+            {
+                fixed (byte* src = &_a0)
+                {
+                    var dst = &other._a0;
+
+                    for (var i = 0; i < ByteLength; i++)
+                    {
+                        var cmp = src[i].CompareTo(dst[i]); // CLR returns a-b for byte comparisons
+                        if (cmp != 0)
+                            return cmp < 0 ? -1 : 1; // Normalize to [-1, 0, +1]
+                    }
+                }
+            }
+
+            return 0;
+        }
+
+        #endregion
+
+        #region Operators
+
+        public static bool operator ==(Sha1 x, Sha1 y) => x.Equals(y);
+
+        public static bool operator !=(Sha1 x, Sha1 y) => !(x == y);
+
+        public static bool operator >=(Sha1 x, Sha1 y) => x.CompareTo(y) >= 0;
+
+        public static bool operator >(Sha1 x, Sha1 y) => x.CompareTo(y) > 0;
+
+        public static bool operator <=(Sha1 x, Sha1 y) => x.CompareTo(y) <= 0;
+
+        public static bool operator <(Sha1 x, Sha1 y) => x.CompareTo(y) < 0;
+
+        #endregion
+    }
+}

--- a/src/SourceCode.Clay/Sha1Comparer.cs
+++ b/src/SourceCode.Clay/Sha1Comparer.cs
@@ -1,0 +1,67 @@
+#region License
+
+// Copyright (c) K2 Workflow (SourceCode Technology Holdings Inc.). All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+#endregion
+
+using System.Collections.Generic;
+
+namespace SourceCode.Clay
+{
+    /// <summary>
+    /// Represents a way to compare different <see cref="Sha1"/> values.
+    /// </summary>
+    public abstract class Sha1Comparer : IEqualityComparer<Sha1>, IComparer<Sha1>
+    {
+        #region Constants
+
+        /// <summary>
+        /// Gets a <see cref="Sha1Comparer"/> that compares all fields of a <see cref="Sha1"/> value.
+        /// </summary>
+        public static Sha1Comparer Default { get; } = new DefaultComparer();
+
+        #endregion
+
+        #region Constructors
+
+        private Sha1Comparer()
+        { }
+
+        #endregion
+
+        #region IComparer
+
+        /// <inheritdoc/>
+        public abstract int Compare(Sha1 x, Sha1 y);
+
+        #endregion
+
+        #region IEqualityComparer
+
+        /// <inheritdoc/>
+        public abstract bool Equals(Sha1 x, Sha1 y);
+
+        /// <inheritdoc/>
+        public abstract int GetHashCode(Sha1 obj);
+
+        #endregion
+
+        #region Concrete
+
+        private sealed class DefaultComparer : Sha1Comparer
+        {
+            #region Methods
+
+            public override int Compare(Sha1 x, Sha1 y) => x.CompareTo(y);
+
+            public override bool Equals(Sha1 x, Sha1 y) => x.Equals(y);
+
+            public override int GetHashCode(Sha1 obj) => obj.GetHashCode();
+
+            #endregion
+        }
+
+        #endregion
+    }
+}

--- a/src/SourceCode.Clay/SourceCode.Clay.csproj
+++ b/src/SourceCode.Clay/SourceCode.Clay.csproj
@@ -15,6 +15,7 @@
     <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.3.0-beta1">
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
+    <PackageReference Include="System.Memory" Version="4.5.0-preview1-25927-02" />
   </ItemGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
Fixes #192 

### Information

`Sha1` is useful outside of the other infrastructure provided by `Chasm`

### Proposed Changes

* Move `Sha1` and related classes to `Clay` from `Chasm`
