### PR TITLE
Remote Context Chaining Fix

### DIFF
--- a/src/SourceCode.Clay.Json.Tests/LinkedData/Cases/expand-0078-in.jsonld
+++ b/src/SourceCode.Clay.Json.Tests/LinkedData/Cases/expand-0078-in.jsonld
@@ -1,0 +1,11 @@
+{
+  "@context": [
+    "http://example.org/context1.jsonld",
+    "http://example.org/context2.jsonld"
+  ],
+  "@id": "http://example.com/speakers#Alice",
+  "foaf:name": "Alice",
+  "foaf:homepage": "http://xkcd.com/177/",
+  "ical:summary": "Alice Talk",
+  "ical:location": "Lyon Convention Centre, Lyon, France"
+}

--- a/src/SourceCode.Clay.Json.Tests/LinkedData/Cases/expand-0078-out.jsonld
+++ b/src/SourceCode.Clay.Json.Tests/LinkedData/Cases/expand-0078-out.jsonld
@@ -1,0 +1,7 @@
+[{
+  "@id": "http://example.com/speakers#Alice",
+  "http://xmlns.com/foaf/0.1/name": [{"@value": "Alice"}],
+  "http://xmlns.com/foaf/0.1/homepage": [{"@id": "http://xkcd.com/177/"}],
+  "http://www.w3.org/2002/12/cal/ical#summary": [{"@value": "Alice Talk"}],
+  "http://www.w3.org/2002/12/cal/ical#location": [{"@value": "Lyon Convention Centre, Lyon, France","@type": "http://schema.org/testvalue"}]
+}]

--- a/src/SourceCode.Clay.Json.Tests/LinkedData/Cases/expand-manifest.jsonld
+++ b/src/SourceCode.Clay.Json.Tests/LinkedData/Cases/expand-manifest.jsonld
@@ -8,532 +8,607 @@
   "sequence": [
     {
       "@id": "#t0001",
-      "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
+      "@type": [ "jld:PositiveEvaluationTest", "jld:ExpandTest" ],
       "name": "drop free-floating nodes",
       "purpose": "Expand drops unreferenced nodes having only @id",
       "input": "expand-0001-in.jsonld",
       "expect": "expand-0001-out.jsonld"
-    }, {
+    },
+    {
       "@id": "#t0002",
-      "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
+      "@type": [ "jld:PositiveEvaluationTest", "jld:ExpandTest" ],
       "name": "basic",
       "purpose": "Expanding terms with different types of values",
       "input": "expand-0002-in.jsonld",
       "expect": "expand-0002-out.jsonld"
-    }, {
+    },
+    {
       "@id": "#t0003",
-      "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
+      "@type": [ "jld:PositiveEvaluationTest", "jld:ExpandTest" ],
       "name": "drop null and unmapped properties",
       "purpose": "Verifies that null values and unmapped properties are removed from expanded output",
       "input": "expand-0003-in.jsonld",
       "expect": "expand-0003-out.jsonld"
-    }, {
+    },
+    {
       "@id": "#t0004",
-      "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
+      "@type": [ "jld:PositiveEvaluationTest", "jld:ExpandTest" ],
       "name": "optimize @set, keep empty arrays",
       "purpose": "Uses of @set are removed in expansion; values of @set, or just plain values which are empty arrays are retained",
       "input": "expand-0004-in.jsonld",
       "expect": "expand-0004-out.jsonld"
-    }, {
+    },
+    {
       "@id": "#t0005",
-      "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
+      "@type": [ "jld:PositiveEvaluationTest", "jld:ExpandTest" ],
       "name": "do not expand aliased @id/@type",
       "purpose": "If a keyword is aliased, it is not used when expanding",
       "input": "expand-0005-in.jsonld",
       "expect": "expand-0005-out.jsonld"
-    }, {
+    },
+    {
       "@id": "#t0006",
-      "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
+      "@type": [ "jld:PositiveEvaluationTest", "jld:ExpandTest" ],
       "name": "alias keywords",
       "purpose": "Aliased keywords expand in resulting document",
       "input": "expand-0006-in.jsonld",
       "expect": "expand-0006-out.jsonld"
-    }, {
+    },
+    {
       "@id": "#t0007",
-      "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
+      "@type": [ "jld:PositiveEvaluationTest", "jld:ExpandTest" ],
       "name": "date type-coercion",
       "purpose": "Expand strings to expanded value with @type: xsd:dateTime",
       "input": "expand-0007-in.jsonld",
       "expect": "expand-0007-out.jsonld"
-    }, {
+    },
+    {
       "@id": "#t0008",
-      "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
+      "@type": [ "jld:PositiveEvaluationTest", "jld:ExpandTest" ],
       "name": "@value with @language",
       "purpose": "Keep expanded values with @language, drop non-conforming value objects containing just @language",
       "input": "expand-0008-in.jsonld",
       "expect": "expand-0008-out.jsonld"
-    }, {
+    },
+    {
       "@id": "#t0009",
-      "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
+      "@type": [ "jld:PositiveEvaluationTest", "jld:ExpandTest" ],
       "name": "@graph with terms",
       "purpose": "Use of @graph to contain multiple nodes within array",
       "input": "expand-0009-in.jsonld",
       "expect": "expand-0009-out.jsonld"
-    }, {
+    },
+    {
       "@id": "#t0010",
-      "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
+      "@type": [ "jld:PositiveEvaluationTest", "jld:ExpandTest" ],
       "name": "native types",
       "purpose": "Expanding native scalar retains native scalar within expanded value",
       "input": "expand-0010-in.jsonld",
       "expect": "expand-0010-out.jsonld"
-    }, {
+    },
+    {
       "@id": "#t0011",
-      "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
+      "@type": [ "jld:PositiveEvaluationTest", "jld:ExpandTest" ],
       "name": "coerced @id",
       "purpose": "A value of a property with @type: @id coercion expands to a node reference",
       "input": "expand-0011-in.jsonld",
       "expect": "expand-0011-out.jsonld"
-    }, {
+    },
+    {
       "@id": "#t0012",
-      "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
+      "@type": [ "jld:PositiveEvaluationTest", "jld:ExpandTest" ],
       "name": "@graph with embed",
       "purpose": "Use of @graph to contain multiple nodes within array",
       "input": "expand-0012-in.jsonld",
       "expect": "expand-0012-out.jsonld"
-    }, {
+    },
+    {
       "@id": "#t0013",
-      "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
+      "@type": [ "jld:PositiveEvaluationTest", "jld:ExpandTest" ],
       "name": "expand already expanded",
       "purpose": "Expand does not mess up already expanded document",
       "input": "expand-0013-in.jsonld",
       "expect": "expand-0013-out.jsonld"
-    }, {
+    },
+    {
       "@id": "#t0014",
-      "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
+      "@type": [ "jld:PositiveEvaluationTest", "jld:ExpandTest" ],
       "name": "@set of @value objects with keyword aliases",
       "purpose": "Expanding aliased @set and @value",
       "input": "expand-0014-in.jsonld",
       "expect": "expand-0014-out.jsonld"
-    }, {
+    },
+    {
       "@id": "#t0015",
-      "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
+      "@type": [ "jld:PositiveEvaluationTest", "jld:ExpandTest" ],
       "name": "collapse set of sets, keep empty lists",
       "purpose": "An array of multiple @set nodes are collapsed into a single array",
       "input": "expand-0015-in.jsonld",
       "expect": "expand-0015-out.jsonld"
-    }, {
+    },
+    {
       "@id": "#t0016",
-      "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
+      "@type": [ "jld:PositiveEvaluationTest", "jld:ExpandTest" ],
       "name": "context reset",
       "purpose": "Setting @context to null within an embedded object resets back to initial context state",
       "input": "expand-0016-in.jsonld",
       "expect": "expand-0016-out.jsonld"
-    }, {
+    },
+    {
       "@id": "#t0017",
-      "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
+      "@type": [ "jld:PositiveEvaluationTest", "jld:ExpandTest" ],
       "name": "@graph and @id aliased",
       "purpose": "Expanding with @graph and @id aliases",
       "input": "expand-0017-in.jsonld",
       "expect": "expand-0017-out.jsonld"
-    }, {
+    },
+    {
       "@id": "#t0018",
-      "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
+      "@type": [ "jld:PositiveEvaluationTest", "jld:ExpandTest" ],
       "name": "override default @language",
       "purpose": "override default @language in terms; only language-tag strings",
       "input": "expand-0018-in.jsonld",
       "expect": "expand-0018-out.jsonld"
-    }, {
+    },
+    {
       "@id": "#t0019",
-      "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
+      "@type": [ "jld:PositiveEvaluationTest", "jld:ExpandTest" ],
       "name": "remove @value = null",
       "purpose": "Expanding a value of null removes the value",
       "input": "expand-0019-in.jsonld",
       "expect": "expand-0019-out.jsonld"
-    }, {
+    },
+    {
       "@id": "#t0020",
-      "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
+      "@type": [ "jld:PositiveEvaluationTest", "jld:ExpandTest" ],
       "name": "do not remove @graph if not at top-level",
       "purpose": "@graph used under a node is retained",
       "input": "expand-0020-in.jsonld",
       "expect": "expand-0020-out.jsonld"
-    }, {
+    },
+    {
       "@id": "#t0021",
-      "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
+      "@type": [ "jld:PositiveEvaluationTest", "jld:ExpandTest" ],
       "name": "do not remove @graph at top-level if not only property",
       "purpose": "@graph used at the top level is retained if there are other properties",
       "input": "expand-0021-in.jsonld",
       "expect": "expand-0021-out.jsonld"
-    }, {
+    },
+    {
       "@id": "#t0022",
-      "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
+      "@type": [ "jld:PositiveEvaluationTest", "jld:ExpandTest" ],
       "name": "expand value with default language",
       "purpose": "Expanding with a default language applies that language to string values",
       "input": "expand-0022-in.jsonld",
       "expect": "expand-0022-out.jsonld"
-    }, {
+    },
+    {
       "@id": "#t0023",
-      "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
+      "@type": [ "jld:PositiveEvaluationTest", "jld:ExpandTest" ],
       "name": "Expanding list/set with coercion",
       "purpose": "Expanding lists and sets with properties having coercion coerces list/set values",
       "input": "expand-0023-in.jsonld",
       "expect": "expand-0023-out.jsonld"
-    }, {
+    },
+    {
       "@id": "#t0024",
-      "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
+      "@type": [ "jld:PositiveEvaluationTest", "jld:ExpandTest" ],
       "name": "Multiple contexts",
       "purpose": "Tests that contexts in an array are merged",
       "input": "expand-0024-in.jsonld",
       "expect": "expand-0024-out.jsonld"
-    }, {
+    },
+    {
       "@id": "#t0025",
-      "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
+      "@type": [ "jld:PositiveEvaluationTest", "jld:ExpandTest" ],
       "name": "Problematic IRI expansion tests",
       "purpose": "Expanding different kinds of terms and Compact IRIs",
       "input": "expand-0025-in.jsonld",
       "expect": "expand-0025-out.jsonld"
-    }, {
+    },
+    {
       "@id": "#t0026",
-      "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
+      "@type": [ "jld:PositiveEvaluationTest", "jld:ExpandTest" ],
       "name": "Term definition with @id: @type",
       "purpose": "Expanding term mapping to @type uses @type syntax",
       "input": "expand-0026-in.jsonld",
       "expect": "expand-0026-out.jsonld"
-    }, {
+    },
+    {
       "@id": "#t0027",
-      "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
+      "@type": [ "jld:PositiveEvaluationTest", "jld:ExpandTest" ],
       "name": "Duplicate values in @list and @set",
       "purpose": "Duplicate values in @list and @set are not merged",
       "input": "expand-0027-in.jsonld",
       "expect": "expand-0027-out.jsonld"
-    }, {
+    },
+    {
       "@id": "#t0028",
-      "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
+      "@type": [ "jld:PositiveEvaluationTest", "jld:ExpandTest" ],
       "name": "Use @vocab in properties and @type but not in @id",
       "purpose": "@vocab is used to compact properties and @type, but is not used for @id",
       "input": "expand-0028-in.jsonld",
       "expect": "expand-0028-out.jsonld"
-    }, {
+    },
+    {
       "@id": "#t0029",
-      "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
+      "@type": [ "jld:PositiveEvaluationTest", "jld:ExpandTest" ],
       "name": "Relative IRIs",
       "purpose": "@base is used to compact @id; test with different relative IRIs",
       "input": "expand-0029-in.jsonld",
       "expect": "expand-0029-out.jsonld"
-    }, {
+    },
+    {
       "@id": "#t0030",
-      "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
+      "@type": [ "jld:PositiveEvaluationTest", "jld:ExpandTest" ],
       "name": "Language maps",
       "purpose": "Language Maps expand values to include @language",
       "input": "expand-0030-in.jsonld",
       "expect": "expand-0030-out.jsonld"
-    }, {
+    },
+    {
       "@id": "#t0031",
-      "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
+      "@type": [ "jld:PositiveEvaluationTest", "jld:ExpandTest" ],
       "name": "type-coercion of native types",
       "purpose": "Expanding native types with type coercion adds the coerced type to an expanded value representation and retains the native value representation",
       "input": "expand-0031-in.jsonld",
       "expect": "expand-0031-out.jsonld"
-    }, {
+    },
+    {
       "@id": "#t0032",
-      "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
+      "@type": [ "jld:PositiveEvaluationTest", "jld:ExpandTest" ],
       "name": "Null term and @vocab",
       "purpose": "Mapping a term to null decouples it from @vocab",
       "input": "expand-0032-in.jsonld",
       "expect": "expand-0032-out.jsonld"
-    }, {
+    },
+    {
       "@id": "#t0033",
-      "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
+      "@type": [ "jld:PositiveEvaluationTest", "jld:ExpandTest" ],
       "name": "Using @vocab with with type-coercion",
       "purpose": "Verifies that terms can be defined using @vocab",
       "input": "expand-0033-in.jsonld",
       "expect": "expand-0033-out.jsonld"
-    }, {
+    },
+    {
       "@id": "#t0034",
-      "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
+      "@type": [ "jld:PositiveEvaluationTest", "jld:ExpandTest" ],
       "name": "Multiple properties expanding to the same IRI",
       "purpose": "Verifies multiple values from separate terms are deterministically made multiple values of the IRI associated with the terms",
       "input": "expand-0034-in.jsonld",
       "expect": "expand-0034-out.jsonld"
-    }, {
+    },
+    {
       "@id": "#t0035",
-      "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
+      "@type": [ "jld:PositiveEvaluationTest", "jld:ExpandTest" ],
       "name": "Language maps with @vocab, default language, and colliding property",
       "purpose": "Pathological tests of language maps",
       "input": "expand-0035-in.jsonld",
       "expect": "expand-0035-out.jsonld"
-    }, {
+    },
+    {
       "@id": "#t0036",
-      "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
+      "@type": [ "jld:PositiveEvaluationTest", "jld:ExpandTest" ],
       "name": "Expanding @index",
       "purpose": "Expanding index maps for terms defined with @container: @index",
       "input": "expand-0036-in.jsonld",
       "expect": "expand-0036-out.jsonld"
-    }, {
+    },
+    {
       "@id": "#t0037",
-      "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
+      "@type": [ "jld:PositiveEvaluationTest", "jld:ExpandTest" ],
       "name": "Expanding @reverse",
       "purpose": "Expanding @reverse keeps @reverse",
       "input": "expand-0037-in.jsonld",
       "expect": "expand-0037-out.jsonld"
-    }, {
+    },
+    {
       "@id": "#t0038",
-      "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
+      "@type": [ "jld:PositiveEvaluationTest", "jld:ExpandTest" ],
       "name": "Expanding blank node labels",
       "purpose": "Blank nodes are not relabeled during expansion",
       "input": "expand-0038-in.jsonld",
       "expect": "expand-0038-out.jsonld"
-    }, {
+    },
+    {
       "@id": "#t0039",
-      "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
+      "@type": [ "jld:PositiveEvaluationTest", "jld:ExpandTest" ],
       "name": "Using terms in a reverse-maps",
       "purpose": "Terms within @reverse are expanded",
       "input": "expand-0039-in.jsonld",
       "expect": "expand-0039-out.jsonld"
-    }, {
+    },
+    {
       "@id": "#t0040",
-      "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
+      "@type": [ "jld:PositiveEvaluationTest", "jld:ExpandTest" ],
       "name": "language and index expansion on non-objects",
       "purpose": "Only invoke language and index map expansion if the value is a JSON object",
       "input": "expand-0040-in.jsonld",
       "expect": "expand-0040-out.jsonld"
-    }, {
+    },
+    {
       "@id": "#t0041",
-      "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
+      "@type": [ "jld:PositiveEvaluationTest", "jld:ExpandTest" ],
       "name": "@language: null",
       "name": "@language: null resets the default language",
       "input": "expand-0041-in.jsonld",
       "expect": "expand-0041-out.jsonld"
-    }, {
+    },
+    {
       "@id": "#t0042",
-      "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
+      "@type": [ "jld:PositiveEvaluationTest", "jld:ExpandTest" ],
       "name": "Reverse properties",
       "purpose": "Expanding terms defined as reverse properties uses @reverse in expanded document",
       "input": "expand-0042-in.jsonld",
       "expect": "expand-0042-out.jsonld"
-    }, {
+    },
+    {
       "@id": "#t0043",
-      "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
+      "@type": [ "jld:PositiveEvaluationTest", "jld:ExpandTest" ],
       "name": "Using reverse properties inside a @reverse-container",
       "purpose": "Expanding a reverse property within a @reverse undoes both reversals",
       "input": "expand-0043-in.jsonld",
       "expect": "expand-0043-out.jsonld"
-    }, {
+    },
+    {
       "@id": "#t0044",
-      "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
+      "@type": [ "jld:PositiveEvaluationTest", "jld:ExpandTest" ],
       "name": "Index maps with language mappings",
       "purpose": "Ensure index maps use language mapping",
       "input": "expand-0044-in.jsonld",
       "expect": "expand-0044-out.jsonld"
-    }, {
+    },
+    {
       "@id": "#t0045",
-      "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
+      "@type": [ "jld:PositiveEvaluationTest", "jld:ExpandTest" ],
       "name": "Top-level value objects",
       "purpose": "Expanding top-level value objects causes them to be removed",
       "input": "expand-0045-in.jsonld",
       "expect": "expand-0045-out.jsonld"
-    }, {
+    },
+    {
       "@id": "#t0046",
-      "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
+      "@type": [ "jld:PositiveEvaluationTest", "jld:ExpandTest" ],
       "name": "Free-floating nodes",
       "purpose": "Expanding free-floating nodes causes them to be removed",
       "input": "expand-0046-in.jsonld",
       "expect": "expand-0046-out.jsonld"
-    }, {
+    },
+    {
       "@id": "#t0047",
-      "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
+      "@type": [ "jld:PositiveEvaluationTest", "jld:ExpandTest" ],
       "name": "Free-floating values in sets and free-floating lists",
       "purpose": "Free-floating values in sets are removed, free-floating lists are removed completely",
       "input": "expand-0047-in.jsonld",
       "expect": "expand-0047-out.jsonld"
-    }, {
+    },
+    {
       "@id": "#t0048",
-      "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
+      "@type": [ "jld:PositiveEvaluationTest", "jld:ExpandTest" ],
       "name": "Terms are ignored in @id",
       "purpose": "Values of @id are not expanded as terms",
       "input": "expand-0048-in.jsonld",
       "expect": "expand-0048-out.jsonld"
-    }, {
+    },
+    {
       "@id": "#t0049",
-      "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
+      "@type": [ "jld:PositiveEvaluationTest", "jld:ExpandTest" ],
       "name": "String values of reverse properties",
       "purpose": "String values of a reverse property with @type: @id are treated as IRIs",
       "input": "expand-0049-in.jsonld",
       "expect": "expand-0049-out.jsonld"
-    }, {
+    },
+    {
       "@id": "#t0050",
-      "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
+      "@type": [ "jld:PositiveEvaluationTest", "jld:ExpandTest" ],
       "name": "Term definitions with prefix separate from prefix definitions",
       "purpose": "Term definitions using compact IRIs don't inherit the definitions of the prefix",
       "input": "expand-0050-in.jsonld",
       "expect": "expand-0050-out.jsonld"
-    }, {
+    },
+    {
       "@id": "#t0051",
-      "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
+      "@type": [ "jld:PositiveEvaluationTest", "jld:ExpandTest" ],
       "name": "Expansion of keyword aliases in term definitions",
       "purpose": "Expanding terms which are keyword aliases",
       "input": "expand-0051-in.jsonld",
       "expect": "expand-0051-out.jsonld"
-    }, {
+    },
+    {
       "@id": "#t0052",
-      "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
+      "@type": [ "jld:PositiveEvaluationTest", "jld:ExpandTest" ],
       "name": "@vocab-relative IRIs in term definitions",
       "purpose": "If @vocab is defined, term definitions are expanded relative to @vocab",
       "input": "expand-0052-in.jsonld",
       "expect": "expand-0052-out.jsonld"
-    }, {
+    },
+    {
       "@id": "#t0053",
-      "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
+      "@type": [ "jld:PositiveEvaluationTest", "jld:ExpandTest" ],
       "name": "Expand absolute IRI with @type: @vocab",
       "purpose": "Expanding values of properties of @type: @vocab does not further expand absolute IRIs",
       "input": "expand-0053-in.jsonld",
       "expect": "expand-0053-out.jsonld"
-    }, {
+    },
+    {
       "@id": "#t0054",
-      "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
+      "@type": [ "jld:PositiveEvaluationTest", "jld:ExpandTest" ],
       "name": "Expand term with @type: @vocab",
       "purpose": "Expanding values of properties of @type: @vocab does not expand term values",
       "input": "expand-0054-in.jsonld",
       "expect": "expand-0054-out.jsonld"
-    }, {
+    },
+    {
       "@id": "#t0055",
-      "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
+      "@type": [ "jld:PositiveEvaluationTest", "jld:ExpandTest" ],
       "name": "Expand @vocab-relative term with @type: @vocab",
       "purpose": "Expanding values of properties of @type: @vocab expands relative IRIs using @vocab",
       "input": "expand-0055-in.jsonld",
       "expect": "expand-0055-out.jsonld"
-    }, {
+    },
+    {
       "@id": "#t0056",
-      "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
+      "@type": [ "jld:PositiveEvaluationTest", "jld:ExpandTest" ],
       "name": "Use terms with @type: @vocab but not with @type: @id",
       "purpose": "Checks that expansion uses appropriate base depending on term definition having @type @id or @vocab",
       "input": "expand-0056-in.jsonld",
       "expect": "expand-0056-out.jsonld"
-    }, {
+    },
+    {
       "@id": "#t0057",
-      "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
+      "@type": [ "jld:PositiveEvaluationTest", "jld:ExpandTest" ],
       "name": "Expand relative IRI with @type: @vocab",
       "purpose": "Relative values of terms with @type: @vocab expand relative to @vocab",
       "input": "expand-0057-in.jsonld",
       "expect": "expand-0057-out.jsonld"
-    }, {
+    },
+    {
       "@id": "#t0058",
-      "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
+      "@type": [ "jld:PositiveEvaluationTest", "jld:ExpandTest" ],
       "name": "Expand compact IRI with @type: @vocab",
       "purpose": "Compact IRIs are expanded normally even if term has @type: @vocab",
       "input": "expand-0058-in.jsonld",
       "expect": "expand-0058-out.jsonld"
-    }, {
+    },
+    {
       "@id": "#t0059",
-      "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
+      "@type": [ "jld:PositiveEvaluationTest", "jld:ExpandTest" ],
       "name": "Reset @vocab by setting it to null",
       "purpose": "Setting @vocab to null removes a previous definition",
       "input": "expand-0059-in.jsonld",
       "expect": "expand-0059-out.jsonld"
-    }, {
+    },
+    {
       "@id": "#t0060",
-      "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
+      "@type": [ "jld:PositiveEvaluationTest", "jld:ExpandTest" ],
       "name": "Overwrite document base with @base and reset it again",
       "purpose": "Setting @base to an IRI and then resetting it to nil",
       "input": "expand-0060-in.jsonld",
       "expect": "expand-0060-out.jsonld"
-    }, {
+    },
+    {
       "@id": "#t0061",
-      "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
+      "@type": [ "jld:PositiveEvaluationTest", "jld:ExpandTest" ],
       "name": "Coercing native types to arbitrary datatypes",
       "purpose": "Expanding native types when coercing to arbitrary datatypes",
       "input": "expand-0061-in.jsonld",
       "expect": "expand-0061-out.jsonld"
-    }, {
+    },
+    {
       "@id": "#t0062",
-      "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
+      "@type": [ "jld:PositiveEvaluationTest", "jld:ExpandTest" ],
       "name": "Various relative IRIs with with @base",
       "purpose": "Pathological relative IRIs",
       "input": "expand-0062-in.jsonld",
       "expect": "expand-0062-out.jsonld"
-    }, {
+    },
+    {
       "@id": "#t0063",
-      "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
+      "@type": [ "jld:PositiveEvaluationTest", "jld:ExpandTest" ],
       "name": "Reverse property and index container",
       "purpose": "Expaning reverse properties with an index-container",
       "input": "expand-0063-in.jsonld",
       "expect": "expand-0063-out.jsonld"
-    }, {
+    },
+    {
       "@id": "#t0064",
-      "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
+      "@type": [ "jld:PositiveEvaluationTest", "jld:ExpandTest" ],
       "name": "bnode values of reverse properties",
       "purpose": "Expand reverse property whose values are unlabeled blank nodes",
       "input": "expand-0064-in.jsonld",
       "expect": "expand-0064-out.jsonld"
-    }, {
+    },
+    {
       "@id": "#t0065",
-      "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
+      "@type": [ "jld:PositiveEvaluationTest", "jld:ExpandTest" ],
       "name": "Drop unmapped keys in reverse map",
       "purpose": "Keys that are not mapped to an IRI in a reverse-map are dropped",
       "input": "expand-0065-in.jsonld",
       "expect": "expand-0065-out.jsonld"
-    }, {
+    },
+    {
       "@id": "#t0066",
-      "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
+      "@type": [ "jld:PositiveEvaluationTest", "jld:ExpandTest" ],
       "name": "Reverse-map keys with @vocab",
       "purpose": "Expand uses @vocab to expand keys in reverse-maps",
       "input": "expand-0066-in.jsonld",
       "expect": "expand-0066-out.jsonld"
-    }, {
+    },
+    {
       "@id": "#t0067",
-      "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
+      "@type": [ "jld:PositiveEvaluationTest", "jld:ExpandTest" ],
       "name": "prefix://suffix not a compact IRI",
       "purpose": "prefix:suffix values are not interpreted as compact IRIs if suffix begins with two slashes",
       "input": "expand-0067-in.jsonld",
       "expect": "expand-0067-out.jsonld"
-    }, {
+    },
+    {
       "@id": "#t0068",
-      "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
+      "@type": [ "jld:PositiveEvaluationTest", "jld:ExpandTest" ],
       "name": "_:suffix values are not a compact IRI",
       "purpose": "prefix:suffix values are not interpreted as compact IRIs if prefix is an underscore",
       "input": "expand-0068-in.jsonld",
       "expect": "expand-0068-out.jsonld"
-    }, {
+    },
+    {
       "@id": "#t0069",
-      "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
+      "@type": [ "jld:PositiveEvaluationTest", "jld:ExpandTest" ],
       "name": "Compact IRI as term with type mapping",
       "purpose": "Redefine compact IRI to define type mapping using the compact IRI itself as value of @id",
       "input": "expand-0069-in.jsonld",
       "expect": "expand-0069-out.jsonld"
-    }, {
+    },
+    {
       "@id": "#t0070",
-      "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
+      "@type": [ "jld:PositiveEvaluationTest", "jld:ExpandTest" ],
       "name": "Compact IRI as term defined using equivalent compact IRI",
       "purpose": "Redefine compact IRI to define type mapping using the compact IRI itself as string value",
       "input": "expand-0070-in.jsonld",
       "expect": "expand-0070-out.jsonld"
-    }, {
+    },
+    {
       "@id": "#t0071",
-      "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
+      "@type": [ "jld:PositiveEvaluationTest", "jld:ExpandTest" ],
       "name": "Redefine terms looking like compact IRIs",
       "purpose": "Term definitions may look like compact IRIs",
       "input": "expand-0071-in.jsonld",
       "expect": "expand-0071-out.jsonld"
-    }, {
+    },
+    {
       "@id": "#t0072",
-      "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
+      "@type": [ "jld:PositiveEvaluationTest", "jld:ExpandTest" ],
       "name": "Redefine term using @vocab, not itself",
       "purpose": "Redefining a term as itself when @vocab is defined uses @vocab, not previous term definition",
       "input": "expand-0072-in.jsonld",
       "expect": "expand-0072-out.jsonld"
-    }, {
+    },
+    {
       "@id": "#t0073",
-      "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
+      "@type": [ "jld:PositiveEvaluationTest", "jld:ExpandTest" ],
       "name": "@context not first property",
       "purpose": "Objects are unordered, so serialized node definition containing @context may have @context at the end of the node definition",
       "input": "expand-0073-in.jsonld",
       "expect": "expand-0073-out.jsonld"
-    }, {
+    },
+    {
       "@id": "#t0074",
-      "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
+      "@type": [ "jld:PositiveEvaluationTest", "jld:ExpandTest" ],
       "name": "@id not first property",
       "purpose": "Objects are unordered, so serialized node definition containing @id may have @id at the end of the node definition",
       "input": "expand-0074-in.jsonld",
       "expect": "expand-0074-out.jsonld"
-    }, {
+    },
+    {
       "@id": "#t0075",
-      "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
+      "@type": [ "jld:PositiveEvaluationTest", "jld:ExpandTest" ],
       "name": "@vocab as blank node identifier",
       "purpose": "Use @vocab to map all properties to blank node identifiers",
       "input": "expand-0075-in.jsonld",
       "expect": "expand-0075-out.jsonld"
-    }, {
+    },
+    {
       "@id": "#t0076",
-      "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
+      "@type": [ "jld:PositiveEvaluationTest", "jld:ExpandTest" ],
       "name": "base option overrides document location",
       "purpose": "Use of the base option overrides the document location",
       "option": {
@@ -541,9 +616,10 @@
       },
       "input": "expand-0076-in.jsonld",
       "expect": "expand-0076-out.jsonld"
-    }, {
+    },
+    {
       "@id": "#t0077",
-      "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
+      "@type": [ "jld:PositiveEvaluationTest", "jld:ExpandTest" ],
       "name": "expandContext option",
       "purpose": "Use of the expandContext option to expand the input document",
       "option": {
@@ -551,6 +627,32 @@
       },
       "input": "expand-0077-in.jsonld",
       "expect": "expand-0077-out.jsonld"
+    },
+    {
+      "@id": "#t0078",
+      "@type": [ "jld:PositiveEvaluationTest", "jld:ExpandTest" ],
+      "name": "multiple remote contexts",
+      "purpose": "Use of the multiple contexts",
+      "contexts": {
+        "http://example.org/context1.jsonld": {
+          "foaf": "http://xmlns.com/foaf/0.1/",
+          "foaf:name": "foaf:name",
+          "foaf:homepage": {
+            "@id": "foaf:homepage",
+            "@type": "@id"
+          }
+        },
+        "http://example.org/context2.jsonld": {
+          "ical": "http://www.w3.org/2002/12/cal/ical#",
+          "ical:summary": "ical:summary",
+          "ical:location": {
+            "@id": "ical:location",
+            "@type": "http://schema.org/testvalue"
+          }
+        }
+      },
+      "input": "expand-0078-in.jsonld",
+      "expect": "expand-0078-out.jsonld"
     }
   ]
 }

--- a/src/SourceCode.Clay.Json.Tests/LinkedData/LinkedDataTransformationTests.cs
+++ b/src/SourceCode.Clay.Json.Tests/LinkedData/LinkedDataTransformationTests.cs
@@ -42,10 +42,7 @@ namespace SourceCode.Clay.Json.Tests.LinkedData
 
             public override string ToString() => Identifier;
         }
-
-        private const int ExpandMin = 1;
-        private const int ExpandMax = 77;
-
+        
         [Theory(DisplayName = nameof(LinkedDataTransformation_Expand))]
         [MemberData(nameof(Expand))]
         public static async Task LinkedDataTransformation_Expand(LinkedDataTestCase testCase)

--- a/src/SourceCode.Clay.Json/LinkedData/LinkedDataContext.cs
+++ b/src/SourceCode.Clay.Json/LinkedData/LinkedDataContext.cs
@@ -168,7 +168,7 @@ namespace SourceCode.Clay.Json.LinkedData
                     // 3.2.4) Set result to the result of recursively calling this algorithm, passing
                     //        result for active context, context for local context, and a copy of remote
                     //        contexts.
-                    result = await ParseAsync(remoteContext, cancellationToken).ConfigureAwait(false);
+                    result = await result.ParseAsync(remoteContext, cancellationToken).ConfigureAwait(false);
                     _remoteContexts.Remove(uri);
                     continue;
                 }

--- a/src/SourceCode.Clay.Json/LinkedData/LinkedDataOptions.cs
+++ b/src/SourceCode.Clay.Json/LinkedData/LinkedDataOptions.cs
@@ -35,7 +35,7 @@ namespace SourceCode.Clay.Json.LinkedData
             ExpandContext = expandContext.HasValue ? expandContext : new LinkedDataContext(this);
         }
 
-        public async ValueTask<LinkedDataOptions> WithContextAsync(
+        public virtual async ValueTask<LinkedDataOptions> WithContextAsync(
             JToken localContext,
             CancellationToken cancellationToken = default)
         {


### PR DESCRIPTION
Fixes #228

### Information

The previous context in the chain was being ignored (only the initial empty context was being honored).

### Proposed Changes

- Add tests for remote contexts.
- Fix bug with remote context chaining.
- Ensure that LinkedDataOptions can be inherited in a useful way.