### PR TITLE
Graph DocComments and Tweaks

### DIFF
--- a/src/SourceCode.Clay.Algorithms/Edge.cs
+++ b/src/SourceCode.Clay.Algorithms/Edge.cs
@@ -11,15 +11,31 @@ using System.Diagnostics;
 
 namespace SourceCode.Clay.Algorithms
 {
+    /// <summary>
+    /// Represents a directed graph edge.
+    /// </summary>
+    /// <typeparam name="T">The type of the vertices in the edge.</typeparam>
     [DebuggerDisplay("{ToString(),nq}")]
     public readonly struct Edge<T> : IEquatable<Edge<T>>
     {
         private readonly IEqualityComparer<T> _equalityComparer;
 
+        /// <summary>
+        /// The vertex that the edge originates from.
+        /// </summary>
         public T From { get; }
 
+        /// <summary>
+        /// The vertex that the edge terminates at.
+        /// </summary>
         public T To { get; }
 
+        /// <summary>
+        /// Creates a new <see cref="Edge{T}"/> value.
+        /// </summary>
+        /// <param name="from">The vertex that the edge originates from.</param>
+        /// <param name="to">The vertex that the edge terminates at.</param>
+        /// <param name="equalityComparer"></param>
         public Edge(T from, T to, IEqualityComparer<T> equalityComparer = null)
         {
             From = from;
@@ -27,12 +43,26 @@ namespace SourceCode.Clay.Algorithms
             _equalityComparer = equalityComparer; // No point coalescing in a struct
         }
 
+        /// <summary>
+        /// Returns a string representation of the edge.
+        /// </summary>
+        /// <returns>A string representation of the edge.</returns>
         public override string ToString() => $"{From} -> {To}";
 
+        /// <summary>
+        /// Determines if this edge is equal to another edge.
+        /// </summary>
+        /// <param name="obj">The other edge.</param>
+        /// <returns>A value indicating whether this edge is equal to another.</returns>
         public override bool Equals(object obj)
             => obj is Edge<T> other
             && Equals(other);
 
+        /// <summary>
+        /// Determines if this edge is equal to another edge.
+        /// </summary>
+        /// <param name="other">The other edge.</param>
+        /// <returns>A value indicating whether this edge is equal to another.</returns>
         public bool Equals(Edge<T> other)
         {
             var equalityComparer = _equalityComparer ?? EqualityComparer<T>.Default;
@@ -41,6 +71,10 @@ namespace SourceCode.Clay.Algorithms
                    && equalityComparer.Equals(To, other.To);
         }
 
+        /// <summary>
+        /// Returns the hash code for this instance.
+        /// </summary>
+        /// <returns>A 32-bit signed integer that is the hashcode for this instance.</returns>
         public override int GetHashCode()
         {
             var equalityComparer = _equalityComparer ?? EqualityComparer<T>.Default;
@@ -51,9 +85,21 @@ namespace SourceCode.Clay.Algorithms
             return hashCode;
         }
 
+        /// <summary>
+        /// Implements the equality operator for <see cref="Edge{T}"/>.
+        /// </summary>
+        /// <param name="edge1">The first edge to compare.</param>
+        /// <param name="edge2">The second edge to compare.</param>
+        /// <returns>A value indicating whether the edges are equal.</returns>
         public static bool operator ==(Edge<T> edge1, Edge<T> edge2) 
             => edge1.Equals(edge2);
 
+        /// <summary>
+        /// Implements the inequality operator for <see cref="Edge{T}"/>.
+        /// </summary>
+        /// <param name="edge1">The first edge to compare.</param>
+        /// <param name="edge2">The second edge to compare.</param>
+        /// <returns>A value indicating whether the edges are not equal.</returns>
         public static bool operator !=(Edge<T> edge1, Edge<T> edge2) 
             => !(edge1 == edge2);
     }

--- a/src/SourceCode.Clay.Algorithms/Graph.Nested.cs
+++ b/src/SourceCode.Clay.Algorithms/Graph.Nested.cs
@@ -12,6 +12,8 @@ using System.Diagnostics;
 
 namespace SourceCode.Clay.Algorithms
 {
+#pragma warning disable CA1815
+
     partial struct Graph<T> // .Nested
     {
         [Flags]
@@ -49,4 +51,6 @@ namespace SourceCode.Clay.Algorithms
             }
         }
     }
+
+#pragma warning restore CA1815
 }

--- a/src/SourceCode.Clay.Algorithms/Graph.RepresentativeForest.cs
+++ b/src/SourceCode.Clay.Algorithms/Graph.RepresentativeForest.cs
@@ -12,6 +12,43 @@ namespace SourceCode.Clay.Algorithms
 {
     partial struct Graph<T> // .RepresentativeForest
     {
+        /// <summary>
+        /// Converts the graph into a representative forest.
+        /// </summary>
+        /// <param name="onCycle">A callback that is invoked when a cycle is detected.</param>
+        /// <param name="onTreeNode">A callback that is invoked when a tree node is detected.</param>
+        /// <remarks>
+        /// A representative forest is a collection of trees and cycles that is used to answer traversal
+        /// queries.
+        /// 
+        /// Traversing the forest (towards either parents or children) will traverse the original
+        /// graph in that direction.  Note that a single node may appear multiple times within the
+        /// forest.
+        /// 
+        /// Each node in the forest is represented by a cycle that has at minimum one element. Nodes that
+        /// are represented by multiple elements are virtualized cycles: traversal queries will always visit
+        /// every node in the cycle no matter the traversal direction.
+        /// 
+        /// To correctly perform a traversal query the following steps should be performed, given node <c>N</c>.
+        /// 
+        /// <list type="number">
+        ///     <item><description>
+        ///         Find the unique set of <see cref="Edge{T}.From"/> where the associated <see cref="Edge{T}.To"/> is <c>N</c>.
+        ///     </description></item>
+        ///     <item><description>
+        ///         Find the unique list of <see cref="TreeNode{T}.Hierarchy"/> where <see cref="TreeNode{T}.Node"/> appears in the set created in (1).
+        ///     </description></item>
+        ///     <item><description>
+        ///         Find the unique set of <see cref="TreeNode{T}.Node"/> according to traversing the forest, starting at the hierarchies discovered in (2).
+        ///     </description></item>
+        ///     <item><description>
+        ///         Find the unique set of <see cref="Edge{T}.To"/> where the associated <see cref="Edge{T}.From"/> appears in the set created in (3).
+        ///     </description></item>
+        /// </list>
+        /// 
+        /// A single list instance is used across <paramref name="onTreeNode"/> invocations, <see cref="TreeNode{T}.Clone"/> must be called if 
+        /// <see cref="TreeNode{T}"/> instances are persisted in memory after the callback completes.
+        /// </remarks>
         public void ToRepresentativeForest(Action<Edge<T>> onCycle, Action<TreeNode<T>> onTreeNode)
         {
             if (onCycle == null) throw new ArgumentNullException(nameof(onCycle));

--- a/src/SourceCode.Clay.Algorithms/Graph.Tarjan.cs
+++ b/src/SourceCode.Clay.Algorithms/Graph.Tarjan.cs
@@ -5,6 +5,15 @@ namespace SourceCode.Clay.Algorithms
 {
     partial struct Graph<T> // .Tarjan
     {
+        /// <summary>
+        /// Identifies strongly connected components (cycles) in a graph and performs a topological sort, by using
+        /// Tarjan's Strongly Connected Components Algorithm.
+        /// </summary>
+        /// <remarks>
+        /// All nodes in the graph appear in at least one strongly connected component (that may only contain the node itself). The
+        /// graph is only cyclic if any cycle contains more than one node.
+        /// </remarks>
+        /// <returns>The list of strongly connected components.</returns>
         public IReadOnlyList<IReadOnlyList<T>> Tarjan()
         {
             var index = 0;

--- a/src/SourceCode.Clay.Algorithms/Graph.cs
+++ b/src/SourceCode.Clay.Algorithms/Graph.cs
@@ -12,9 +12,19 @@ using System.Diagnostics;
 
 namespace SourceCode.Clay.Algorithms
 {
+    /// <summary>
+    /// Factory methods for <see cref="Graph{T}"/>.
+    /// </summary>
     public static class Graph
     {
-        public static Graph<T> Create<T>(int capacity, IEqualityComparer<T> equalityComparer = null)
+        /// <summary>
+        /// Creates a new <see cref="Graph{T}"/> value.
+        /// </summary>
+        /// <typeparam name="T">The type of the vertices in the graph.</typeparam>
+        /// <param name="capacity">The initial capacity of the graph.</param>
+        /// <param name="equalityComparer">The equality comparer for vertices.</param>
+        /// <returns>The <see cref="Graph{T}"/>.</returns>
+        public static Graph<T> Create<T>(int capacity = 10, IEqualityComparer<T> equalityComparer = null)
             => new Graph<T>(capacity, equalityComparer);
     }
 
@@ -22,12 +32,23 @@ namespace SourceCode.Clay.Algorithms
 
     // Override equals and operator equals on value types
     // No best-fit implementation
+
+    /// <summary>
+    /// Represents several algorithms that can be performed on a graph.
+    /// </summary>
+    /// <typeparam name="T">The type of the vertices in the graph.</typeparam>
+    /// <remarks>Multiple algorithms should not be executed against a single instance of this structure.</remarks>
     [DebuggerDisplay("{_nodes.Count,ac}")]
     public readonly partial struct Graph<T>
     {
         private readonly ConcurrentDictionary<T, Node> _nodes;
         private readonly IEqualityComparer<T> _equalityComparer;
 
+        /// <summary>
+        /// Creates a new <see cref="Graph{T}"/> value.
+        /// </summary>
+        /// <param name="capacity">The initial capacity of the graph.</param>
+        /// <param name="equalityComparer">The equality comparer for vertices.</param>
         public Graph(int capacity, IEqualityComparer<T> equalityComparer)
         {
             if (capacity < 0) throw new ArgumentOutOfRangeException(nameof(capacity));
@@ -36,6 +57,11 @@ namespace SourceCode.Clay.Algorithms
             _nodes = new ConcurrentDictionary<T, Node>(1, capacity, _equalityComparer);
         }
 
+        /// <summary>
+        /// Adds the specified directed edge to the graph.
+        /// </summary>
+        /// <param name="from">The vertex that the edge originates from.</param>
+        /// <param name="to">The vertex that the edge terminates at.</param>
         public void Add(T from, T to)
         {
             var nodes = _nodes;

--- a/src/SourceCode.Clay.Algorithms/SourceCode.Clay.Algorithms.csproj
+++ b/src/SourceCode.Clay.Algorithms/SourceCode.Clay.Algorithms.csproj
@@ -23,4 +23,12 @@
     <Version>1.0.0-local</Version>
     <PackageVersion>1.0.0-local</PackageVersion>
   </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
+    <DocumentationFile>bin\Release\netstandard2.0\SourceCode.Clay.Algorithms.xml</DocumentationFile>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+    <DocumentationFile>bin\Debug\netstandard2.0\SourceCode.Clay.Algorithms.xml</DocumentationFile>
+  </PropertyGroup>
 </Project>

--- a/src/SourceCode.Clay.Algorithms/TreeNode.cs
+++ b/src/SourceCode.Clay.Algorithms/TreeNode.cs
@@ -14,15 +14,28 @@ using System.Text;
 
 namespace SourceCode.Clay.Algorithms
 {
+    /// <summary>
+    /// Represents a tree node that uses a hierarchy path for positioning.
+    /// </summary>
+    /// <typeparam name="T">The type of the node in the tree.</typeparam>
     [DebuggerDisplay("{HierarchyPath,nq} {Node}")]
-    public readonly struct TreeNode<T> : IEquatable<TreeNode<T>>
+    public readonly struct TreeNode<T> : IEquatable<TreeNode<T>>, ICloneable
     {
         private readonly IEqualityComparer<T> _equalityComparer;
 
+        /// <summary>
+        /// Gets the list of integers that index to the tree node position.
+        /// </summary>
         public IReadOnlyList<int> Hierarchy { get; }
 
+        /// <summary>
+        /// Gets the node value.
+        /// </summary>
         public T Node { get; }
 
+        /// <summary>
+        /// Gets a path containing <see cref="Hierarchy"/> elements separated by a '/' character.
+        /// </summary>
         public string HierarchyPath
         {
             get
@@ -39,6 +52,12 @@ namespace SourceCode.Clay.Algorithms
             }
         }
 
+        /// <summary>
+        /// Creates a new <see cref="TreeNode{T}"/> value.
+        /// </summary>
+        /// <param name="node">The node value.</param>
+        /// <param name="equalityComparer">The equality comparer used to compare values.</param>
+        /// <param name="hierarchy">The list of integers that index to the tree node position.</param>
         public TreeNode(T node, IEqualityComparer<T> equalityComparer, IReadOnlyList<int> hierarchy)
         {
             Hierarchy = hierarchy ?? throw new ArgumentNullException(nameof(hierarchy));
@@ -46,33 +65,71 @@ namespace SourceCode.Clay.Algorithms
             _equalityComparer = equalityComparer; // No point coalescing in a struct
         }
 
+        /// <summary>
+        /// Creates a new <see cref="TreeNode{T}"/> value.
+        /// </summary>
+        /// <param name="node">The node value.</param>
+        /// <param name="equalityComparer">The equality comparer used to compare values.</param>
+        /// <param name="hierarchy">The list of integers that index to the tree node position.</param>
         public TreeNode(T node, IEqualityComparer<T> equalityComparer, params int[] hierarchy)
             : this(node, equalityComparer, (IReadOnlyList<int>)hierarchy)
         { }
 
+        /// <summary>
+        /// Creates a new <see cref="TreeNode{T}"/> value.
+        /// </summary>
+        /// <param name="node">The node value.</param>
+        /// <param name="hierarchy">The list of integers that index to the tree node position.</param>
         public TreeNode(T node, IReadOnlyList<int> hierarchy)
             : this(node, null, hierarchy)
         { }
 
+        /// <summary>
+        /// Creates a new <see cref="TreeNode{T}"/> value.
+        /// </summary>
+        /// <param name="node">The node value.</param>
+        /// <param name="hierarchy">The list of integers that index to the tree node position.</param>
         public TreeNode(T node, params int[] hierarchy)
             : this(node, null, (IReadOnlyList<int>)hierarchy)
         { }
 
+        object ICloneable.Clone() => Clone();
+
+        /// <summary>
+        /// Clones the <see cref="TreeNode{T}"/> so that it contains a unique instance of <see cref="Hierarchy"/>.
+        /// </summary>
+        /// <returns>The <see cref="TreeNode{T}"/>.</returns>
         public TreeNode<T> Clone()
         {
-            var equalityComparer = _equalityComparer ?? EqualityComparer<T>.Default;
+            if (Hierarchy is null) return default;
 
-            return Hierarchy is null ?
-                default :
-                new TreeNode<T>(Node, equalityComparer, Hierarchy.ToArray()); // Use ToArray as a vehicle for cloning
+            var array = new int[Hierarchy.Count];
+            for (var i = 0; i < array.Length; i++)
+                array[i] = Hierarchy[i];
+
+            return new TreeNode<T>(Node, _equalityComparer, array);
         }
 
+        /// <summary>
+        /// Returns a string representation of the tree node.
+        /// </summary>
+        /// <returns>A string representation of the tree node.</returns>
         public override string ToString() => $"{HierarchyPath} {Node}";
 
+        /// <summary>
+        /// Determines if this tree node is equal to another tree node.
+        /// </summary>
+        /// <param name="obj">The other tree node.</param>
+        /// <returns>A value indicating whether this tree node is equal to another.</returns>
         public override bool Equals(object obj)
             => obj is TreeNode<T> other
             && Equals(other);
 
+        /// <summary>
+        /// Determines if this tree node is equal to another tree node.
+        /// </summary>
+        /// <param name="other">The other tree node.</param>
+        /// <returns>A value indicating whether this tree node is equal to another.</returns>
         public bool Equals(TreeNode<T> other)
         {
             if (Hierarchy is null) return other.Hierarchy is null;
@@ -92,32 +149,51 @@ namespace SourceCode.Clay.Algorithms
             return true;
         }
 
+        /// <summary>
+        /// Returns the hash code for this instance.
+        /// </summary>
+        /// <returns>A 32-bit signed integer that is the hashcode for this instance.</returns>
         public override int GetHashCode()
         {
             var hashCode = -1781160927;
 
+            // Equal hierarchies probably represent the same node, losing this entropy is less
+            // important than the hierarchy itself.
             var equalityComparer = _equalityComparer ?? EqualityComparer<T>.Default;
             hashCode = hashCode * -1521134295 + equalityComparer.GetHashCode(Node);
 
             if (Hierarchy != null)
             {
-                hashCode = hashCode * -1521134295 + Hierarchy.Count;
-
                 var step = Math.Max(1, Hierarchy.Count / 10);
 
-                // Hierarchies have a greater probability of being different starting from the end
-                for (var i = Hierarchy.Count - 1; i >= 0; i -= step)
+                // Hierarchies have a greater probability of being different starting from the end,
+                // that value should be mixed in last (as opposed to checked first as-per equals).
+                for (var i = 0; i < Hierarchy.Count; i += step)
                 {
                     hashCode = hashCode * -1521134295 + Hierarchy[i].GetHashCode();
                 }
-            }
 
+                hashCode = hashCode * -1521134295 + Hierarchy.Count;
+            }
+            
             return hashCode;
         }
 
+        /// <summary>
+        /// Implements the equality operator for <see cref="TreeNode{T}"/>.
+        /// </summary>
+        /// <param name="node1">The first tree node to compare.</param>
+        /// <param name="node2">The second tree node to compare.</param>
+        /// <returns>A value indicating whether the tree nodes are equal.</returns>
         public static bool operator ==(TreeNode<T> node1, TreeNode<T> node2) 
             => node1.Equals(node2);
 
+        /// <summary>
+        /// Implements the inequality operator for <see cref="TreeNode{T}"/>.
+        /// </summary>
+        /// <param name="node1">The first tree node to compare.</param>
+        /// <param name="node2">The second tree node to compare.</param>
+        /// <returns>A value indicating whether the tree nodes are not equal.</returns>
         public static bool operator !=(TreeNode<T> node1, TreeNode<T> node2) 
             => !(node1 == node2);
     }


### PR DESCRIPTION
Fixes #233.

* Add DocComments
* Improve behavior of `TreeNode<T>.GetHashCode`
* TreeNode.Clone uses explicit array copy to guarantee one allocation.
* Warnings from `Graph<T>.Nested` for some reason, disabled warnings for the file.