### PR TITLE
BitOps fixes

### DIFF
--- a/src/SourceCode.Clay.Buffers.Tests/BitOpsTests.cs
+++ b/src/SourceCode.Clay.Buffers.Tests/BitOpsTests.cs
@@ -21,20 +21,26 @@ namespace SourceCode.Clay.Buffers.Tests
         [InlineData(0b010, 1, true)]
         [InlineData(byte.MaxValue, 7, true)]
         [InlineData(byte.MaxValue, 8, true)]
-        public static void BitOps_ExtractBit_8u(byte n, uint offset, bool expected)
+        public static void BitOps_ExtractBit_8u(byte n, int offset, bool expected)
         {
             // Scalar
-            var actual = BitOps.ExtractBit(n, (byte)offset);
+            var actual = BitOps.ExtractBit(n, offset);
             Assert.Equal(expected, actual);
 
-            actual = BitOps.ExtractBit(n, (byte)(offset + 32 * 2));
+            actual = BitOps.ExtractBit(n, offset + 8 * 2);
+            Assert.Equal(expected, actual);
+
+            actual = BitOps.ExtractBit(n, offset - 8 * 2);
             Assert.Equal(expected, actual);
 
             // Span
-            Span<byte> span = stackalloc byte[4]; span[2] = n;
-            actual = BitOps.ExtractBit(span, (byte)(8 * 2 + offset));
+            if (offset > 0)
+            {
+                Span<byte> span = stackalloc byte[4]; span[2] = n;
+                actual = BitOps.ExtractBit(span, (byte)(8 * 2 + offset));
 
-            Assert.Equal(offset >= 8 ? false : expected, actual);
+                Assert.Equal(offset >= 8 ? false : expected, actual);
+            }
         }
 
         [Theory(DisplayName = nameof(BitOps_ExtractBit_16u))]
@@ -46,20 +52,25 @@ namespace SourceCode.Clay.Buffers.Tests
         [InlineData(byte.MaxValue, 8, false)]
         [InlineData(ushort.MaxValue, 15, true)]
         [InlineData(ushort.MaxValue, 16, true)]
-        public static void BitOps_ExtractBit_16u(ushort n, uint offset, bool expected)
+        public static void BitOps_ExtractBit_16u(ushort n, int offset, bool expected)
         {
             // Scalar
-            var actual = BitOps.ExtractBit(n, (byte)offset);
+            var actual = BitOps.ExtractBit(n, offset);
             Assert.Equal(expected, actual);
 
-            actual = BitOps.ExtractBit(n, (byte)(offset + 16 * 2));
+            actual = BitOps.ExtractBit(n, offset + 16 * 2);
             Assert.Equal(expected, actual);
 
-            // Span
-            Span<ushort> span = stackalloc ushort[4]; span[2] = n;
+            actual = BitOps.ExtractBit(n, offset - 16 * 2);
+            Assert.Equal(expected, actual);
 
-            actual = BitOps.ExtractBit(span, (byte)(16 * 2 + offset));
-            Assert.Equal(offset >= 16 ? false : expected, actual);
+            // Spanif (offset > 0)
+            {
+                Span<ushort> span = stackalloc ushort[4]; span[2] = n;
+
+                actual = BitOps.ExtractBit(span, (byte)(16 * 2 + offset));
+                Assert.Equal(offset >= 16 ? false : expected, actual);
+            }
         }
 
         [Theory(DisplayName = nameof(BitOps_ExtractBit_32u))]
@@ -73,20 +84,25 @@ namespace SourceCode.Clay.Buffers.Tests
         [InlineData(ushort.MaxValue, 16, false)]
         [InlineData(uint.MaxValue, 31, true)]
         [InlineData(uint.MaxValue, 32, true)]
-        public static void BitOps_ExtractBit_32u(uint n, uint offset, bool expected)
+        public static void BitOps_ExtractBit_32u(uint n, int offset, bool expected)
         {
             // Scalar
-            var actual = BitOps.ExtractBit(n, (byte)offset);
+            var actual = BitOps.ExtractBit(n, offset);
             Assert.Equal(expected, actual);
 
-            actual = BitOps.ExtractBit(n, (byte)(offset + 32 * 2));
+            actual = BitOps.ExtractBit(n, offset + 32 * 2);
             Assert.Equal(expected, actual);
 
-            // Span
-            Span<uint> span = stackalloc uint[4]; span[2] = n;
+            actual = BitOps.ExtractBit(n, offset - 32 * 2);
+            Assert.Equal(expected, actual);
 
-            actual = BitOps.ExtractBit(span, (byte)(32 * 2 + offset));
-            Assert.Equal(offset >= 32 ? false : expected, actual);
+            // Spanif (offset > 0)
+            {
+                Span<uint> span = stackalloc uint[4]; span[2] = n;
+
+                actual = BitOps.ExtractBit(span, (byte)(32 * 2 + offset));
+                Assert.Equal(offset >= 32 ? false : expected, actual);
+            }
         }
 
         [Theory(DisplayName = nameof(BitOps_ExtractBit_64u))]
@@ -102,20 +118,25 @@ namespace SourceCode.Clay.Buffers.Tests
         [InlineData(uint.MaxValue, 32, false)]
         [InlineData(ulong.MaxValue, 63, true)]
         [InlineData(ulong.MaxValue, 64, true)]
-        public static void BitOps_ExtractBit_64u(ulong n, uint offset, bool expected)
+        public static void BitOps_ExtractBit_64u(ulong n, int offset, bool expected)
         {
             // Scalar
-            var actual = BitOps.ExtractBit(n, (byte)offset);
+            var actual = BitOps.ExtractBit(n, offset);
             Assert.Equal(expected, actual);
 
-            actual = BitOps.ExtractBit(n, (byte)(offset + 64 * 2));
+            actual = BitOps.ExtractBit(n, offset + 64 * 2);
             Assert.Equal(expected, actual);
 
-            // Span
-            Span<ulong> span = stackalloc ulong[4]; span[2] = n;
+            actual = BitOps.ExtractBit(n, offset - 64 * 2);
+            Assert.Equal(expected, actual);
 
-            actual = BitOps.ExtractBit(span, (byte)(64 * 2 + offset));
-            Assert.Equal(offset >= 64 ? false : expected, actual);
+            // Spanif (offset > 0)
+            {
+                Span<ulong> span = stackalloc ulong[4]; span[2] = n;
+
+                actual = BitOps.ExtractBit(span, (byte)(64 * 2 + offset));
+                Assert.Equal(offset >= 64 ? false : expected, actual);
+            }
         }
 
         #endregion
@@ -139,12 +160,16 @@ namespace SourceCode.Clay.Buffers.Tests
         [InlineData(0b011, 0, true, true, 0b011)]
         [InlineData(0b011, 1, false, true, 0b001)]
         [InlineData(0b011, 1, true, true, 0b011)]
+        [InlineData(0b011, 0 - 8 * 2, false, true, 0b010)] // == 1
+        [InlineData(0b011, 0 - 8 * 2, true, true, 0b011)]
+        [InlineData(0b011, 1 - 8 * 2, false, true, 0b001)]
+        [InlineData(0b011, 1 - 8 * 2, true, true, 0b011)]
         [InlineData(byte.MaxValue, 0, false, true, byte.MaxValue - 1)]
         [InlineData(byte.MaxValue, 0, true, true, byte.MaxValue)]
         [InlineData(byte.MaxValue, 7, false, true, byte.MaxValue >> 1)]
         [InlineData(byte.MaxValue, 7, true, true, byte.MaxValue)]
         [InlineData(byte.MaxValue, 8, false, true, byte.MaxValue - 1)]
-        public static void BitOps_WriteBit_8u(byte n, byte offset, bool on, bool was, byte expected)
+        public static void BitOps_WriteBit_8u(byte n, int offset, bool on, bool was, byte expected)
         {
             // Scalar
             var actual = on ? BitOps.InsertBit(n, offset) : BitOps.ClearBit(n, offset);
@@ -168,9 +193,12 @@ namespace SourceCode.Clay.Buffers.Tests
             }
 
             // Span
-            Span<byte> span = stackalloc byte[4]; span[2] = n;
-            var tf = on ? BitOps.InsertBit(span, (byte)(8 * 2 + offset)) : BitOps.ClearBit(span, (byte)(8 * 2 + offset));
-            Assert.Equal(offset >= 8 ? false : was, tf);
+            if (offset > 0)
+            {
+                Span<byte> span = stackalloc byte[4]; span[2] = n;
+                var tf = on ? BitOps.InsertBit(span, 8 * 2 + offset) : BitOps.ClearBit(span, 8 * 2 + offset);
+                Assert.Equal(offset >= 8 ? false : was, tf);
+            }
         }
 
         [Theory(DisplayName = nameof(BitOps_WriteBit_16u))]
@@ -190,6 +218,10 @@ namespace SourceCode.Clay.Buffers.Tests
         [InlineData(0b011, 0, true, true, 0b011)]
         [InlineData(0b011, 1, false, true, 0b001)]
         [InlineData(0b011, 1, true, true, 0b011)]
+        [InlineData(0b011, 0 - 16 * 2, false, true, 0b010)] // == 1
+        [InlineData(0b011, 0 - 16 * 2, true, true, 0b011)]
+        [InlineData(0b011, 1 - 16 * 2, false, true, 0b001)]
+        [InlineData(0b011, 1 - 16 * 2, true, true, 0b011)]
         [InlineData(byte.MaxValue, 0, false, true, byte.MaxValue - 1)]
         [InlineData(byte.MaxValue, 0, true, true, byte.MaxValue)]
         [InlineData(byte.MaxValue, 7, false, true, byte.MaxValue >> 1)]
@@ -201,7 +233,7 @@ namespace SourceCode.Clay.Buffers.Tests
         [InlineData(ushort.MaxValue, 15, false, true, ushort.MaxValue >> 1)]
         [InlineData(ushort.MaxValue, 15, true, true, ushort.MaxValue)]
         [InlineData(ushort.MaxValue, 16, false, true, ushort.MaxValue - 1)]
-        public static void BitOps_WriteBit_16u(ushort n, byte offset, bool on, bool was, ushort expected)
+        public static void BitOps_WriteBit_16u(ushort n, int offset, bool on, bool was, ushort expected)
         {
             // Scalar
             var actual = on ? BitOps.InsertBit(n, offset) : BitOps.ClearBit(n, offset);
@@ -225,9 +257,12 @@ namespace SourceCode.Clay.Buffers.Tests
             }
 
             // Span
-            Span<ushort> span = stackalloc ushort[4]; span[2] = n;
-            var tf = on ? BitOps.InsertBit(span, (byte)(16 * 2 + offset)) : BitOps.ClearBit(span, (byte)(16 * 2 + offset));
-            Assert.Equal(offset >= 16 ? false : was, tf);
+            if (offset > 0)
+            {
+                Span<ushort> span = stackalloc ushort[4]; span[2] = n;
+                var tf = on ? BitOps.InsertBit(span, 16 * 2 + offset) : BitOps.ClearBit(span, 16 * 2 + offset);
+                Assert.Equal(offset >= 16 ? false : was, tf);
+            }
         }
 
         [Theory(DisplayName = nameof(BitOps_WriteBit_32u))]
@@ -247,6 +282,10 @@ namespace SourceCode.Clay.Buffers.Tests
         [InlineData(0b011, 0, true, true, 0b011)]
         [InlineData(0b011, 1, false, true, 0b001)]
         [InlineData(0b011, 1, true, true, 0b011)]
+        [InlineData(0b001, 0 - 32 * 2, false, true, 0b000)] // == 1
+        [InlineData(0b001, 0 - 32 * 2, true, true, 0b001)]
+        [InlineData(0b001, 1 - 32 * 2, false, false, 0b001)]
+        [InlineData(0b001, 1 - 32 * 2, true, false, 0b011)]
         [InlineData(byte.MaxValue, 0, false, true, byte.MaxValue - 1)]
         [InlineData(byte.MaxValue, 0, true, true, byte.MaxValue)]
         [InlineData(byte.MaxValue, 7, false, true, byte.MaxValue >> 1)]
@@ -264,7 +303,7 @@ namespace SourceCode.Clay.Buffers.Tests
         [InlineData(uint.MaxValue, 31, false, true, uint.MaxValue >> 1)]
         [InlineData(uint.MaxValue, 31, true, true, uint.MaxValue)]
         [InlineData(uint.MaxValue, 32, false, true, uint.MaxValue - 1)]
-        public static void BitOps_WriteBit_32u(uint n, byte offset, bool on, bool was, uint expected)
+        public static void BitOps_WriteBit_32u(uint n, int offset, bool on, bool was, uint expected)
         {
             // Scalar
             var actual = on ? BitOps.InsertBit(n, offset) : BitOps.ClearBit(n, offset);
@@ -288,9 +327,12 @@ namespace SourceCode.Clay.Buffers.Tests
             }
 
             // Span
-            Span<uint> span = stackalloc uint[4]; span[2] = n;
-            var tf = on ? BitOps.InsertBit(span, (byte)(32 * 2 + offset)) : BitOps.ClearBit(span, (byte)(32 * 2 + offset));
-            Assert.Equal(offset >= 32 ? false : was, tf);
+            if (offset > 0)
+            {
+                Span<uint> span = stackalloc uint[4]; span[2] = n;
+                var tf = on ? BitOps.InsertBit(span, 32 * 2 + offset) : BitOps.ClearBit(span, 32 * 2 + offset);
+                Assert.Equal(offset >= 32 ? false : was, tf);
+            }
         }
 
         [Theory(DisplayName = nameof(BitOps_WriteBit_64u))]
@@ -310,6 +352,10 @@ namespace SourceCode.Clay.Buffers.Tests
         [InlineData(0b011, 0, true, true, 0b011)]
         [InlineData(0b011, 1, false, true, 0b001)]
         [InlineData(0b011, 1, true, true, 0b011)]
+        [InlineData(0b001, 0 - 64 * 2, false, true, 0b000)] // == 1
+        [InlineData(0b001, 0 - 64 * 2, true, true, 0b001)]
+        [InlineData(0b001, 1 - 64 * 2, false, false, 0b001)]
+        [InlineData(0b001, 1 - 64 * 2, true, false, 0b011)]
         [InlineData(byte.MaxValue, 0, false, true, byte.MaxValue - 1)]
         [InlineData(byte.MaxValue, 0, true, true, byte.MaxValue)]
         [InlineData(byte.MaxValue, 7, false, true, byte.MaxValue >> 1)]
@@ -331,7 +377,7 @@ namespace SourceCode.Clay.Buffers.Tests
         [InlineData(ulong.MaxValue, 63, false, true, ulong.MaxValue >> 1)]
         [InlineData(ulong.MaxValue, 63, true, true, ulong.MaxValue)]
         [InlineData(ulong.MaxValue, 64, false, true, ulong.MaxValue - 1)]
-        public static void BitOps_WriteBit_64u(ulong n, byte offset, bool on, bool was, ulong expected)
+        public static void BitOps_WriteBit_64u(ulong n, int offset, bool on, bool was, ulong expected)
         {
             // Scalar
             var actual = on ? BitOps.InsertBit(n, offset) : BitOps.ClearBit(n, offset);
@@ -355,9 +401,12 @@ namespace SourceCode.Clay.Buffers.Tests
             }
 
             // Span
-            Span<ulong> span = stackalloc ulong[4]; span[2] = n;
-            var tf = on ? BitOps.InsertBit(span, (byte)(64 * 2 + offset)) : BitOps.ClearBit(span, (byte)(64 * 2 + offset));
-            Assert.Equal(offset >= 64 ? false : was, tf);
+            if (offset > 0)
+            {
+                Span<ulong> span = stackalloc ulong[4]; span[2] = n;
+                var tf = on ? BitOps.InsertBit(span, 64 * 2 + offset) : BitOps.ClearBit(span, 64 * 2 + offset);
+                Assert.Equal(offset >= 64 ? false : was, tf);
+            }
         }
 
         #endregion
@@ -372,13 +421,19 @@ namespace SourceCode.Clay.Buffers.Tests
         [InlineData(byte.MaxValue, 0, byte.MaxValue - 1, true)]
         [InlineData(byte.MaxValue, 7, byte.MaxValue >> 1, true)]
         [InlineData(byte.MaxValue, 8, byte.MaxValue - 1, true)]
-        public static void BitOps_ComplementBit_8u(byte n, byte offset, uint expected, bool was)
+        public static void BitOps_ComplementBit_8u(byte n, int offset, uint expected, bool was)
         {
             // Scalar
             var actual = BitOps.ComplementBit(n, offset);
             Assert.Equal(expected, actual);
 
             actual = BitOps.ComplementBit(actual, offset);
+            Assert.Equal(n, actual);
+
+            actual = BitOps.ComplementBit(actual, offset + 8 * 2);
+            Assert.Equal(expected, actual);
+
+            actual = BitOps.ComplementBit(actual, offset - 8 * 2);
             Assert.Equal(n, actual);
 
             // Ref
@@ -391,8 +446,11 @@ namespace SourceCode.Clay.Buffers.Tests
             Assert.Equal(n, actual);
 
             // Span
-            Span<byte> span = stackalloc byte[4]; span[2] = n;
-            Assert.Equal(offset >= 8 ? false : was, BitOps.ComplementBit(span, (byte)(8 * 2 + offset)));
+            if (offset > 0)
+            {
+                Span<byte> span = stackalloc byte[4]; span[2] = n;
+                Assert.Equal(offset >= 8 ? false : was, BitOps.ComplementBit(span, (byte)(8 * 2 + offset)));
+            }
         }
 
         [Theory(DisplayName = nameof(BitOps_ComplementBit_16u))]
@@ -406,13 +464,19 @@ namespace SourceCode.Clay.Buffers.Tests
         [InlineData(ushort.MaxValue, 0, ushort.MaxValue - 1, true)]
         [InlineData(ushort.MaxValue, 15, ushort.MaxValue >> 1, true)]
         [InlineData(ushort.MaxValue, 16, ushort.MaxValue - 1, true)]
-        public static void BitOps_ComplementBit_16u(ushort n, byte offset, uint expected, bool was)
+        public static void BitOps_ComplementBit_16u(ushort n, int offset, uint expected, bool was)
         {
             // Scalar
             var actual = BitOps.ComplementBit(n, offset);
             Assert.Equal(expected, actual);
 
             actual = BitOps.ComplementBit(actual, offset);
+            Assert.Equal(n, actual);
+
+            actual = BitOps.ComplementBit(actual, offset + 16 * 2);
+            Assert.Equal(expected, actual);
+
+            actual = BitOps.ComplementBit(actual, offset - 16 * 2);
             Assert.Equal(n, actual);
 
             // Ref
@@ -424,9 +488,11 @@ namespace SourceCode.Clay.Buffers.Tests
             Assert.Equal(BitOps.ComplementBit(ref actual, offset), !was);
             Assert.Equal(n, actual);
 
-            // Span
-            Span<ushort> span = stackalloc ushort[4]; span[2] = n;
-            Assert.Equal(offset >= 16 ? false : was, BitOps.ComplementBit(span, (byte)(16 * 2 + offset)));
+            // Spanif (offset > 0)
+            {
+                Span<ushort> span = stackalloc ushort[4]; span[2] = n;
+                Assert.Equal(offset >= 16 ? false : was, BitOps.ComplementBit(span, (byte)(16 * 2 + offset)));
+            }
         }
 
         [Theory(DisplayName = nameof(BitOps_ComplementBit_32u))]
@@ -443,13 +509,19 @@ namespace SourceCode.Clay.Buffers.Tests
         [InlineData(uint.MaxValue, 0, uint.MaxValue - 1, true)]
         [InlineData(uint.MaxValue, 31, uint.MaxValue >> 1, true)]
         [InlineData(uint.MaxValue, 32, uint.MaxValue - 1, true)]
-        public static void BitOps_ComplementBit_32u(uint n, byte offset, uint expected, bool was)
+        public static void BitOps_ComplementBit_32u(uint n, int offset, uint expected, bool was)
         {
             // Scalar
             var actual = BitOps.ComplementBit(n, offset);
             Assert.Equal(expected, actual);
 
             actual = BitOps.ComplementBit(actual, offset);
+            Assert.Equal(n, actual);
+
+            actual = BitOps.ComplementBit(actual, offset + 32 * 2);
+            Assert.Equal(expected, actual);
+
+            actual = BitOps.ComplementBit(actual, offset - 32 * 2);
             Assert.Equal(n, actual);
 
             // Ref
@@ -462,8 +534,11 @@ namespace SourceCode.Clay.Buffers.Tests
             Assert.Equal(n, actual);
 
             // Span
-            Span<uint> span = stackalloc uint[4]; span[2] = n;
-            Assert.Equal(offset >= 32 ? false : was, BitOps.ComplementBit(span, (byte)(32 * 2 + offset)));
+            if (offset > 0)
+            {
+                Span<uint> span = stackalloc uint[4]; span[2] = n;
+                Assert.Equal(offset >= 32 ? false : was, BitOps.ComplementBit(span, (byte)(32 * 2 + offset)));
+            }
         }
 
         [Theory(DisplayName = nameof(BitOps_ComplementBit_64u))]
@@ -483,13 +558,19 @@ namespace SourceCode.Clay.Buffers.Tests
         [InlineData(ulong.MaxValue, 0, ulong.MaxValue - 1, true)]
         [InlineData(ulong.MaxValue, 63, ulong.MaxValue >> 1, true)]
         [InlineData(ulong.MaxValue, 64, ulong.MaxValue - 1, true)]
-        public static void BitOps_ComplementBit_64u(ulong n, byte offset, ulong expected, bool was)
+        public static void BitOps_ComplementBit_64u(ulong n, int offset, ulong expected, bool was)
         {
             // Scalar
             var actual = BitOps.ComplementBit(n, offset);
             Assert.Equal(expected, actual);
 
             actual = BitOps.ComplementBit(actual, offset);
+            Assert.Equal(n, actual);
+
+            actual = BitOps.ComplementBit(actual, offset + 64 * 2);
+            Assert.Equal(expected, actual);
+
+            actual = BitOps.ComplementBit(actual, offset - 64 * 2);
             Assert.Equal(n, actual);
 
             // Ref
@@ -501,9 +582,11 @@ namespace SourceCode.Clay.Buffers.Tests
             Assert.Equal(BitOps.ComplementBit(ref actual, offset), !was);
             Assert.Equal(n, actual);
 
-            // Span
-            Span<ulong> span = stackalloc ulong[4]; span[2] = n;
-            Assert.Equal(offset >= 64 ? false : was, BitOps.ComplementBit(span, (byte)(64 * 2 + offset)));
+            // Spanif (offset > 0)
+            {
+                Span<ulong> span = stackalloc ulong[4]; span[2] = n;
+                Assert.Equal(offset >= 64 ? false : was, BitOps.ComplementBit(span, (byte)(64 * 2 + offset)));
+            }
         }
 
         #endregion

--- a/src/SourceCode.Clay.Buffers.Tests/BitOpsTests.cs
+++ b/src/SourceCode.Clay.Buffers.Tests/BitOpsTests.cs
@@ -19,6 +19,8 @@ namespace SourceCode.Clay.Buffers.Tests
         [InlineData(0b001, 0, true)]
         [InlineData(0b000, 1, false)]
         [InlineData(0b010, 1, true)]
+        [InlineData(1, int.MinValue, true)] // % 8 = 0
+        [InlineData(1 << 7, int.MaxValue, true)] // % 8 = 7
         [InlineData(byte.MaxValue, 7, true)]
         [InlineData(byte.MaxValue, 8, true)]
         public static void BitOps_ExtractBit_8u(byte n, int offset, bool expected)
@@ -48,6 +50,8 @@ namespace SourceCode.Clay.Buffers.Tests
         [InlineData(0b001, 0, true)]
         [InlineData(0b000, 1, false)]
         [InlineData(0b010, 1, true)]
+        [InlineData(1, int.MinValue, true)] // % 16 = 0
+        [InlineData(1 << 15, int.MaxValue, true)] // % 16 = 15
         [InlineData(byte.MaxValue, 7, true)]
         [InlineData(byte.MaxValue, 8, false)]
         [InlineData(ushort.MaxValue, 15, true)]
@@ -78,6 +82,8 @@ namespace SourceCode.Clay.Buffers.Tests
         [InlineData(0b001, 0, true)]
         [InlineData(0b000, 1, false)]
         [InlineData(0b010, 1, true)]
+        [InlineData(1, int.MinValue, true)] // % 32 = 0
+        [InlineData(unchecked((uint)(1 << 31)), int.MaxValue, true)] // % 32 = 31
         [InlineData(byte.MaxValue, 7, true)]
         [InlineData(byte.MaxValue, 8, false)]
         [InlineData(ushort.MaxValue, 15, true)]
@@ -110,6 +116,8 @@ namespace SourceCode.Clay.Buffers.Tests
         [InlineData(0b001, 0, true)]
         [InlineData(0b000, 1, false)]
         [InlineData(0b010, 1, true)]
+        [InlineData(1, int.MinValue, true)] // % 64 = 0
+        [InlineData(unchecked((ulong)(1 << 63)), int.MaxValue, true)] // % 64 = 63
         [InlineData(byte.MaxValue, 7, true)]
         [InlineData(byte.MaxValue, 8, false)]
         [InlineData(ushort.MaxValue, 15, true)]
@@ -164,6 +172,8 @@ namespace SourceCode.Clay.Buffers.Tests
         [InlineData(0b011, 0 - 8 * 2, true, true, 0b011)]
         [InlineData(0b011, 1 - 8 * 2, false, true, 0b001)]
         [InlineData(0b011, 1 - 8 * 2, true, true, 0b011)]
+        [InlineData(1, int.MinValue, false, true, 0)] // % 8 = 0
+        //[InlineData(1 << 7, int.MaxValue, false, true, 0)] // % 8 = 7 TODO
         [InlineData(byte.MaxValue, 0, false, true, byte.MaxValue - 1)]
         [InlineData(byte.MaxValue, 0, true, true, byte.MaxValue)]
         [InlineData(byte.MaxValue, 7, false, true, byte.MaxValue >> 1)]
@@ -222,6 +232,8 @@ namespace SourceCode.Clay.Buffers.Tests
         [InlineData(0b011, 0 - 16 * 2, true, true, 0b011)]
         [InlineData(0b011, 1 - 16 * 2, false, true, 0b001)]
         [InlineData(0b011, 1 - 16 * 2, true, true, 0b011)]
+        [InlineData(1, int.MinValue, false, true, 0)] // % 16 = 0
+        //[InlineData(1 << 15, int.MaxValue, false, true, 0)] // % 16 = 15 TODO
         [InlineData(byte.MaxValue, 0, false, true, byte.MaxValue - 1)]
         [InlineData(byte.MaxValue, 0, true, true, byte.MaxValue)]
         [InlineData(byte.MaxValue, 7, false, true, byte.MaxValue >> 1)]
@@ -286,6 +298,8 @@ namespace SourceCode.Clay.Buffers.Tests
         [InlineData(0b001, 0 - 32 * 2, true, true, 0b001)]
         [InlineData(0b001, 1 - 32 * 2, false, false, 0b001)]
         [InlineData(0b001, 1 - 32 * 2, true, false, 0b011)]
+        [InlineData(1, int.MinValue, false, true, 0)] // % 32 = 0
+        //[InlineData(1 << 31, int.MaxValue, false, true, 0)] // % 32 = 31 TODO
         [InlineData(byte.MaxValue, 0, false, true, byte.MaxValue - 1)]
         [InlineData(byte.MaxValue, 0, true, true, byte.MaxValue)]
         [InlineData(byte.MaxValue, 7, false, true, byte.MaxValue >> 1)]
@@ -356,6 +370,8 @@ namespace SourceCode.Clay.Buffers.Tests
         [InlineData(0b001, 0 - 64 * 2, true, true, 0b001)]
         [InlineData(0b001, 1 - 64 * 2, false, false, 0b001)]
         [InlineData(0b001, 1 - 64 * 2, true, false, 0b011)]
+        [InlineData(1, int.MinValue, false, true, 0)] // % 64 = 0
+        //[InlineData(1 << 63, int.MaxValue, false, true, 0)] // % 64 = 63 TODO
         [InlineData(byte.MaxValue, 0, false, true, byte.MaxValue - 1)]
         [InlineData(byte.MaxValue, 0, true, true, byte.MaxValue)]
         [InlineData(byte.MaxValue, 7, false, true, byte.MaxValue >> 1)]
@@ -418,6 +434,8 @@ namespace SourceCode.Clay.Buffers.Tests
         [InlineData(0b001, 0, 0b000, true)]
         [InlineData(0b000, 1, 0b010, false)]
         [InlineData(0b010, 1, 0b000, true)]
+        [InlineData(1, int.MinValue, 0, true)] // % 8 = 0
+        [InlineData(1 << 7, int.MaxValue, 0, true)] // % 8 = 7
         [InlineData(byte.MaxValue, 0, byte.MaxValue - 1, true)]
         [InlineData(byte.MaxValue, 7, byte.MaxValue >> 1, true)]
         [InlineData(byte.MaxValue, 8, byte.MaxValue - 1, true)]
@@ -458,6 +476,8 @@ namespace SourceCode.Clay.Buffers.Tests
         [InlineData(0b001, 0, 0b000, true)]
         [InlineData(0b000, 1, 0b010, false)]
         [InlineData(0b010, 1, 0b000, true)]
+        [InlineData(1, int.MinValue, 0, true)] // % 16 = 0
+        [InlineData(1 << 15, int.MaxValue, 0, true)] // % 16 = 15
         [InlineData(byte.MaxValue, 0, byte.MaxValue - 1, true)]
         [InlineData(byte.MaxValue, 7, byte.MaxValue >> 1, true)]
         [InlineData(byte.MaxValue, 8, byte.MaxValue + (1U << 8), false)]
@@ -500,6 +520,8 @@ namespace SourceCode.Clay.Buffers.Tests
         [InlineData(0b001, 0, 0b000, true)]
         [InlineData(0b000, 1, 0b010, false)]
         [InlineData(0b010, 1, 0b000, true)]
+        [InlineData(1, int.MinValue, 0, true)] // % 32 = 0
+        [InlineData(unchecked((uint)(1 << 31)), int.MaxValue, 0, true)] // % 32 = 31
         [InlineData(byte.MaxValue, 0, byte.MaxValue - 1, true)]
         [InlineData(byte.MaxValue, 7, byte.MaxValue >> 1, true)]
         [InlineData(byte.MaxValue, 8, byte.MaxValue + (1U << 8), false)]
@@ -546,6 +568,8 @@ namespace SourceCode.Clay.Buffers.Tests
         [InlineData(0b001, 0, 0b000, true)]
         [InlineData(0b000, 1, 0b010, false)]
         [InlineData(0b010, 1, 0b000, true)]
+        [InlineData(1, int.MinValue, 0, true)] // % 64 = 0
+        //[InlineData(unchecked((ulong)(1 << 63)), int.MaxValue, 0, true)] // % 64 = 63 // TODO
         [InlineData(byte.MaxValue, 0, byte.MaxValue - 1, true)]
         [InlineData(byte.MaxValue, 7, byte.MaxValue >> 1, true)]
         [InlineData(byte.MaxValue, 8, byte.MaxValue + (1UL << 8), false)]
@@ -600,6 +624,8 @@ namespace SourceCode.Clay.Buffers.Tests
             Assert.Equal((byte)0b10101010, BitOps.RotateLeft(sut, 1));
             Assert.Equal((byte)0b01010101, BitOps.RotateLeft(sut, 2));
             Assert.Equal((byte)0b10101010, BitOps.RotateLeft(sut, 3));
+            Assert.Equal(sut, BitOps.RotateLeft(sut, int.MinValue)); // % 8 = 0
+            Assert.Equal(BitOps.RotateLeft(sut, 7), BitOps.RotateLeft(sut, int.MaxValue)); // % 8 = 7
         }
 
         [Fact(DisplayName = nameof(BitOps_RotateLeft_UShort))]
@@ -609,6 +635,8 @@ namespace SourceCode.Clay.Buffers.Tests
             Assert.Equal((ushort)0b10101010_10101010, BitOps.RotateLeft(sut, 1));
             Assert.Equal((ushort)0b01010101_01010101, BitOps.RotateLeft(sut, 2));
             Assert.Equal((ushort)0b10101010_10101010, BitOps.RotateLeft(sut, 3));
+            Assert.Equal(sut, BitOps.RotateLeft(sut, int.MinValue)); // % 16 = 0
+            Assert.Equal(BitOps.RotateLeft(sut, 15), BitOps.RotateLeft(sut, int.MaxValue)); // % 16 = 15
         }
 
         [Fact(DisplayName = nameof(BitOps_RotateLeft_UInt))]
@@ -618,6 +646,8 @@ namespace SourceCode.Clay.Buffers.Tests
             Assert.Equal((uint)0b10101010_10101010_10101010_10101010, BitOps.RotateLeft(sut, 1));
             Assert.Equal((uint)0b01010101_01010101_01010101_01010101, BitOps.RotateLeft(sut, 2));
             Assert.Equal((uint)0b10101010_10101010_10101010_10101010, BitOps.RotateLeft(sut, 3));
+            Assert.Equal(sut, BitOps.RotateLeft(sut, int.MinValue)); // % 32 = 0
+            Assert.Equal(BitOps.RotateLeft(sut, 31), BitOps.RotateLeft(sut, int.MaxValue)); // % 32 = 31
         }
 
         [Fact(DisplayName = nameof(BitOps_RotateLeft_ULong))]
@@ -627,6 +657,8 @@ namespace SourceCode.Clay.Buffers.Tests
             Assert.Equal((ulong)0b10101010_10101010_10101010_10101010_10101010_10101010_10101010_10101010, BitOps.RotateLeft(sut, 1));
             Assert.Equal((ulong)0b01010101_01010101_01010101_01010101_01010101_01010101_01010101_01010101, BitOps.RotateLeft(sut, 2));
             Assert.Equal((ulong)0b10101010_10101010_10101010_10101010_10101010_10101010_10101010_10101010, BitOps.RotateLeft(sut, 3));
+            Assert.Equal(sut, BitOps.RotateLeft(sut, int.MinValue)); // % 64 = 0
+            Assert.Equal(BitOps.RotateLeft(sut, 63), BitOps.RotateLeft(sut, int.MaxValue)); // % 64 = 63
         }
 
         [Fact(DisplayName = nameof(BitOps_RotateRight_Byte))]
@@ -636,6 +668,8 @@ namespace SourceCode.Clay.Buffers.Tests
             Assert.Equal((byte)0b10101010, BitOps.RotateRight(sut, 1));
             Assert.Equal((byte)0b01010101, BitOps.RotateRight(sut, 2));
             Assert.Equal((byte)0b10101010, BitOps.RotateRight(sut, 3));
+            Assert.Equal(sut, BitOps.RotateRight(sut, int.MinValue)); // % 8 = 0
+            Assert.Equal(BitOps.RotateLeft(sut, 7), BitOps.RotateRight(sut, int.MaxValue)); // % 8 = 7
         }
 
         [Fact(DisplayName = nameof(BitOps_RotateRight_UShort))]
@@ -645,6 +679,8 @@ namespace SourceCode.Clay.Buffers.Tests
             Assert.Equal((ushort)0b10101010_10101010, BitOps.RotateRight(sut, 1));
             Assert.Equal((ushort)0b01010101_01010101, BitOps.RotateRight(sut, 2));
             Assert.Equal((ushort)0b10101010_10101010, BitOps.RotateRight(sut, 3));
+            Assert.Equal(sut, BitOps.RotateRight(sut, int.MinValue)); // % 16 = 0
+            Assert.Equal(BitOps.RotateLeft(sut, 15), BitOps.RotateRight(sut, int.MaxValue)); // % 16 = 15
         }
 
         [Fact(DisplayName = nameof(BitOps_RotateRight_UInt))]
@@ -654,6 +690,8 @@ namespace SourceCode.Clay.Buffers.Tests
             Assert.Equal((uint)0b10101010_10101010_10101010_10101010, BitOps.RotateRight(sut, 1));
             Assert.Equal((uint)0b01010101_01010101_01010101_01010101, BitOps.RotateRight(sut, 2));
             Assert.Equal((uint)0b10101010_10101010_10101010_10101010, BitOps.RotateRight(sut, 3));
+            Assert.Equal(sut, BitOps.RotateRight(sut, int.MinValue)); // % 32 = 0
+            Assert.Equal(BitOps.RotateLeft(sut, 15), BitOps.RotateRight(sut, int.MaxValue)); // % 32 = 15
         }
 
         [Fact(DisplayName = nameof(BitOps_RotateRight_ULong))]
@@ -663,6 +701,8 @@ namespace SourceCode.Clay.Buffers.Tests
             Assert.Equal((ulong)0b10101010_10101010_10101010_10101010_10101010_10101010_10101010_10101010, BitOps.RotateRight(sut, 1));
             Assert.Equal((ulong)0b01010101_01010101_01010101_01010101_01010101_01010101_01010101_01010101, BitOps.RotateRight(sut, 2));
             Assert.Equal((ulong)0b10101010_10101010_10101010_10101010_10101010_10101010_10101010_10101010, BitOps.RotateRight(sut, 3));
+            Assert.Equal(sut, BitOps.RotateRight(sut, int.MinValue)); // % 64 = 0
+            Assert.Equal(BitOps.RotateLeft(sut, 63), BitOps.RotateRight(sut, int.MaxValue)); // % 64 = 63
         }
 
         #endregion

--- a/src/SourceCode.Clay.Buffers/BitOps.Span.cs
+++ b/src/SourceCode.Clay.Buffers/BitOps.Span.cs
@@ -11,9 +11,9 @@ namespace System
         /// </summary>
         /// <param name="value">The mask.</param>
         /// <param name="offset">The ordinal position of the bit to read.</param>
-        public static bool ExtractBit(ReadOnlySpan<byte> value, uint offset)
+        public static bool ExtractBit(ReadOnlySpan<byte> value, int offset)
         {
-            var ix = (int)(offset >> 3); // div 8
+            var ix = offset >> 3; // div 8
             if (ix >= value.Length) throw new ArgumentOutOfRangeException(nameof(offset));
 
             var shft = (byte)(offset & 7); // mod 8: design choice ignores out-of-range values
@@ -27,9 +27,9 @@ namespace System
         /// </summary>
         /// <param name="value">The mask.</param>
         /// <param name="offset">The ordinal position of the bit to read.</param>
-        public static bool ExtractBit(ReadOnlySpan<ushort> value, uint offset)
+        public static bool ExtractBit(ReadOnlySpan<ushort> value, int offset)
         {
-            var ix = (int)(offset >> 4); // div 16
+            var ix = offset >> 4; // div 16
             if (ix >= value.Length) throw new ArgumentOutOfRangeException(nameof(offset));
             
             var shft = (byte)(offset & 15); // mod 16: design choice ignores out-of-range values
@@ -43,9 +43,9 @@ namespace System
         /// </summary>
         /// <param name="value">The mask.</param>
         /// <param name="offset">The ordinal position of the bit to read.</param>
-        public static bool ExtractBit(ReadOnlySpan<uint> value, uint offset)
+        public static bool ExtractBit(ReadOnlySpan<uint> value, int offset)
         {
-            var ix = (int)(offset >> 5); // div 32
+            var ix = offset >> 5; // div 32
             if (ix >= value.Length) throw new ArgumentOutOfRangeException(nameof(offset));
             
             var shft = (byte)(offset & 31); // mod 32: design choice ignores out-of-range values
@@ -59,9 +59,9 @@ namespace System
         /// </summary>
         /// <param name="value">The mask.</param>
         /// <param name="offset">The ordinal position of the bit to read.</param>
-        public static bool ExtractBit(ReadOnlySpan<ulong> value, uint offset)
+        public static bool ExtractBit(ReadOnlySpan<ulong> value, int offset)
         {
-            var ix = (int)(offset >> 6); // div 64
+            var ix = offset >> 6; // div 64
             if (ix >= value.Length) throw new ArgumentOutOfRangeException(nameof(offset));
 
             var shft = (byte)(offset & 63); // mod 64: design choice ignores out-of-range values
@@ -79,9 +79,9 @@ namespace System
         /// </summary>
         /// <param name="value">The mask.</param>
         /// <param name="offset">The ordinal position of the bit to clear.</param>
-        public static bool ClearBit(Span<byte> value, uint offset)
+        public static bool ClearBit(Span<byte> value, int offset)
         {
-            var ix = (int)(offset >> 3); // div 8
+            var ix = offset >> 3; // div 8
             if (ix >= value.Length) throw new ArgumentOutOfRangeException(nameof(offset));
 
             var shft = (byte)(offset & 7); // mod 8: design choice ignores out-of-range values
@@ -100,9 +100,9 @@ namespace System
         /// </summary>
         /// <param name="value">The mask.</param>
         /// <param name="offset">The ordinal position of the bit to clear.</param>
-        public static bool ClearBit(Span<ushort> value, uint offset)
+        public static bool ClearBit(Span<ushort> value, int offset)
         {
-            var ix = (int)(offset >> 4); // div 16
+            var ix = offset >> 4; // div 16
             if (ix >= value.Length) throw new ArgumentOutOfRangeException(nameof(offset));
 
             var shft = (byte)(offset & 15); // mod 16: design choice ignores out-of-range values
@@ -121,9 +121,9 @@ namespace System
         /// </summary>
         /// <param name="value">The mask.</param>
         /// <param name="offset">The ordinal position of the bit to clear.</param>
-        public static bool ClearBit(Span<uint> value, uint offset)
+        public static bool ClearBit(Span<uint> value, int offset)
         {
-            var ix = (int)(offset >> 5); // div 32
+            var ix = offset >> 5; // div 32
             if (ix >= value.Length) throw new ArgumentOutOfRangeException(nameof(offset));
 
             var shft = (byte)(offset & 31); // mod 32: design choice ignores out-of-range values
@@ -142,9 +142,9 @@ namespace System
         /// </summary>
         /// <param name="value">The mask.</param>
         /// <param name="offset">The ordinal position of the bit to clear.</param>
-        public static bool ClearBit(Span<ulong> value, uint offset)
+        public static bool ClearBit(Span<ulong> value, int offset)
         {
-            var ix = (int)(offset >> 6); // div 64
+            var ix = offset >> 6; // div 64
             if (ix >= value.Length) throw new ArgumentOutOfRangeException(nameof(offset));
 
             var shft = (byte)(offset & 63); // mod 64: design choice ignores out-of-range values
@@ -167,9 +167,9 @@ namespace System
         /// </summary>
         /// <param name="value">The mask.</param>
         /// <param name="offset">The ordinal position of the bit to write.</param>
-        public static bool InsertBit(Span<byte> value, uint offset)
+        public static bool InsertBit(Span<byte> value, int offset)
         {
-            var ix = (int)(offset >> 3); // div 8
+            var ix = offset >> 3; // div 8
             if (ix >= value.Length) throw new ArgumentOutOfRangeException(nameof(offset));
             
             var shft = (byte)(offset & 7); // mod 8: design choice ignores out-of-range values
@@ -188,9 +188,9 @@ namespace System
         /// </summary>
         /// <param name="value">The mask.</param>
         /// <param name="offset">The ordinal position of the bit to write.</param>
-        public static bool InsertBit(Span<ushort> value, uint offset)
+        public static bool InsertBit(Span<ushort> value, int offset)
         {
-            var ix = (int)(offset >> 4); // div 16
+            var ix = offset >> 4; // div 16
             if (ix >= value.Length) throw new ArgumentOutOfRangeException(nameof(offset));
 
             var shft = (byte)(offset & 15); // mod 16: design choice ignores out-of-range values
@@ -209,9 +209,9 @@ namespace System
         /// </summary>
         /// <param name="value">The mask.</param>
         /// <param name="offset">The ordinal position of the bit to write.</param>
-        public static bool InsertBit(Span<uint> value, uint offset)
+        public static bool InsertBit(Span<uint> value, int offset)
         {
-            var ix = (int)(offset >> 5); // div 32
+            var ix = offset >> 5; // div 32
             if (ix >= value.Length) throw new ArgumentOutOfRangeException(nameof(offset));
 
             var shft = (byte)(offset & 31); // mod 32: design choice ignores out-of-range values
@@ -230,9 +230,9 @@ namespace System
         /// </summary>
         /// <param name="value">The mask.</param>
         /// <param name="offset">The ordinal position of the bit to write.</param>
-        public static bool InsertBit(Span<ulong> value, uint offset)
+        public static bool InsertBit(Span<ulong> value, int offset)
         {
-            var ix = (int)(offset >> 6); // div 64
+            var ix = offset >> 6; // div 64
             if (ix >= value.Length) throw new ArgumentOutOfRangeException(nameof(offset));
 
             var shft = (byte)(offset & 63); // mod 64: design choice ignores out-of-range values
@@ -255,9 +255,9 @@ namespace System
         /// </summary>
         /// <param name="value">The mask.</param>
         /// <param name="offset">The ordinal position of the bit to complement.</param>
-        public static bool ComplementBit(Span<byte> value, uint offset)
+        public static bool ComplementBit(Span<byte> value, int offset)
         {
-            var ix = (int)(offset >> 3); // div 8
+            var ix = offset >> 3; // div 8
             if (ix >= value.Length) throw new ArgumentOutOfRangeException(nameof(offset));
 
             var shft = (byte)(offset & 7); // mod 8: design choice ignores out-of-range values
@@ -276,9 +276,9 @@ namespace System
         /// </summary>
         /// <param name="value">The mask.</param>
         /// <param name="offset">The ordinal position of the bit to complement.</param>
-        public static bool ComplementBit(Span<ushort> value, uint offset)
+        public static bool ComplementBit(Span<ushort> value, int offset)
         {
-            var ix = (int)(offset >> 4); // div 16
+            var ix = offset >> 4; // div 16
             if (ix >= value.Length) throw new ArgumentOutOfRangeException(nameof(offset));
 
             var shft = (byte)(offset & 15); // mod 16: design choice ignores out-of-range values
@@ -297,9 +297,9 @@ namespace System
         /// </summary>
         /// <param name="value">The mask.</param>
         /// <param name="offset">The ordinal position of the bit to complement.</param>
-        public static bool ComplementBit(Span<uint> value, uint offset)
+        public static bool ComplementBit(Span<uint> value, int offset)
         {
-            var ix = (int)(offset >> 5); // div 32
+            var ix = offset >> 5; // div 32
             if (ix >= value.Length) throw new ArgumentOutOfRangeException(nameof(offset));
 
             var shft = (byte)(offset & 31); // mod 32: design choice ignores out-of-range values
@@ -318,9 +318,9 @@ namespace System
         /// </summary>
         /// <param name="value">The mask.</param>
         /// <param name="offset">The ordinal position of the bit to complement.</param>
-        public static bool ComplementBit(Span<ulong> value, uint offset)
+        public static bool ComplementBit(Span<ulong> value, int offset)
         {
-            var ix = (int)(offset >> 6); // div 64
+            var ix = offset >> 6; // div 64
             if (ix >= value.Length) throw new ArgumentOutOfRangeException(nameof(offset));
 
             var shft = (byte)(offset & 63); // mod 64: design choice ignores out-of-range values

--- a/src/SourceCode.Clay.Buffers/BitOps.Span.cs
+++ b/src/SourceCode.Clay.Buffers/BitOps.Span.cs
@@ -1,5 +1,7 @@
 namespace System
 {
+#pragma warning disable IDE0007 // Use implicit type
+
     partial class BitOps // .Span
     {
         #region ExtractBit
@@ -654,4 +656,6 @@ namespace System
 
         #endregion
     }
+
+#pragma warning restore IDE0007 // Use implicit type
 }

--- a/src/SourceCode.Clay.Buffers/BitOps.Span.cs
+++ b/src/SourceCode.Clay.Buffers/BitOps.Span.cs
@@ -1,5 +1,3 @@
-using System.Runtime.CompilerServices;
-
 namespace System
 {
     partial class BitOps // .Span
@@ -13,13 +11,11 @@ namespace System
         /// <param name="offset">The ordinal position of the bit to read.</param>
         public static bool ExtractBit(ReadOnlySpan<byte> value, int offset)
         {
-            var ix = offset >> 3; // div 8
+            int ix = offset >> 3; // div 8
             if (ix >= value.Length) throw new ArgumentOutOfRangeException(nameof(offset));
 
-            var shft = (byte)(offset & 7); // mod 8: design choice ignores out-of-range values
-            var mask = 1U << shft;
-
-            return (value[ix] & mask) != 0;
+            var val = ExtractBit(value[ix], offset);
+            return val;
         }
 
         /// <summary>
@@ -29,13 +25,11 @@ namespace System
         /// <param name="offset">The ordinal position of the bit to read.</param>
         public static bool ExtractBit(ReadOnlySpan<ushort> value, int offset)
         {
-            var ix = offset >> 4; // div 16
+            int ix = offset >> 4; // div 16
             if (ix >= value.Length) throw new ArgumentOutOfRangeException(nameof(offset));
-            
-            var shft = (byte)(offset & 15); // mod 16: design choice ignores out-of-range values
-            var mask = 1U << shft;
 
-            return (value[ix] & mask) != 0;
+            var val = ExtractBit(value[ix], offset);
+            return val;
         }
 
         /// <summary>
@@ -45,13 +39,11 @@ namespace System
         /// <param name="offset">The ordinal position of the bit to read.</param>
         public static bool ExtractBit(ReadOnlySpan<uint> value, int offset)
         {
-            var ix = offset >> 5; // div 32
+            int ix = offset >> 5; // div 32
             if (ix >= value.Length) throw new ArgumentOutOfRangeException(nameof(offset));
-            
-            var shft = (byte)(offset & 31); // mod 32: design choice ignores out-of-range values
-            var mask = 1U << shft;
 
-            return (value[ix] & mask) != 0;
+            var val = ExtractBit(value[ix], offset);
+            return val;
         }
 
         /// <summary>
@@ -61,13 +53,11 @@ namespace System
         /// <param name="offset">The ordinal position of the bit to read.</param>
         public static bool ExtractBit(ReadOnlySpan<ulong> value, int offset)
         {
-            var ix = offset >> 6; // div 64
+            int ix = offset >> 6; // div 64
             if (ix >= value.Length) throw new ArgumentOutOfRangeException(nameof(offset));
 
-            var shft = (byte)(offset & 63); // mod 64: design choice ignores out-of-range values
-            var mask = 1UL << shft;
-
-            return (value[ix] & mask) != 0;
+            var val = ExtractBit(value[ix], offset);
+            return val;
         }
 
         #endregion
@@ -84,15 +74,10 @@ namespace System
             var ix = offset >> 3; // div 8
             if (ix >= value.Length) throw new ArgumentOutOfRangeException(nameof(offset));
 
-            var shft = (byte)(offset & 7); // mod 8: design choice ignores out-of-range values
-            var mask = 1U << shft;
-
             ref byte val = ref value[ix];
-            var rsp = val & mask;
 
-            val = (byte)(val & ~mask);
-
-            return rsp != 0; // BTR
+            var btr =  ClearBit(ref val, offset);
+            return btr;
         }
 
         /// <summary>
@@ -105,15 +90,10 @@ namespace System
             var ix = offset >> 4; // div 16
             if (ix >= value.Length) throw new ArgumentOutOfRangeException(nameof(offset));
 
-            var shft = (byte)(offset & 15); // mod 16: design choice ignores out-of-range values
-            var mask = 1U << shft;
-
             ref ushort val = ref value[ix];
-            var rsp = val & mask;
 
-            val = (ushort)(val & ~mask);
-
-            return rsp != 0; // BTR
+            var btr = ClearBit(ref val, offset);
+            return btr;
         }
 
         /// <summary>
@@ -126,15 +106,10 @@ namespace System
             var ix = offset >> 5; // div 32
             if (ix >= value.Length) throw new ArgumentOutOfRangeException(nameof(offset));
 
-            var shft = (byte)(offset & 31); // mod 32: design choice ignores out-of-range values
-            var mask = 1U << shft;
-
             ref uint val = ref value[ix];
-            var rsp = val & mask;
 
-            val = val & ~mask;
-
-            return rsp != 0; // BTR
+            var btr = ClearBit(ref val, offset);
+            return btr;
         }
 
         /// <summary>
@@ -147,15 +122,10 @@ namespace System
             var ix = offset >> 6; // div 64
             if (ix >= value.Length) throw new ArgumentOutOfRangeException(nameof(offset));
 
-            var shft = (byte)(offset & 63); // mod 64: design choice ignores out-of-range values
-            var mask = 1UL << shft;
-
             ref ulong val = ref value[ix];
-            var rsp = val & mask;
 
-            val = val & ~mask;
-
-            return rsp != 0; // BTR
+            var btr = ClearBit(ref val, offset);
+            return btr;
         }
 
         #endregion
@@ -171,16 +141,11 @@ namespace System
         {
             var ix = offset >> 3; // div 8
             if (ix >= value.Length) throw new ArgumentOutOfRangeException(nameof(offset));
-            
-            var shft = (byte)(offset & 7); // mod 8: design choice ignores out-of-range values
-            var mask = 1U << shft;
 
             ref byte val = ref value[ix];
-            var rsp = val & mask;
 
-            val = (byte)(val | mask);
-
-            return rsp != 0; // BTS
+            var bts = InsertBit(ref val, offset);
+            return bts;
         }
 
         /// <summary>
@@ -193,15 +158,10 @@ namespace System
             var ix = offset >> 4; // div 16
             if (ix >= value.Length) throw new ArgumentOutOfRangeException(nameof(offset));
 
-            var shft = (byte)(offset & 15); // mod 16: design choice ignores out-of-range values
-            var mask = 1U << shft;
-
             ref ushort val = ref value[ix];
-            var rsp = val & mask;
 
-            val = (ushort)(val | mask);
-
-            return rsp != 0; // BTS
+            var bts = InsertBit(ref val, offset);
+            return bts;
         }
 
         /// <summary>
@@ -214,15 +174,10 @@ namespace System
             var ix = offset >> 5; // div 32
             if (ix >= value.Length) throw new ArgumentOutOfRangeException(nameof(offset));
 
-            var shft = (byte)(offset & 31); // mod 32: design choice ignores out-of-range values
-            var mask = 1U << shft;
-
             ref uint val = ref value[ix];
-            var rsp = val & mask;
 
-            val = val | mask;
-
-            return rsp != 0; // BTS
+            var bts = InsertBit(ref val, offset);
+            return bts;
         }
 
         /// <summary>
@@ -235,15 +190,10 @@ namespace System
             var ix = offset >> 6; // div 64
             if (ix >= value.Length) throw new ArgumentOutOfRangeException(nameof(offset));
 
-            var shft = (byte)(offset & 63); // mod 64: design choice ignores out-of-range values
-            var mask = 1UL << shft;
-
             ref ulong val = ref value[ix];
-            var rsp = val & mask;
 
-            val = val | mask;
-
-            return rsp != 0; // BTS
+            var bts = InsertBit(ref val, offset);
+            return bts;
         }
 
         #endregion
@@ -260,15 +210,10 @@ namespace System
             var ix = offset >> 3; // div 8
             if (ix >= value.Length) throw new ArgumentOutOfRangeException(nameof(offset));
 
-            var shft = (byte)(offset & 7); // mod 8: design choice ignores out-of-range values
-            var mask = 1U << shft;
-
             ref byte val = ref value[ix];
-            var rsp = val & mask;
 
-            val = (byte)~(~mask ^ val);
-
-            return rsp != 0; // BTC
+            var btc = ComplementBit(ref val, offset);
+            return btc;
         }
 
         /// <summary>
@@ -281,15 +226,10 @@ namespace System
             var ix = offset >> 4; // div 16
             if (ix >= value.Length) throw new ArgumentOutOfRangeException(nameof(offset));
 
-            var shft = (byte)(offset & 15); // mod 16: design choice ignores out-of-range values
-            var mask = 1U << shft;
-
             ref ushort val = ref value[ix];
-            var rsp = val & mask;
 
-            val = (ushort)~(~mask ^ val);
-
-            return rsp != 0; // BTC
+            var btc = ComplementBit(ref val, offset);
+            return btc;
         }
 
         /// <summary>
@@ -302,15 +242,10 @@ namespace System
             var ix = offset >> 5; // div 32
             if (ix >= value.Length) throw new ArgumentOutOfRangeException(nameof(offset));
 
-            var shft = (byte)(offset & 31); // mod 32: design choice ignores out-of-range values
-            var mask = 1U << shft;
-
             ref uint val = ref value[ix];
-            var rsp = val & mask;
 
-            val = ~(~mask ^ val);
-
-            return rsp != 0; // BTC
+            var btc = ComplementBit(ref val, offset);
+            return btc;
         }
 
         /// <summary>
@@ -323,15 +258,10 @@ namespace System
             var ix = offset >> 6; // div 64
             if (ix >= value.Length) throw new ArgumentOutOfRangeException(nameof(offset));
 
-            var shft = (byte)(offset & 63); // mod 64: design choice ignores out-of-range values
-            var mask = 1UL << shft;
-
             ref ulong val = ref value[ix];
-            var rsp = val & mask;
 
-            val = ~(~mask ^ val);
-
-            return rsp != 0; // BTC
+            var btc = ComplementBit(ref val, offset);
+            return btc;
         }
 
         #endregion
@@ -342,7 +272,6 @@ namespace System
         /// Returns the population count (number of bits set) of a mask.
         /// </summary>
         /// <param name="value">The mask.</param>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static long PopCount(ReadOnlySpan<byte> value)
         {
             if (value.Length == 0)
@@ -364,7 +293,6 @@ namespace System
         /// Returns the population count (number of bits set) of a mask.
         /// </summary>
         /// <param name="value">The mask.</param>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static long PopCount(ReadOnlySpan<ushort> value)
         {
             if (value.Length == 0)
@@ -386,7 +314,6 @@ namespace System
         /// Returns the population count (number of bits set) of a mask.
         /// </summary>
         /// <param name="value">The mask.</param>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static long PopCount(ReadOnlySpan<uint> value)
         {
             if (value.Length == 0)
@@ -408,7 +335,6 @@ namespace System
         /// Returns the population count (number of bits set) of a mask.
         /// </summary>
         /// <param name="value">The mask.</param>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static long PopCount(ReadOnlySpan<ulong> value)
         {
             if (value.Length == 0)
@@ -434,7 +360,6 @@ namespace System
         /// Count the number of leading zero bits in a mask.
         /// </summary>
         /// <param name="value">The mask.</param>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static long LeadingZeros(ReadOnlySpan<byte> value)
         {
             if (value.Length == 0)
@@ -442,11 +367,8 @@ namespace System
 
             // TODO: Vectorize
 
-            var ix = 0;
+            int ix = 0;
             while (value[ix] == 0) ix++;
-
-            if (value[ix] == byte.MaxValue)
-                return 0;
 
             return 7 - FloorLog2Impl(value[ix]) + (ix << 3); // mul 8
         }
@@ -455,7 +377,6 @@ namespace System
         /// Count the number of leading one bits in a mask.
         /// </summary>
         /// <param name="value">The mask.</param>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static long LeadingOnes(ReadOnlySpan<byte> value)
         {
             if (value.Length == 0)
@@ -463,13 +384,10 @@ namespace System
 
             // TODO: Vectorize
 
-            var ix = 0;
+            int ix = 0;
             while (value[ix] == 0) ix++;
 
-            if (value[ix] == byte.MaxValue)
-                return 8;
-
-            // Negate mask but remember to truncate carry-bits
+            // Complement mask but remember to truncate carry-bits
             var val = (uint)(byte)~(uint)value[ix];
 
             return 7 - FloorLog2Impl(val) + (ix << 3); // mul 8
@@ -479,7 +397,6 @@ namespace System
         /// Count the number of leading zero bits in a mask.
         /// </summary>
         /// <param name="value">The mask.</param>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static long LeadingZeros(ReadOnlySpan<ushort> value)
         {
             if (value.Length == 0)
@@ -487,11 +404,8 @@ namespace System
 
             // TODO: Vectorize
 
-            var ix = 0;
+            int ix = 0;
             while (value[ix] == 0) ix++;
-
-            if (value[ix] == ushort.MaxValue)
-                return 0;
 
             return 15 - FloorLog2Impl(value[ix]) + (ix << 4); // mul 16
         }
@@ -500,7 +414,6 @@ namespace System
         /// Count the number of leading one bits in a mask.
         /// </summary>
         /// <param name="value">The mask.</param>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static long LeadingOnes(ReadOnlySpan<ushort> value)
         {
             if (value.Length == 0)
@@ -508,13 +421,10 @@ namespace System
 
             // TODO: Vectorize
 
-            var ix = 0;
+            int ix = 0;
             while (value[ix] == 0) ix++;
 
-            if (value[ix] == ushort.MaxValue)
-                return 16;
-
-            // Negate mask but remember to truncate carry-bits
+            // Complement mask but remember to truncate carry-bits
             var val = (uint)(ushort)~(uint)value[ix];
 
             return 15 - FloorLog2Impl(val) + (ix << 4); // mul 16
@@ -524,7 +434,6 @@ namespace System
         /// Count the number of leading zero bits in a mask.
         /// </summary>
         /// <param name="value">The mask.</param>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static long LeadingZeros(ReadOnlySpan<uint> value)
         {
             if (value.Length == 0)
@@ -532,11 +441,8 @@ namespace System
 
             // TODO: Vectorize
 
-            var ix = 0;
+            int ix = 0;
             while (value[ix] == 0) ix++;
-
-            if (value[ix] == uint.MaxValue)
-                return 0;
 
             return 31 - FloorLog2Impl(value[ix]) + (ix << 5); // mul 32
         }
@@ -545,7 +451,6 @@ namespace System
         /// Count the number of leading one bits in a mask.
         /// </summary>
         /// <param name="value">The mask.</param>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static long LeadingOnes(ReadOnlySpan<uint> value)
         {
             if (value.Length == 0)
@@ -553,13 +458,10 @@ namespace System
 
             // TODO: Vectorize
 
-            var ix = 0;
+            int ix = 0;
             while (value[ix] == 0) ix++;
 
-            if (value[ix] == uint.MaxValue)
-                return 32;
-
-            // Negate mask but remember to truncate carry-bits
+            // Complement mask but remember to truncate carry-bits
             var val = ~value[ix];
 
             return 31 - FloorLog2Impl(val) + (ix << 5); // mul 32
@@ -569,7 +471,6 @@ namespace System
         /// Count the number of leading zero bits in a mask.
         /// </summary>
         /// <param name="value">The mask.</param>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static long LeadingZeros(ReadOnlySpan<ulong> value)
         {
             if (value.Length == 0)
@@ -577,11 +478,8 @@ namespace System
 
             // TODO: Vectorize
 
-            var ix = 0;
+            int ix = 0;
             while (value[ix] == 0) ix++;
-
-            if (value[ix] == ulong.MaxValue)
-                return 0;
 
             return 63 - FloorLog2Impl(value[ix]) + (ix << 6); // mul 64
         }
@@ -590,7 +488,6 @@ namespace System
         /// Count the number of leading one bits in a mask.
         /// </summary>
         /// <param name="value">The mask.</param>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static long LeadingOnes(ReadOnlySpan<ulong> value)
         {
             if (value.Length == 0)
@@ -598,13 +495,10 @@ namespace System
 
             // TODO: Vectorize
 
-            var ix = 0;
+            int ix = 0;
             while (value[ix] == 0) ix++;
 
-            if (value[ix] == ulong.MaxValue)
-                return 64;
-
-            // Negate mask but remember to truncate carry-bits
+            // Complement mask but remember to truncate carry-bits
             var val = ~value[ix];
 
             return 63 - FloorLog2Impl(val) + (ix << 6); // mul 64
@@ -618,7 +512,6 @@ namespace System
         /// Count the number of zero trailing bits in a mask.
         /// </summary>
         /// <param name="value">The mask.</param>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static long TrailingZeros(ReadOnlySpan<byte> value)
         {
             if (value.Length == 0)
@@ -626,7 +519,7 @@ namespace System
 
             // TODO: Vectorize
 
-            var ix = 0;
+            int ix = 0;
             var last = value.Length - 1;
             while (value[last - ix] == 0) ix++;
 
@@ -637,7 +530,6 @@ namespace System
         /// Count the number of trailing one bits in a mask.
         /// </summary>
         /// <param name="value">The mask.</param>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static long TrailingOnes(ReadOnlySpan<byte> value)
         {
             if (value.Length == 0)
@@ -645,7 +537,7 @@ namespace System
 
             // TODO: Vectorize
 
-            var ix = 0;
+            int ix = 0;
             var last = value.Length - 1;
             while (value[last - ix] == 0) ix++;
 
@@ -656,7 +548,6 @@ namespace System
         /// Count the number of trailing zero bits in a mask.
         /// </summary>
         /// <param name="value">The mask.</param>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static long TrailingZeros(ReadOnlySpan<ushort> value)
         {
             if (value.Length == 0)
@@ -664,7 +555,7 @@ namespace System
 
             // TODO: Vectorize
 
-            var ix = 0;
+            int ix = 0;
             var last = value.Length - 1;
             while (value[last - ix] == 0) ix++;
 
@@ -675,7 +566,6 @@ namespace System
         /// Count the number of trailing one bits in a mask.
         /// </summary>
         /// <param name="value">The mask.</param>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static long TrailingOnes(ReadOnlySpan<ushort> value)
         {
             if (value.Length == 0)
@@ -683,7 +573,7 @@ namespace System
 
             // TODO: Vectorize
 
-            var ix = 0;
+            int ix = 0;
             var last = value.Length - 1;
             while (value[last - ix] == 0) ix++;
 
@@ -694,7 +584,6 @@ namespace System
         /// Count the number of trailing zero bits in a mask.
         /// </summary>
         /// <param name="value">The mask.</param>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static long TrailingZeros(ReadOnlySpan<uint> value)
         {
             if (value.Length == 0)
@@ -702,7 +591,7 @@ namespace System
 
             // TODO: Vectorize
 
-            var ix = 0;
+            int ix = 0;
             var last = value.Length - 1;
             while (value[last - ix] == 0) ix++;
 
@@ -713,7 +602,6 @@ namespace System
         /// Count the number of trailing one bits in a mask.
         /// </summary>
         /// <param name="value">The mask.</param>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static long TrailingOnes(ReadOnlySpan<uint> value)
         {
             if (value.Length == 0)
@@ -721,7 +609,7 @@ namespace System
 
             // TODO: Vectorize
 
-            var ix = 0;
+            int ix = 0;
             var last = value.Length - 1;
             while (value[last - ix] == 0) ix++;
 
@@ -732,7 +620,6 @@ namespace System
         /// Count the number of trailing zero bits in a mask.
         /// </summary>
         /// <param name="value">The mask.</param>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static long TrailingZeros(ReadOnlySpan<ulong> value)
         {
             if (value.Length == 0)
@@ -740,7 +627,7 @@ namespace System
 
             // TODO: Vectorize
 
-            var ix = 0;
+            int ix = 0;
             var last = value.Length - 1;
             while (value[last - ix] == 0) ix++;
 
@@ -751,7 +638,6 @@ namespace System
         /// Count the number of trailing one bits in a mask.
         /// </summary>
         /// <param name="value">The mask.</param>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static long TrailingOnes(ReadOnlySpan<ulong> value)
         {
             if (value.Length == 0)
@@ -759,7 +645,7 @@ namespace System
 
             // TODO: Vectorize
 
-            var ix = 0;
+            int ix = 0;
             var last = value.Length - 1;
             while (value[last - ix] == 0) ix++;
 

--- a/src/SourceCode.Clay.Buffers/BitOps.Span.cs
+++ b/src/SourceCode.Clay.Buffers/BitOps.Span.cs
@@ -1,10 +1,3 @@
-#region License
-
-// Copyright (c) K2 Workflow (SourceCode Technology Holdings Inc.). All rights reserved.
-// Licensed under the MIT License. See LICENSE file in the project root for full license information.
-
-#endregion
-
 using System;
 using System.Runtime.CompilerServices;
 

--- a/src/SourceCode.Clay.Buffers/BitOps.Span.cs
+++ b/src/SourceCode.Clay.Buffers/BitOps.Span.cs
@@ -1,7 +1,6 @@
-using System;
 using System.Runtime.CompilerServices;
 
-namespace SourceCode.Clay.Buffers
+namespace System
 {
     partial class BitOps // .Span
     {

--- a/src/SourceCode.Clay.Buffers/BitOps.Span.cs
+++ b/src/SourceCode.Clay.Buffers/BitOps.Span.cs
@@ -14,7 +14,7 @@ namespace System
         public static bool ExtractBit(ReadOnlySpan<byte> value, int offset)
         {
             int ix = offset >> 3; // div 8
-            if (ix >= value.Length) throw new ArgumentOutOfRangeException(nameof(offset));
+            if (ix < 0 || ix >= value.Length) throw new ArgumentOutOfRangeException(nameof(offset));
 
             var val = ExtractBit(value[ix], offset);
             return val;
@@ -28,7 +28,7 @@ namespace System
         public static bool ExtractBit(ReadOnlySpan<ushort> value, int offset)
         {
             int ix = offset >> 4; // div 16
-            if (ix >= value.Length) throw new ArgumentOutOfRangeException(nameof(offset));
+            if (ix < 0 || ix >= value.Length) throw new ArgumentOutOfRangeException(nameof(offset));
 
             var val = ExtractBit(value[ix], offset);
             return val;
@@ -42,7 +42,7 @@ namespace System
         public static bool ExtractBit(ReadOnlySpan<uint> value, int offset)
         {
             int ix = offset >> 5; // div 32
-            if (ix >= value.Length) throw new ArgumentOutOfRangeException(nameof(offset));
+            if (ix < 0 || ix >= value.Length) throw new ArgumentOutOfRangeException(nameof(offset));
 
             var val = ExtractBit(value[ix], offset);
             return val;
@@ -56,7 +56,7 @@ namespace System
         public static bool ExtractBit(ReadOnlySpan<ulong> value, int offset)
         {
             int ix = offset >> 6; // div 64
-            if (ix >= value.Length) throw new ArgumentOutOfRangeException(nameof(offset));
+            if (ix < 0 || ix >= value.Length) throw new ArgumentOutOfRangeException(nameof(offset));
 
             var val = ExtractBit(value[ix], offset);
             return val;
@@ -74,7 +74,7 @@ namespace System
         public static bool ClearBit(Span<byte> value, int offset)
         {
             var ix = offset >> 3; // div 8
-            if (ix >= value.Length) throw new ArgumentOutOfRangeException(nameof(offset));
+            if (ix < 0 || ix >= value.Length) throw new ArgumentOutOfRangeException(nameof(offset));
 
             ref byte val = ref value[ix];
 
@@ -90,7 +90,7 @@ namespace System
         public static bool ClearBit(Span<ushort> value, int offset)
         {
             var ix = offset >> 4; // div 16
-            if (ix >= value.Length) throw new ArgumentOutOfRangeException(nameof(offset));
+            if (ix < 0 || ix >= value.Length) throw new ArgumentOutOfRangeException(nameof(offset));
 
             ref ushort val = ref value[ix];
 
@@ -106,7 +106,7 @@ namespace System
         public static bool ClearBit(Span<uint> value, int offset)
         {
             var ix = offset >> 5; // div 32
-            if (ix >= value.Length) throw new ArgumentOutOfRangeException(nameof(offset));
+            if (ix < 0 || ix >= value.Length) throw new ArgumentOutOfRangeException(nameof(offset));
 
             ref uint val = ref value[ix];
 
@@ -122,7 +122,7 @@ namespace System
         public static bool ClearBit(Span<ulong> value, int offset)
         {
             var ix = offset >> 6; // div 64
-            if (ix >= value.Length) throw new ArgumentOutOfRangeException(nameof(offset));
+            if (ix < 0 || ix >= value.Length) throw new ArgumentOutOfRangeException(nameof(offset));
 
             ref ulong val = ref value[ix];
 
@@ -142,7 +142,7 @@ namespace System
         public static bool InsertBit(Span<byte> value, int offset)
         {
             var ix = offset >> 3; // div 8
-            if (ix >= value.Length) throw new ArgumentOutOfRangeException(nameof(offset));
+            if (ix < 0 || ix >= value.Length) throw new ArgumentOutOfRangeException(nameof(offset));
 
             ref byte val = ref value[ix];
 
@@ -158,7 +158,7 @@ namespace System
         public static bool InsertBit(Span<ushort> value, int offset)
         {
             var ix = offset >> 4; // div 16
-            if (ix >= value.Length) throw new ArgumentOutOfRangeException(nameof(offset));
+            if (ix < 0 || ix >= value.Length) throw new ArgumentOutOfRangeException(nameof(offset));
 
             ref ushort val = ref value[ix];
 
@@ -174,7 +174,7 @@ namespace System
         public static bool InsertBit(Span<uint> value, int offset)
         {
             var ix = offset >> 5; // div 32
-            if (ix >= value.Length) throw new ArgumentOutOfRangeException(nameof(offset));
+            if (ix < 0 || ix >= value.Length) throw new ArgumentOutOfRangeException(nameof(offset));
 
             ref uint val = ref value[ix];
 
@@ -190,7 +190,7 @@ namespace System
         public static bool InsertBit(Span<ulong> value, int offset)
         {
             var ix = offset >> 6; // div 64
-            if (ix >= value.Length) throw new ArgumentOutOfRangeException(nameof(offset));
+            if (ix < 0 || ix >= value.Length) throw new ArgumentOutOfRangeException(nameof(offset));
 
             ref ulong val = ref value[ix];
 
@@ -210,7 +210,7 @@ namespace System
         public static bool ComplementBit(Span<byte> value, int offset)
         {
             var ix = offset >> 3; // div 8
-            if (ix >= value.Length) throw new ArgumentOutOfRangeException(nameof(offset));
+            if (ix < 0 || ix >= value.Length) throw new ArgumentOutOfRangeException(nameof(offset));
 
             ref byte val = ref value[ix];
 
@@ -226,7 +226,7 @@ namespace System
         public static bool ComplementBit(Span<ushort> value, int offset)
         {
             var ix = offset >> 4; // div 16
-            if (ix >= value.Length) throw new ArgumentOutOfRangeException(nameof(offset));
+            if (ix < 0 || ix >= value.Length) throw new ArgumentOutOfRangeException(nameof(offset));
 
             ref ushort val = ref value[ix];
 
@@ -242,7 +242,7 @@ namespace System
         public static bool ComplementBit(Span<uint> value, int offset)
         {
             var ix = offset >> 5; // div 32
-            if (ix >= value.Length) throw new ArgumentOutOfRangeException(nameof(offset));
+            if (ix < 0 || ix >= value.Length) throw new ArgumentOutOfRangeException(nameof(offset));
 
             ref uint val = ref value[ix];
 
@@ -258,7 +258,7 @@ namespace System
         public static bool ComplementBit(Span<ulong> value, int offset)
         {
             var ix = offset >> 6; // div 64
-            if (ix >= value.Length) throw new ArgumentOutOfRangeException(nameof(offset));
+            if (ix < 0 || ix >= value.Length) throw new ArgumentOutOfRangeException(nameof(offset));
 
             ref ulong val = ref value[ix];
 

--- a/src/SourceCode.Clay.Buffers/BitOps.cs
+++ b/src/SourceCode.Clay.Buffers/BitOps.cs
@@ -16,7 +16,7 @@ namespace System
         /// <param name="value">The mask.</param>
         /// <param name="offset">The ordinal position of the bit to read.</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool ExtractBit(byte value, byte offset)
+        public static bool ExtractBit(byte value, int offset)
         {
             var shft = offset & 7; // mod 8: design choice ignores out-of-range values
             var mask = 1U << shft;
@@ -30,7 +30,7 @@ namespace System
         /// <param name="value">The mask.</param>
         /// <param name="offset">The ordinal position of the bit to read.</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool ExtractBit(ushort value, byte offset)
+        public static bool ExtractBit(ushort value, int offset)
         {
             var shft = offset & 15; // mod 16: design choice ignores out-of-range values
             var mask = 1U << shft;
@@ -44,7 +44,7 @@ namespace System
         /// <param name="value">The mask.</param>
         /// <param name="offset">The ordinal position of the bit to read.</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool ExtractBit(uint value, byte offset)
+        public static bool ExtractBit(uint value, int offset)
         {
             var mask = 1U << offset; // uint.shift is natively mod-32
 
@@ -57,7 +57,7 @@ namespace System
         /// <param name="value">The mask.</param>
         /// <param name="offset">The ordinal position of the bit to read.</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool ExtractBit(ulong value, byte offset)
+        public static bool ExtractBit(ulong value, int offset)
         {
             var mask = 1UL << offset; // ulong.shift is natively mod-64
 
@@ -74,7 +74,7 @@ namespace System
         /// <param name="value">The mask.</param>
         /// <param name="offset">The ordinal position of the bit to clear.</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static byte ClearBit(byte value, byte offset)
+        public static byte ClearBit(byte value, int offset)
         {
             var shft = offset & 7; // mod 8: design choice ignores out-of-range values
             var mask = 1U << shft;
@@ -88,7 +88,7 @@ namespace System
         /// <param name="value">The mask.</param>
         /// <param name="offset">The ordinal position of the bit to clear.</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static ushort ClearBit(ushort value, byte offset)
+        public static ushort ClearBit(ushort value, int offset)
         {
             var shft = offset & 15; // mod 16: design choice ignores out-of-range values
             var mask = 1U << shft;
@@ -102,7 +102,7 @@ namespace System
         /// <param name="value">The mask.</param>
         /// <param name="offset">The ordinal position of the bit to clear.</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static uint ClearBit(uint value, byte offset)
+        public static uint ClearBit(uint value, int offset)
         {
             var mask = 1U << offset; // uint.shift is natively mod-32
 
@@ -115,7 +115,7 @@ namespace System
         /// <param name="value">The mask.</param>
         /// <param name="offset">The ordinal position of the bit to clear.</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static ulong ClearBit(ulong value, byte offset)
+        public static ulong ClearBit(ulong value, int offset)
         {
             var mask = 1UL << offset; // ulong.shift is natively mod-64
 
@@ -132,12 +132,12 @@ namespace System
         /// <param name="value">The mask.</param>
         /// <param name="offset">The ordinal position of the bit to clear.</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool ClearBit(ref byte value, byte offset)
+        public static bool ClearBit(ref byte value, int offset)
         {
             var shft = offset & 7; // mod 8: design choice ignores out-of-range values
             var mask = 1U << shft;
-            var rsp = value & mask;
 
+            var rsp = value & mask;
             value = (byte)(value & ~mask);
 
             return rsp != 0; // BTR
@@ -149,12 +149,12 @@ namespace System
         /// <param name="value">The mask.</param>
         /// <param name="offset">The ordinal position of the bit to clear.</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool ClearBit(ref ushort value, byte offset)
+        public static bool ClearBit(ref ushort value, int offset)
         {
             var shft = offset & 15; // mod 16: design choice ignores out-of-range values
             var mask = 1U << shft;
-            var rsp = value & mask;
 
+            var rsp = value & mask;
             value = (ushort)(value & ~mask);
 
             return rsp != 0; // BTR
@@ -166,11 +166,11 @@ namespace System
         /// <param name="value">The mask.</param>
         /// <param name="offset">The ordinal position of the bit to clear.</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool ClearBit(ref uint value, byte offset)
+        public static bool ClearBit(ref uint value, int offset)
         {
             var mask = 1U << offset; // uint.shift is natively mod-32
-            var rsp = value & mask;
 
+            var rsp = value & mask;
             value = value & ~mask;
 
             return rsp != 0; // BTR
@@ -182,11 +182,11 @@ namespace System
         /// <param name="value">The mask.</param>
         /// <param name="offset">The ordinal position of the bit to clear.</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool ClearBit(ref ulong value, byte offset)
+        public static bool ClearBit(ref ulong value, int offset)
         {
             var mask = 1UL << offset; // ulong.shift is natively mod-64
-            var rsp = value & mask;
 
+            var rsp = value & mask;
             value = value & ~mask;
 
             return rsp != 0; // BTR
@@ -202,7 +202,7 @@ namespace System
         /// <param name="value">The mask.</param>
         /// <param name="offset">The ordinal position of the bit to write.</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static byte InsertBit(byte value, byte offset)
+        public static byte InsertBit(byte value, int offset)
         {
             var shft = offset & 7; // mod 8: design choice ignores out-of-range values
             var mask = 1U << shft;
@@ -216,7 +216,7 @@ namespace System
         /// <param name="value">The mask.</param>
         /// <param name="offset">The ordinal position of the bit to write.</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static ushort InsertBit(ushort value, byte offset)
+        public static ushort InsertBit(ushort value, int offset)
         {
             var shft = offset & 15; // mod 16: design choice ignores out-of-range values
             var mask = 1U << shft;
@@ -230,7 +230,7 @@ namespace System
         /// <param name="value">The mask.</param>
         /// <param name="offset">The ordinal position of the bit to write.</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static uint InsertBit(uint value, byte offset)
+        public static uint InsertBit(uint value, int offset)
         {
             var mask = 1U << offset; // uint.shift is natively mod-32
 
@@ -243,7 +243,7 @@ namespace System
         /// <param name="value">The mask.</param>
         /// <param name="offset">The ordinal position of the bit to write.</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static ulong InsertBit(ulong value, byte offset)
+        public static ulong InsertBit(ulong value, int offset)
         {
             var mask = 1UL << offset; // ulong.shift is natively mod-64
 
@@ -260,12 +260,12 @@ namespace System
         /// <param name="value">The mask.</param>
         /// <param name="offset">The ordinal position of the bit to write.</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool InsertBit(ref byte value, byte offset)
+        public static bool InsertBit(ref byte value, int offset)
         {
             var shft = offset & 7; // mod 8: design choice ignores out-of-range values
             var mask = 1U << shft;
-            var rsp = value & mask;
             
+            var rsp = value & mask;
             value = (byte)(value | mask);
 
             return rsp != 0; // BTS
@@ -277,12 +277,12 @@ namespace System
         /// <param name="value">The mask.</param>
         /// <param name="offset">The ordinal position of the bit to write.</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool InsertBit(ref ushort value, byte offset)
+        public static bool InsertBit(ref ushort value, int offset)
         {
             var shft = offset & 15; // mod 16: design choice ignores out-of-range values
             var mask = 1U << shft;
-            var rsp = value & mask;
 
+            var rsp = value & mask;
             value = (ushort)(value | mask);
 
             return rsp != 0; // BTS
@@ -294,11 +294,11 @@ namespace System
         /// <param name="value">The mask.</param>
         /// <param name="offset">The ordinal position of the bit to write.</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool InsertBit(ref uint value, byte offset)
+        public static bool InsertBit(ref uint value, int offset)
         {
             var mask = 1U << offset; // uint.shift is natively mod-32
-            var rsp = value & mask;
 
+            var rsp = value & mask;
             value = value | mask;
 
             return rsp != 0; // BTS
@@ -310,11 +310,11 @@ namespace System
         /// <param name="value">The mask.</param>
         /// <param name="offset">The ordinal position of the bit to write.</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool InsertBit(ref ulong value, byte offset)
+        public static bool InsertBit(ref ulong value, int offset)
         {
             var mask = 1UL << offset; // ulong.shift is natively mod-64
-            var rsp = value & mask;
 
+            var rsp = value & mask;
             value = value | mask;
 
             return rsp != 0; // BTS
@@ -324,7 +324,7 @@ namespace System
 
         #region ComplementBit (Scalar)
 
-        // Truth table (1):
+        // Truth table (1)
         // v   m  | ~m  ^v  ~
         // 00  01 | 10  10  01
         // 01  01 | 10  11  00
@@ -342,7 +342,7 @@ namespace System
         /// <param name="value">The mask.</param>
         /// <param name="offset">The ordinal position of the bit to complement.</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static byte ComplementBit(byte value, byte offset)
+        public static byte ComplementBit(byte value, int offset)
         {
             var shft = offset & 7; // mod 8: design choice ignores out-of-range values
             var mask = 1U << shft;
@@ -358,7 +358,7 @@ namespace System
         /// <param name="value">The mask.</param>
         /// <param name="offset">The ordinal position of the bit to complement.</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static ushort ComplementBit(ushort value, byte offset)
+        public static ushort ComplementBit(ushort value, int offset)
         {
             var shft = offset & 15; // mod 16: design choice ignores out-of-range values
             var mask = 1U << shft;
@@ -374,7 +374,7 @@ namespace System
         /// <param name="value">The mask.</param>
         /// <param name="offset">The ordinal position of the bit to complement.</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static uint ComplementBit(uint value, byte offset)
+        public static uint ComplementBit(uint value, int offset)
         {            
             var mask = 1U << offset; // uint.shift is natively mod-32
 
@@ -389,7 +389,7 @@ namespace System
         /// <param name="value">The mask.</param>
         /// <param name="offset">The ordinal position of the bit to complement.</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static ulong ComplementBit(ulong value, byte offset)
+        public static ulong ComplementBit(ulong value, int offset)
         {
             var mask = 1UL << offset; // ulong.shift is natively mod-64
 
@@ -408,13 +408,13 @@ namespace System
         /// <param name="value">The mask.</param>
         /// <param name="offset">The ordinal position of the bit to complement.</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool ComplementBit(ref byte value, byte offset)
+        public static bool ComplementBit(ref byte value, int offset)
         {
             var shft = offset & 7; // mod 8: design choice ignores out-of-range values
             var mask = 1U << shft;
-            var rsp = value & mask;
 
             // See Truth table (1) above
+            var rsp = value & mask;
             value = (byte)~(~mask ^ value);
 
             return rsp != 0; // BTC
@@ -426,13 +426,13 @@ namespace System
         /// <param name="value">The mask.</param>
         /// <param name="offset">The ordinal position of the bit to complement.</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool ComplementBit(ref ushort value, byte offset)
+        public static bool ComplementBit(ref ushort value, int offset)
         {
             var shft = offset & 15; // mod 16: design choice ignores out-of-range values
             var mask = 1U << shft;
-            var rsp = value & mask;
 
             // See Truth table (1) above
+            var rsp = value & mask;
             value = (ushort)~(~mask ^ value);
 
             return rsp != 0; // BTC
@@ -444,12 +444,12 @@ namespace System
         /// <param name="value">The mask.</param>
         /// <param name="offset">The ordinal position of the bit to complement.</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool ComplementBit(ref uint value, byte offset)
+        public static bool ComplementBit(ref uint value, int offset)
         {
             var mask = 1U << offset; // uint.shift is natively mod-32
-            var rsp = value & mask;
 
             // See Truth table (1) above
+            var rsp = value & mask;
             value = ~(~mask ^ value);
 
             return rsp != 0; // BTC
@@ -461,12 +461,12 @@ namespace System
         /// <param name="value">The mask.</param>
         /// <param name="offset">The ordinal position of the bit to complement.</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool ComplementBit(ref ulong value, byte offset)
+        public static bool ComplementBit(ref ulong value, int offset)
         {
             var mask = 1UL << offset; // ulong.shift is natively mod-64
-            var rsp = value & mask;
 
             // See Truth table (1) above
+            var rsp = value & mask;
             value = ~(~mask ^ value);
 
             return rsp != 0; // BTC
@@ -483,7 +483,7 @@ namespace System
         /// <param name="offset">The number of bits to rotate by.</param>
         /// <returns>The rotated value.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static byte RotateLeft(byte value, byte offset)
+        public static byte RotateLeft(byte value, int offset)
         {
             var shft = offset & 7; // mod 8 safely ignores boundary checks
             var val = (uint)value;
@@ -499,7 +499,7 @@ namespace System
         /// <param name="offset">The number of bits to rotate by.</param>
         /// <returns>The rotated value.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static byte RotateRight(byte value, byte offset)
+        public static byte RotateRight(byte value, int offset)
         {
             var shft = offset & 7; // mod 8 safely ignores boundary checks
             var val = (uint)value;
@@ -515,7 +515,7 @@ namespace System
         /// <param name="offset">The number of bits to rotate by.</param>
         /// <returns>The rotated value.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static ushort RotateLeft(ushort value, byte offset)
+        public static ushort RotateLeft(ushort value, int offset)
         {
             var shft = offset & 15; // mod 16 safely ignores boundary checks
             var val = (uint)value;
@@ -531,7 +531,7 @@ namespace System
         /// <param name="offset">The number of bits to rotate by.</param>
         /// <returns>The rotated value.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static ushort RotateRight(ushort value, byte offset)
+        public static ushort RotateRight(ushort value, int offset)
         {
             var shft = offset & 15; // mod 16 safely ignores boundary checks
             var val = (uint)value;
@@ -547,7 +547,7 @@ namespace System
         /// <param name="offset">The number of bits to rotate by.</param>
         /// <returns>The rotated value.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static uint RotateLeft(uint value, byte offset)
+        public static uint RotateLeft(uint value, int offset)
         {
             // uint.shift is natively mod-32, but we need the subtraction below
             var shft = offset & 31;
@@ -564,7 +564,7 @@ namespace System
         /// <param name="offset">The number of bits to rotate by.</param>
         /// <returns>The rotated value.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static uint RotateRight(uint value, byte offset)
+        public static uint RotateRight(uint value, int offset)
         {
             // uint.shift is natively mod-32, but we need the subtraction below
             var shft = offset & 31;
@@ -581,7 +581,7 @@ namespace System
         /// <param name="offset">The number of bits to rotate by.</param>
         /// <returns>The rotated value.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static ulong RotateLeft(ulong value, byte offset)
+        public static ulong RotateLeft(ulong value, int offset)
         {
             // ulong.shift is natively mod-64, but we need the subtraction below
             var shft = offset & 63;
@@ -598,7 +598,7 @@ namespace System
         /// <param name="offset">The number of bits to rotate by.</param>
         /// <returns>The rotated value.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static ulong RotateRight(ulong value, byte offset)
+        public static ulong RotateRight(ulong value, int offset)
         {
             // ulong.shift is natively mod-64, but we need the subtraction below
             var shft = offset & 63;

--- a/src/SourceCode.Clay.Buffers/BitOps.cs
+++ b/src/SourceCode.Clay.Buffers/BitOps.cs
@@ -1,10 +1,3 @@
-#region License
-
-// Copyright (c) K2 Workflow (SourceCode Technology Holdings Inc.). All rights reserved.
-// Licensed under the MIT License. See LICENSE file in the project root for full license information.
-
-#endregion
-
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
 

--- a/src/SourceCode.Clay.Buffers/BitOps.cs
+++ b/src/SourceCode.Clay.Buffers/BitOps.cs
@@ -53,8 +53,7 @@ namespace SourceCode.Clay.Buffers
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool ExtractBit(uint value, byte offset)
         {
-            var shft = offset & 31; // mod 32: design choice ignores out-of-range values
-            var mask = 1U << shft;
+            var mask = 1U << offset; // uint.shift is natively mod-32
 
             return (value & mask) != 0;
         }
@@ -67,8 +66,7 @@ namespace SourceCode.Clay.Buffers
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool ExtractBit(ulong value, byte offset)
         {
-            var shft = offset & 63; // mod 64: design choice ignores out-of-range values
-            var mask = 1UL << shft;
+            var mask = 1UL << offset; // ulong.shift is natively mod-64
 
             return (value & mask) != 0;
         }
@@ -113,8 +111,7 @@ namespace SourceCode.Clay.Buffers
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static uint ClearBit(uint value, byte offset)
         {
-            var shft = offset & 31; // mod 32: design choice ignores out-of-range values
-            var mask = 1U << shft;
+            var mask = 1U << offset; // uint.shift is natively mod-32
 
             return value & ~mask;
         }
@@ -127,8 +124,7 @@ namespace SourceCode.Clay.Buffers
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static ulong ClearBit(ulong value, byte offset)
         {
-            var shft = offset & 63; // mod 64: design choice ignores out-of-range values
-            var mask = 1UL << shft;
+            var mask = 1UL << offset; // ulong.shift is natively mod-64
 
             return value & ~mask;
         }
@@ -179,8 +175,7 @@ namespace SourceCode.Clay.Buffers
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool ClearBit(ref uint value, byte offset)
         {
-            var shft = offset & 31; // mod 32: design choice ignores out-of-range values
-            var mask = 1U << shft;
+            var mask = 1U << offset; // uint.shift is natively mod-32
             var rsp = value & mask;
 
             value = value & ~mask;
@@ -196,8 +191,7 @@ namespace SourceCode.Clay.Buffers
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool ClearBit(ref ulong value, byte offset)
         {
-            var shft = offset & 63; // mod 64: design choice ignores out-of-range values
-            var mask = 1UL << shft;
+            var mask = 1UL << offset; // ulong.shift is natively mod-64
             var rsp = value & mask;
 
             value = value & ~mask;
@@ -245,8 +239,7 @@ namespace SourceCode.Clay.Buffers
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static uint InsertBit(uint value, byte offset)
         {
-            var shft = offset & 31; // mod 32: design choice ignores out-of-range values
-            var mask = 1U << shft;
+            var mask = 1U << offset; // uint.shift is natively mod-32
 
             return value | mask;
         }
@@ -259,8 +252,7 @@ namespace SourceCode.Clay.Buffers
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static ulong InsertBit(ulong value, byte offset)
         {
-            var shft = offset & 63; // mod 64: design choice ignores out-of-range values
-            var mask = 1UL << shft;
+            var mask = 1UL << offset; // ulong.shift is natively mod-64
 
             return value | mask;
         }
@@ -311,8 +303,7 @@ namespace SourceCode.Clay.Buffers
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool InsertBit(ref uint value, byte offset)
         {
-            var shft = offset & 31; // mod 32: design choice ignores out-of-range values
-            var mask = 1U << shft;
+            var mask = 1U << offset; // uint.shift is natively mod-32
             var rsp = value & mask;
 
             value = value | mask;
@@ -328,8 +319,7 @@ namespace SourceCode.Clay.Buffers
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool InsertBit(ref ulong value, byte offset)
         {
-            var shft = offset & 63; // mod 64: design choice ignores out-of-range values
-            var mask = 1UL << shft;
+            var mask = 1UL << offset; // ulong.shift is natively mod-64
             var rsp = value & mask;
 
             value = value | mask;
@@ -392,9 +382,8 @@ namespace SourceCode.Clay.Buffers
         /// <param name="offset">The ordinal position of the bit to complement.</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static uint ComplementBit(uint value, byte offset)
-        {
-            var shft = offset & 31; // mod 32: design choice ignores out-of-range values
-            var mask = 1U << shft;
+        {            
+            var mask = 1U << offset; // uint.shift is natively mod-32
 
             // See Truth table (1) above
             var val = ~(~mask ^ value);
@@ -409,8 +398,7 @@ namespace SourceCode.Clay.Buffers
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static ulong ComplementBit(ulong value, byte offset)
         {
-            var shft = offset & 63; // mod 64: design choice ignores out-of-range values
-            var mask = 1UL << shft;
+            var mask = 1UL << offset; // ulong.shift is natively mod-64
 
             // See Truth table (1) above
             var val = ~(~mask ^ value);
@@ -465,8 +453,7 @@ namespace SourceCode.Clay.Buffers
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool ComplementBit(ref uint value, byte offset)
         {
-            var shft = offset & 31; // mod 32: design choice ignores out-of-range values
-            var mask = 1U << shft;
+            var mask = 1U << offset; // uint.shift is natively mod-32
             var rsp = value & mask;
 
             // See Truth table (1) above
@@ -483,8 +470,7 @@ namespace SourceCode.Clay.Buffers
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool ComplementBit(ref ulong value, byte offset)
         {
-            var shft = offset & 63; // mod 64: design choice ignores out-of-range values
-            var mask = 1UL << shft;
+            var mask = 1UL << offset; // ulong.shift is natively mod-64
             var rsp = value & mask;
 
             // See Truth table (1) above
@@ -570,7 +556,8 @@ namespace SourceCode.Clay.Buffers
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static uint RotateLeft(uint value, byte offset)
         {
-            var shft = offset & 31; // mod 32 safely ignores boundary checks
+            // uint.shift is natively mod-32, but we need the subtraction below
+            var shft = offset & 31;
 
             // Will compile to instrinsic if pattern complies (uint/ulong):
             // https://github.com/dotnet/coreclr/pull/1830
@@ -586,7 +573,8 @@ namespace SourceCode.Clay.Buffers
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static uint RotateRight(uint value, byte offset)
         {
-            var shft = offset & 31; // mod 32 safely ignores boundary checks
+            // uint.shift is natively mod-32, but we need the subtraction below
+            var shft = offset & 31;
 
             // Will compile to instrinsic if pattern complies (uint/ulong):
             // https://github.com/dotnet/coreclr/pull/1830
@@ -602,7 +590,8 @@ namespace SourceCode.Clay.Buffers
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static ulong RotateLeft(ulong value, byte offset)
         {
-            var shft = offset & 63; // mod 64 safely ignores boundary checks
+            // ulong.shift is natively mod-64, but we need the subtraction below
+            var shft = offset & 63;
 
             // Will compile to instrinsic if pattern complies (uint/ulong):
             // https://github.com/dotnet/coreclr/pull/1830
@@ -618,7 +607,8 @@ namespace SourceCode.Clay.Buffers
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static ulong RotateRight(ulong value, byte offset)
         {
-            var shft = offset & 63; // mod 64 safely ignores boundary checks
+            // ulong.shift is natively mod-64, but we need the subtraction below
+            var shft = offset & 63;
 
             // Will compile to instrinsic if pattern complies (uint/ulong):
             // https://github.com/dotnet/coreclr/pull/1830

--- a/src/SourceCode.Clay.Buffers/BitOps.cs
+++ b/src/SourceCode.Clay.Buffers/BitOps.cs
@@ -1,7 +1,7 @@
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
 
-namespace SourceCode.Clay.Buffers
+namespace System
 {
     /// <summary>
     /// Represents additional blit methods.

--- a/src/SourceCode.Clay.Buffers/BitOps.cs
+++ b/src/SourceCode.Clay.Buffers/BitOps.cs
@@ -3,6 +3,8 @@ using System.Runtime.CompilerServices;
 
 namespace System
 {
+#pragma warning disable IDE0007 // Use implicit type
+
     /// <summary>
     /// Represents additional blit methods.
     /// </summary>
@@ -1116,4 +1118,6 @@ namespace System
 
         #endregion
     }
+
+#pragma warning restore IDE0007 // Use implicit type
 }

--- a/src/SourceCode.Clay.Buffers/BitOps.cs
+++ b/src/SourceCode.Clay.Buffers/BitOps.cs
@@ -10,16 +10,24 @@ namespace System
     {
         #region ExtractBit
 
+        // For bitlength N, it is conventional to treat N as congruent modulo-N 
+        // under the shift operation.
+        // So for uint, 1 << 33 == 1 << 1, and likewise 1 << -46 == 1 << +18.
+        // Note -46 % 32 == -14. But -46 & 31 (0011_1111) == +18. So we use & not %.
+        // Software & hardware intrinsics already do this for uint/ulong, but
+        // we need to emulate for byte/ushort.
+
         /// <summary>
         /// Reads whether the specified bit in a mask is set.
         /// </summary>
         /// <param name="value">The mask.</param>
-        /// <param name="offset">The ordinal position of the bit to read.</param>
+        /// <param name="offset">The ordinal position of the bit to read.
+        /// Any value outside the range [0..7] is treated as congruent mod 8.</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool ExtractBit(byte value, int offset)
         {
-            var shft = offset & 7; // mod 8: design choice ignores out-of-range values
-            var mask = 1U << shft;
+            int shft = offset & 7;
+            uint mask = 1U << shft;
 
             return (value & mask) != 0;
         }
@@ -28,12 +36,13 @@ namespace System
         /// Reads whether the specified bit in a mask is set.
         /// </summary>
         /// <param name="value">The mask.</param>
-        /// <param name="offset">The ordinal position of the bit to read.</param>
+        /// <param name="offset">The ordinal position of the bit to read.
+        /// Any value outside the range [0..15] is treated as congruent mod 16.</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool ExtractBit(ushort value, int offset)
         {
-            var shft = offset & 15; // mod 16: design choice ignores out-of-range values
-            var mask = 1U << shft;
+            int shft = offset & 15;
+            uint mask = 1U << shft;
 
             return (value & mask) != 0;
         }
@@ -42,11 +51,12 @@ namespace System
         /// Reads whether the specified bit in a mask is set.
         /// </summary>
         /// <param name="value">The mask.</param>
-        /// <param name="offset">The ordinal position of the bit to read.</param>
+        /// <param name="offset">The ordinal position of the bit to read.
+        /// Any value outside the range [0..31] is treated as congruent mod 32.</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool ExtractBit(uint value, int offset)
         {
-            var mask = 1U << offset; // uint.shift is natively mod-32
+            uint mask = 1U << offset;
 
             return (value & mask) != 0;
         }
@@ -55,11 +65,12 @@ namespace System
         /// Reads whether the specified bit in a mask is set.
         /// </summary>
         /// <param name="value">The mask.</param>
-        /// <param name="offset">The ordinal position of the bit to read.</param>
+        /// <param name="offset">The ordinal position of the bit to read.
+        /// Any value outside the range [0..63] is treated as congruent mod 63.</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool ExtractBit(ulong value, int offset)
         {
-            var mask = 1UL << offset; // ulong.shift is natively mod-64
+            ulong mask = 1UL << offset;
 
             return (value & mask) != 0;
         }
@@ -72,12 +83,13 @@ namespace System
         /// Clears the specified bit in a mask and returns the new value.
         /// </summary>
         /// <param name="value">The mask.</param>
-        /// <param name="offset">The ordinal position of the bit to clear.</param>
+        /// <param name="offset">The ordinal position of the bit to clear.
+        /// Any value outside the range [0..7] is treated as congruent mod 8.</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static byte ClearBit(byte value, int offset)
         {
-            var shft = offset & 7; // mod 8: design choice ignores out-of-range values
-            var mask = 1U << shft;
+            int shft = offset & 7;
+            uint mask = 1U << shft;
 
             return (byte)(value & ~mask);
         }
@@ -86,12 +98,13 @@ namespace System
         /// Clears the specified bit in a mask and returns the new value.
         /// </summary>
         /// <param name="value">The mask.</param>
-        /// <param name="offset">The ordinal position of the bit to clear.</param>
+        /// <param name="offset">The ordinal position of the bit to clear.
+        /// Any value outside the range [0..15] is treated as congruent mod 16.</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static ushort ClearBit(ushort value, int offset)
         {
-            var shft = offset & 15; // mod 16: design choice ignores out-of-range values
-            var mask = 1U << shft;
+            int shft = offset & 15;
+            uint mask = 1U << shft;
 
             return (ushort)(value & ~mask);
         }
@@ -100,11 +113,12 @@ namespace System
         /// Clears the specified bit in a mask and returns the new value.
         /// </summary>
         /// <param name="value">The mask.</param>
-        /// <param name="offset">The ordinal position of the bit to clear.</param>
+        /// <param name="offset">The ordinal position of the bit to clear.
+        /// Any value outside the range [0..31] is treated as congruent mod 32.</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static uint ClearBit(uint value, int offset)
         {
-            var mask = 1U << offset; // uint.shift is natively mod-32
+            uint mask = 1U << offset;
 
             return value & ~mask;
         }
@@ -113,11 +127,12 @@ namespace System
         /// Clears the specified bit in a mask and returns the new value.
         /// </summary>
         /// <param name="value">The mask.</param>
-        /// <param name="offset">The ordinal position of the bit to clear.</param>
+        /// <param name="offset">The ordinal position of the bit to clear.
+        /// Any value outside the range [0..63] is treated as congruent mod 64.</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static ulong ClearBit(ulong value, int offset)
         {
-            var mask = 1UL << offset; // ulong.shift is natively mod-64
+            ulong mask = 1UL << offset;
 
             return value & ~mask;
         }
@@ -130,66 +145,70 @@ namespace System
         /// Clears the specified bit in a mask and returns whether it was originally set.
         /// </summary>
         /// <param name="value">The mask.</param>
-        /// <param name="offset">The ordinal position of the bit to clear.</param>
+        /// <param name="offset">The ordinal position of the bit to clear.
+        /// Any value outside the range [0..7] is treated as congruent mod 8.</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool ClearBit(ref byte value, int offset)
         {
-            var shft = offset & 7; // mod 8: design choice ignores out-of-range values
-            var mask = 1U << shft;
+            int shft = offset & 7;
+            uint mask = 1U << shft;
 
-            var rsp = value & mask;
+            uint btr = value & mask;
             value = (byte)(value & ~mask);
 
-            return rsp != 0; // BTR
+            return btr != 0;
         }
 
         /// <summary>
         /// Clears the specified bit in a mask and returns whether it was originally set.
         /// </summary>
         /// <param name="value">The mask.</param>
-        /// <param name="offset">The ordinal position of the bit to clear.</param>
+        /// <param name="offset">The ordinal position of the bit to clear.
+        /// Any value outside the range [0..15] is treated as congruent mod 16.</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool ClearBit(ref ushort value, int offset)
         {
-            var shft = offset & 15; // mod 16: design choice ignores out-of-range values
-            var mask = 1U << shft;
+            int shft = offset & 15;
+            uint mask = 1U << shft;
 
-            var rsp = value & mask;
+            uint btr = value & mask;
             value = (ushort)(value & ~mask);
 
-            return rsp != 0; // BTR
+            return btr != 0;
         }
 
         /// <summary>
         /// Clears the specified bit in a mask and returns whether it was originally set.
         /// </summary>
         /// <param name="value">The mask.</param>
-        /// <param name="offset">The ordinal position of the bit to clear.</param>
+        /// <param name="offset">The ordinal position of the bit to clear.
+        /// Any value outside the range [0..31] is treated as congruent mod 32.</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool ClearBit(ref uint value, int offset)
         {
-            var mask = 1U << offset; // uint.shift is natively mod-32
+            uint mask = 1U << offset;
 
-            var rsp = value & mask;
+            uint btr = value & mask;
             value = value & ~mask;
 
-            return rsp != 0; // BTR
+            return btr != 0;
         }
 
         /// <summary>
         /// Clears the specified bit in a mask and returns whether it was originally set.
         /// </summary>
         /// <param name="value">The mask.</param>
-        /// <param name="offset">The ordinal position of the bit to clear.</param>
+        /// <param name="offset">The ordinal position of the bit to clear.
+        /// Any value outside the range [0..63] is treated as congruent mod 64.</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool ClearBit(ref ulong value, int offset)
         {
-            var mask = 1UL << offset; // ulong.shift is natively mod-64
+            ulong mask = 1UL << offset;
 
-            var rsp = value & mask;
+            ulong btr = value & mask;
             value = value & ~mask;
 
-            return rsp != 0; // BTR
+            return btr != 0;
         }
 
         #endregion
@@ -200,12 +219,13 @@ namespace System
         /// Sets the specified bit in a mask and returns the new value.
         /// </summary>
         /// <param name="value">The mask.</param>
-        /// <param name="offset">The ordinal position of the bit to write.</param>
+        /// <param name="offset">The ordinal position of the bit to write.
+        /// Any value outside the range [0..7] is treated as congruent mod 8.</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static byte InsertBit(byte value, int offset)
         {
-            var shft = offset & 7; // mod 8: design choice ignores out-of-range values
-            var mask = 1U << shft;
+            int shft = offset & 7;
+            uint mask = 1U << shft;
 
             return (byte)(value | mask);
         }
@@ -214,12 +234,13 @@ namespace System
         /// Sets the specified bit in a mask and returns the new value.
         /// </summary>
         /// <param name="value">The mask.</param>
-        /// <param name="offset">The ordinal position of the bit to write.</param>
+        /// <param name="offset">The ordinal position of the bit to write.
+        /// Any value outside the range [0..15] is treated as congruent mod 32.</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static ushort InsertBit(ushort value, int offset)
         {
-            var shft = offset & 15; // mod 16: design choice ignores out-of-range values
-            var mask = 1U << shft;
+            int shft = offset & 15;
+            uint mask = 1U << shft;
 
             return (ushort)(value | mask);
         }
@@ -228,11 +249,12 @@ namespace System
         /// Sets the specified bit in a mask and returns the new value.
         /// </summary>
         /// <param name="value">The mask.</param>
-        /// <param name="offset">The ordinal position of the bit to write.</param>
+        /// <param name="offset">The ordinal position of the bit to write.
+        /// Any value outside the range [0..31] is treated as congruent mod 32.</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static uint InsertBit(uint value, int offset)
         {
-            var mask = 1U << offset; // uint.shift is natively mod-32
+            uint mask = 1U << offset;
 
             return value | mask;
         }
@@ -241,11 +263,12 @@ namespace System
         /// Sets the specified bit in a mask and returns the new value.
         /// </summary>
         /// <param name="value">The mask.</param>
-        /// <param name="offset">The ordinal position of the bit to write.</param>
+        /// <param name="offset">The ordinal position of the bit to write.
+        /// Any value outside the range [0..63] is treated as congruent mod 64.</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static ulong InsertBit(ulong value, int offset)
         {
-            var mask = 1UL << offset; // ulong.shift is natively mod-64
+            ulong mask = 1UL << offset;
 
             return value | mask;
         }
@@ -258,66 +281,70 @@ namespace System
         /// Sets the specified bit in a mask and returns whether it was originally set.
         /// </summary>
         /// <param name="value">The mask.</param>
-        /// <param name="offset">The ordinal position of the bit to write.</param>
+        /// <param name="offset">The ordinal position of the bit to write.
+        /// Any value outside the range [0..7] is treated as congruent mod 8.</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool InsertBit(ref byte value, int offset)
         {
-            var shft = offset & 7; // mod 8: design choice ignores out-of-range values
-            var mask = 1U << shft;
+            int shft = offset & 7;
+            uint mask = 1U << shft;
             
-            var rsp = value & mask;
+            uint bts = value & mask;
             value = (byte)(value | mask);
 
-            return rsp != 0; // BTS
+            return bts != 0;
         }
 
         /// <summary>
         /// Sets the specified bit in a mask and returns whether it was originally set.
         /// </summary>
         /// <param name="value">The mask.</param>
-        /// <param name="offset">The ordinal position of the bit to write.</param>
+        /// <param name="offset">The ordinal position of the bit to write.
+        /// Any value outside the range [0..15] is treated as congruent mod 16.</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool InsertBit(ref ushort value, int offset)
         {
-            var shft = offset & 15; // mod 16: design choice ignores out-of-range values
-            var mask = 1U << shft;
+            int shft = offset & 15;
+            uint mask = 1U << shft;
 
-            var rsp = value & mask;
+            uint bts = value & mask;
             value = (ushort)(value | mask);
 
-            return rsp != 0; // BTS
+            return bts != 0;
         }
 
         /// <summary>
         /// Sets the specified bit in a mask and returns whether it was originally set.
         /// </summary>
         /// <param name="value">The mask.</param>
-        /// <param name="offset">The ordinal position of the bit to write.</param>
+        /// <param name="offset">The ordinal position of the bit to write.
+        /// Any value outside the range [0..31] is treated as congruent mod 32.</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool InsertBit(ref uint value, int offset)
         {
-            var mask = 1U << offset; // uint.shift is natively mod-32
+            uint mask = 1U << offset;
 
-            var rsp = value & mask;
+            uint bts = value & mask;
             value = value | mask;
 
-            return rsp != 0; // BTS
+            return bts != 0;
         }
 
         /// <summary>
         /// Sets the specified bit in a mask and returns whether it was originally set.
         /// </summary>
         /// <param name="value">The mask.</param>
-        /// <param name="offset">The ordinal position of the bit to write.</param>
+        /// <param name="offset">The ordinal position of the bit to write.
+        /// Any value outside the range [0..63] is treated as congruent mod 64.</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool InsertBit(ref ulong value, int offset)
         {
-            var mask = 1UL << offset; // ulong.shift is natively mod-64
+            ulong mask = 1UL << offset;
 
-            var rsp = value & mask;
+            ulong bts = value & mask;
             value = value | mask;
 
-            return rsp != 0; // BTS
+            return bts != 0;
         }
 
         #endregion
@@ -340,62 +367,62 @@ namespace System
         /// Complements the specified bit in a mask and returns the new value.
         /// </summary>
         /// <param name="value">The mask.</param>
-        /// <param name="offset">The ordinal position of the bit to complement.</param>
+        /// <param name="offset">The ordinal position of the bit to complement.
+        /// Any value outside the range [0..7] is treated as congruent mod 8.</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static byte ComplementBit(byte value, int offset)
         {
-            var shft = offset & 7; // mod 8: design choice ignores out-of-range values
-            var mask = 1U << shft;
+            int shft = offset & 7;
+            uint mask = 1U << shft;
 
-            // See Truth table (1) above
-            var val = (byte)~(~mask ^ value);
-            return val;
+            mask = ~(~mask ^ value);
+            return (byte)mask;
         }
 
         /// <summary>
         /// Complements the specified bit in a mask and returns the new value.
         /// </summary>
         /// <param name="value">The mask.</param>
-        /// <param name="offset">The ordinal position of the bit to complement.</param>
+        /// <param name="offset">The ordinal position of the bit to complement.
+        /// Any value outside the range [0..15] is treated as congruent mod 16.</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static ushort ComplementBit(ushort value, int offset)
         {
-            var shft = offset & 15; // mod 16: design choice ignores out-of-range values
-            var mask = 1U << shft;
+            int shft = offset & 15;
+            uint mask = 1U << shft;
 
-            // See Truth table (1) above
-            var val = (ushort)~(~mask ^ value);
-            return val;
+            mask = ~(~mask ^ value);
+            return (ushort)mask;
         }
 
         /// <summary>
         /// Complements the specified bit in a mask and returns the new value.
         /// </summary>
         /// <param name="value">The mask.</param>
-        /// <param name="offset">The ordinal position of the bit to complement.</param>
+        /// <param name="offset">The ordinal position of the bit to complement.
+        /// Any value outside the range [0..31] is treated as congruent mod 32.</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static uint ComplementBit(uint value, int offset)
         {            
-            var mask = 1U << offset; // uint.shift is natively mod-32
+            uint mask = 1U << offset;
 
-            // See Truth table (1) above
-            var val = ~(~mask ^ value);
-            return val;
+            mask = ~(~mask ^ value);
+            return mask;
         }
 
         /// <summary>
         /// Complements the specified bit in a mask and returns whether it was originally set.
         /// </summary>
         /// <param name="value">The mask.</param>
-        /// <param name="offset">The ordinal position of the bit to complement.</param>
+        /// <param name="offset">The ordinal position of the bit to complement.
+        /// Any value outside the range [0..63] is treated as congruent mod 64.</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static ulong ComplementBit(ulong value, int offset)
         {
-            var mask = 1UL << offset; // ulong.shift is natively mod-64
+            ulong mask = 1UL << offset;
 
-            // See Truth table (1) above
-            var val = ~(~mask ^ value);
-            return val;
+            mask = ~(~mask ^ value);
+            return mask;
         }
 
         #endregion
@@ -406,211 +433,209 @@ namespace System
         /// Complements the specified bit in a mask and returns whether it was originally set.
         /// </summary>
         /// <param name="value">The mask.</param>
-        /// <param name="offset">The ordinal position of the bit to complement.</param>
+        /// <param name="offset">The ordinal position of the bit to complement.
+        /// Any value outside the range [0..7] is treated as congruent mod 8.</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool ComplementBit(ref byte value, int offset)
         {
-            var shft = offset & 7; // mod 8: design choice ignores out-of-range values
-            var mask = 1U << shft;
+            int shft = offset & 7;
+            uint mask = 1U << shft;
 
-            // See Truth table (1) above
-            var rsp = value & mask;
+            uint btc = value & mask;
             value = (byte)~(~mask ^ value);
 
-            return rsp != 0; // BTC
+            return btc != 0;
         }
 
         /// <summary>
         /// Complements the specified bit in a mask and returns whether it was originally set.
         /// </summary>
         /// <param name="value">The mask.</param>
-        /// <param name="offset">The ordinal position of the bit to complement.</param>
+        /// <param name="offset">The ordinal position of the bit to complement.
+        /// Any value outside the range [0..15] is treated as congruent mod 16.</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool ComplementBit(ref ushort value, int offset)
         {
-            var shft = offset & 15; // mod 16: design choice ignores out-of-range values
-            var mask = 1U << shft;
+            int shft = offset & 15;
+            uint mask = 1U << shft;
 
-            // See Truth table (1) above
-            var rsp = value & mask;
+            uint btc = value & mask;
             value = (ushort)~(~mask ^ value);
 
-            return rsp != 0; // BTC
+            return btc != 0;
         }
 
         /// <summary>
         /// Complements the specified bit in a mask and returns whether it was originally set.
         /// </summary>
         /// <param name="value">The mask.</param>
-        /// <param name="offset">The ordinal position of the bit to complement.</param>
+        /// <param name="offset">The ordinal position of the bit to complement.
+        /// Any value outside the range [0..31] is treated as congruent mod 32.</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool ComplementBit(ref uint value, int offset)
         {
-            var mask = 1U << offset; // uint.shift is natively mod-32
+            uint mask = 1U << offset;
 
-            // See Truth table (1) above
-            var rsp = value & mask;
+            uint btc = value & mask;
             value = ~(~mask ^ value);
 
-            return rsp != 0; // BTC
+            return btc != 0;
         }
 
         /// <summary>
         /// Complements the specified bit in a mask and returns whether it was originally set.
         /// </summary>
         /// <param name="value">The mask.</param>
-        /// <param name="offset">The ordinal position of the bit to complement.</param>
+        /// <param name="offset">The ordinal position of the bit to complement.
+        /// Any value outside the range [0..63] is treated as congruent mod 64.</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool ComplementBit(ref ulong value, int offset)
         {
-            var mask = 1UL << offset; // ulong.shift is natively mod-64
+            ulong mask = 1UL << offset;
 
-            // See Truth table (1) above
-            var rsp = value & mask;
+            ulong btc = value & mask;
             value = ~(~mask ^ value);
 
-            return rsp != 0; // BTC
+            return btc != 0;
         }
 
         #endregion
 
         #region Rotate
 
+        // Will compile to instrinsics if pattern complies (uint/ulong):
+        // https://github.com/dotnet/coreclr/pull/1830
+        // No intrinsics support for byte/ushort rotation
+
         /// <summary>
         /// Rotates the specified value left by the specified number of bits.
         /// </summary>
         /// <param name="value">The value to rotate.</param>
-        /// <param name="offset">The number of bits to rotate by.</param>
+        /// <param name="offset">The number of bits to rotate by.
+        /// Any value outside the range [0..7] is treated as congruent mod 8.</param>
         /// <returns>The rotated value.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static byte RotateLeft(byte value, int offset)
         {
-            var shft = offset & 7; // mod 8 safely ignores boundary checks
+            int shft = offset & 7;
             var val = (uint)value;
-
-            // Intrinsic not available for byte/ushort
-            return (byte)((val << shft) | (val >> (8 - shft)));
+            
+            val = (val << shft) | (val >> (8 - shft));
+            return (byte)val;
         }
 
         /// <summary>
         /// Rotates the specified value right by the specified number of bits.
         /// </summary>
         /// <param name="value">The value to rotate.</param>
-        /// <param name="offset">The number of bits to rotate by.</param>
+        /// <param name="offset">The number of bits to rotate by.
+        /// Any value outside the range [0..7] is treated as congruent mod 8.</param>
         /// <returns>The rotated value.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static byte RotateRight(byte value, int offset)
         {
-            var shft = offset & 7; // mod 8 safely ignores boundary checks
+            int shft = offset & 7;
             var val = (uint)value;
-
-            // Intrinsic not available for byte/ushort
-            return (byte)((val >> shft) | (val << (8 - shft)));
+            
+            val = (val >> shft) | (val << (8 - shft));
+            return (byte)val;
         }
 
         /// <summary>
         /// Rotates the specified value left by the specified number of bits.
         /// </summary>
         /// <param name="value">The value to rotate.</param>
-        /// <param name="offset">The number of bits to rotate by.</param>
+        /// <param name="offset">The number of bits to rotate by.
+        /// Any value outside the range [0..15] is treated as congruent mod 16.</param>
         /// <returns>The rotated value.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static ushort RotateLeft(ushort value, int offset)
         {
-            var shft = offset & 15; // mod 16 safely ignores boundary checks
+            int shft = offset & 15;
             var val = (uint)value;
 
-            // Intrinsic not available for byte/ushort
-            return (ushort)((val << shft) | (val >> (16 - shft)));
+            val = (val << shft) | (val >> (16 - shft));
+            return (ushort)val;
         }
 
         /// <summary>
         /// Rotates the specified value right by the specified number of bits.
         /// </summary>
         /// <param name="value">The value to rotate.</param>
-        /// <param name="offset">The number of bits to rotate by.</param>
+        /// <param name="offset">The number of bits to rotate by.
+        /// Any value outside the range [0..15] is treated as congruent mod 16.</param>
         /// <returns>The rotated value.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static ushort RotateRight(ushort value, int offset)
         {
-            var shft = offset & 15; // mod 16 safely ignores boundary checks
+            int shft = offset & 15;
             var val = (uint)value;
 
-            // Intrinsic not available for byte/ushort
-            return (ushort)((val >> shft) | (val << (16 - shft)));
+            val = (val >> shft) | (val << (16 - shft));
+            return (ushort)val;
         }
 
         /// <summary>
         /// Rotates the specified value left by the specified number of bits.
         /// </summary>
         /// <param name="value">The value to rotate.</param>
-        /// <param name="offset">The number of bits to rotate by.</param>
+        /// <param name="offset">The number of bits to rotate by.
+        /// Any value outside the range [0..31] is treated as congruent mod 32.</param>
         /// <returns>The rotated value.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static uint RotateLeft(uint value, int offset)
         {
-            // uint.shift is natively mod-32, but we need the subtraction below
-            var shft = offset & 31;
-
-            // Will compile to instrinsic if pattern complies (uint/ulong):
-            // https://github.com/dotnet/coreclr/pull/1830
-            return (value << shft) | (value >> (32 - shft));
+            uint val = (value << offset) | (value >> (32 - offset));
+            return val;
         }
 
         /// <summary>
         /// Rotates the specified value right by the specified number of bits.
         /// </summary>
         /// <param name="value">The value to rotate.</param>
-        /// <param name="offset">The number of bits to rotate by.</param>
+        /// <param name="offset">The number of bits to rotate by.
+        /// Any value outside the range [0..31] is treated as congruent mod 32.</param>
         /// <returns>The rotated value.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static uint RotateRight(uint value, int offset)
         {
-            // uint.shift is natively mod-32, but we need the subtraction below
-            var shft = offset & 31;
-
-            // Will compile to instrinsic if pattern complies (uint/ulong):
-            // https://github.com/dotnet/coreclr/pull/1830
-            return (value >> shft) | (value << (32 - shft));
+            uint val = (value >> offset) | (value << (32 - offset));
+            return val;
         }
 
         /// <summary>
         /// Rotates the specified value left by the specified number of bits.
         /// </summary>
         /// <param name="value">The value to rotate.</param>
-        /// <param name="offset">The number of bits to rotate by.</param>
+        /// <param name="offset">The number of bits to rotate by.
+        /// Any value outside the range [0..63] is treated as congruent mod 64.</param>
         /// <returns>The rotated value.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static ulong RotateLeft(ulong value, int offset)
         {
-            // ulong.shift is natively mod-64, but we need the subtraction below
-            var shft = offset & 63;
-
-            // Will compile to instrinsic if pattern complies (uint/ulong):
-            // https://github.com/dotnet/coreclr/pull/1830
-            return (value << shft) | (value >> (64 - shft));
+            ulong val = (value << offset) | (value >> (64 - offset));
+            return val;
         }
 
         /// <summary>
         /// Rotates the specified value right by the specified number of bits.
         /// </summary>
         /// <param name="value">The value to rotate.</param>
-        /// <param name="offset">The number of bits to rotate by.</param>
+        /// <param name="offset">The number of bits to rotate by.
+        /// Any value outside the range [0..63] is treated as congruent mod 64.</param>
         /// <returns>The rotated value.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static ulong RotateRight(ulong value, int offset)
         {
-            // ulong.shift is natively mod-64, but we need the subtraction below
-            var shft = offset & 63;
-
-            // Will compile to instrinsic if pattern complies (uint/ulong):
-            // https://github.com/dotnet/coreclr/pull/1830
-            return (value >> shft) | (value << (64 - shft));
+            ulong val = (value >> offset) | (value << (64 - offset));
+            return val;
         }
 
         #endregion
 
         #region PopCount
+
+        // Uses SWAR (SIMD Within A Register).
 
         /// <summary>
         /// Returns the population count (number of bits set) of a mask.
@@ -618,21 +643,7 @@ namespace System
         /// <param name="value">The mask.</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static int PopCount(byte value)
-        {
-            // 22 ops
-            // TODO: Benchmark whether other algo is faster
-            var val
-                = (value & 1)
-                + (value >> 1 & 1)
-                + (value >> 2 & 1)
-                + (value >> 3 & 1)
-                + (value >> 4 & 1)
-                + (value >> 5 & 1)
-                + (value >> 6 & 1)
-                + (value >> 7 & 1);
-
-            return val;
-        }
+            => PopCount((uint)value);
 
         /// <summary>
         /// Returns the population count (number of bits set) of a mask.
@@ -649,14 +660,12 @@ namespace System
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static int PopCount(uint value)
         {
-            // Uses a SWAR (SIMD Within A Register) approach
-
             const uint c0 = 0x_5555_5555;
             const uint c1 = 0x_3333_3333;
             const uint c2 = 0x_0F0F_0F0F;
             const uint c3 = 0x_0101_0101;
 
-            var val = value;
+            uint val = value;
 
             val -= (val >> 1) & c0;
             val = (val & c1) + ((val >> 2) & c1);
@@ -674,8 +683,6 @@ namespace System
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static int PopCount(ulong value)
         {
-            // Use a SWAR (SIMD Within A Register) approach
-
             const ulong c0 = 0x_5555_5555_5555_5555;
             const ulong c1 = 0x_3333_3333_3333_3333;
             const ulong c2 = 0x_0F0F_0F0F_0F0F_0F0F;
@@ -718,11 +725,11 @@ namespace System
             if (value == 0)
                 return 0;
 
-            // Negation of Max == 0; see above
+            // Complement of Max == 0; see above
             if (value == byte.MaxValue)
                 return 8;
 
-            // Negate mask but remember to truncate carry-bits
+            // Complement mask but remember to truncate carry-bits
             var val = (uint)(byte)~(uint)value;
 
             return 7 - FloorLog2Impl(val);
@@ -750,11 +757,11 @@ namespace System
             if (value == 0)
                 return 0;
 
-            // Negation of Max == 0; see above
+            // Complement of Max == 0; see above
             if (value == ushort.MaxValue)
                 return 16;
 
-            // Negate mask but remember to truncate carry-bits
+            // Complement mask but remember to truncate carry-bits
             var val = (uint)(ushort)~(uint)value;
 
             return 15 - FloorLog2Impl(val);
@@ -782,14 +789,11 @@ namespace System
             if (value == 0)
                 return 0;
 
-            // Negation of Max == 0; see above
+            // Complement of Max == 0; see above
             if (value == uint.MaxValue)
                 return 32;
 
-            // Negate mask but remember to truncate carry-bits
-            var val = ~value;
-
-            return 31 - FloorLog2Impl(val);
+            return 31 - FloorLog2Impl(~value);
         }
 
         /// <summary>
@@ -814,14 +818,11 @@ namespace System
             if (value == 0)
                 return 0;
 
-            // Negation of Max == 0; see above
+            // Complement of Max == 0; see above
             if (value == ulong.MaxValue)
                 return 64;
 
-            // Negate mask but remember to truncate carry-bits
-            var val = ~value;
-
-            return 63 - FloorLog2Impl(val);
+            return 63 - FloorLog2Impl(~value);
         }
 
         #endregion
@@ -855,21 +856,21 @@ namespace System
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static int TrailingZeros(byte value)
         {
-            var val = value;
+            byte val = value;
 
             // The expression (n & -n) returns lsb(n).
             // Only possible values are therefore [0,1,2,4,...,128]
-            var lsb = val & -val; // eg 44==0010 1100 -> (44 & -44) -> 4. 4==0100, which is the lsb of 44.
+            int lsb = val & -val; // eg 44==0010 1100 -> (44 & -44) -> 4. 4==0100, which is the lsb of 44.
 
             // We want to map [0...128] to the smallest contiguous range, ideally [0..9] since 9 is the range cardinality.
             // Mod-11 is a simple perfect-hashing scheme over this range, where 11 is chosen as the closest prime greater than 9.
-            lsb = lsb % 11; // eg 44 -> 4 % 11 -> 4
+            lsb = lsb % 11; // mod 11
 
             // NoOp: Hashing scheme has unused outputs (inputs 256 and higher do not fit a byte)
-            Debug.Assert(!(lsb == 3 || lsb == 6), $"{nameof(TrailingZeros)}({value}) resulted in unexpected {typeof(byte)} hash {lsb}");
+            Debug.Assert(!(lsb == 3 || lsb == 6), $"{value} resulted in unexpected {typeof(byte)} hash {lsb}");
 
             // TODO: For such a small range, would a switch be faster?
-            var cnt = s_trail8u[lsb]; // eg 44 -> 4 -> 2 (44==0010 1100 has 2 trailing zeros)
+            byte cnt = s_trail8u[lsb]; // eg 44 -> 4 -> 2 (44==0010 1100 has 2 trailing zeros)
             return cnt;
         }
 
@@ -879,28 +880,11 @@ namespace System
         /// <param name="value">The mask.</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static int TrailingOnes(byte value)
-        {
-            // Negate mask but remember to truncate carry-bits
-            var val = (uint)(byte)~(uint)value;
+            => TrailingZeros((byte)~(uint)value); // Ones(N) == Zeros(~N)
 
-            // The expression (n & -n) returns lsb(n).
-            // Only possible values are therefore [0,1,2,4,...,128]
-            var lsb = val & -val; // eg 44==0010 1100 -> (44 & -44) -> 4. 4==0100, which is the lsb of 44.
-
-            // We want to map [0...128] to the smallest contiguous range, ideally [0..9] since 9 is the range cardinality.
-            // Mod-11 is a simple perfect-hashing scheme over this range, where 11 is chosen as the closest prime greater than 9.
-            lsb = lsb % 11; // eg 44 -> 4 % 11 -> 4
-
-            // NoOp: Hashing scheme has unused outputs (inputs 256 and higher do not fit a byte)
-            Debug.Assert(!(lsb == 3 || lsb == 6), $"{nameof(TrailingOnes)}({value}) resulted in unexpected {typeof(byte)} hash {lsb}");
-
-            // TODO: For such a small range, would a switch be faster?
-            var cnt = s_trail8u[lsb]; // eg 44 -> 4 -> 2 (44==0010 1100 has 2 trailing zeros)
-            return cnt;
-        }
-
-        // See algorithm notes in TrailingCount(byte)
-        private static readonly byte[] s_trail16u = new byte[19] // mod 19
+        // See algorithm notes in TrailingCount(byte).
+        // 19 is the closest prime greater than the range's cardinality of 17.
+        private static readonly byte[] s_trail16u = new byte[19]
         {
             //        2^n  % 19     b=bin(n)             z=tz(b)
             16, //      0  [ 0]     0000_0000_0000_0000  16
@@ -935,17 +919,16 @@ namespace System
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static int TrailingZeros(ushort value)
         {
-            var val = value;
+            ushort val = value;
 
             // See algorithm notes in TrailingZeros(byte)
-            // 19 is the closest prime greater than the range's cardinality of 17.
-            var lsb = val & -val;
+            int lsb = val & -val;
             lsb = lsb % 19; // mod 19
 
             // NoOp: Hashing scheme has unused outputs (inputs 65536 and higher do not fit a ushort)
-            Debug.Assert(!(lsb == 5 || lsb == 10), $"{nameof(TrailingZeros)}({value}) resulted in unexpected {typeof(ushort)} hash {lsb}");
+            Debug.Assert(!(lsb == 5 || lsb == 10), $"{value} resulted in unexpected {typeof(ushort)} hash {lsb}");
 
-            var cnt = s_trail16u[lsb];
+            byte cnt = s_trail16u[lsb];
             return cnt;
         }
 
@@ -955,23 +938,10 @@ namespace System
         /// <param name="value">The mask.</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static int TrailingOnes(ushort value)
-        {
-            // Negate mask but remember to truncate carry-bits
-            var val = (uint)(ushort)~(uint)value;
-
-            // See algorithm notes in TrailingOnes(byte)
-            // 19 is the closest prime greater than the range's cardinality of 17.
-            var lsb = val & -val;
-            lsb = lsb % 19; // mod 19
-
-            // NoOp: Hashing scheme has unused outputs (inputs 65536 and higher do not fit a ushort)
-            Debug.Assert(!(lsb == 5 || lsb == 10), $"{nameof(TrailingOnes)}({value}) resulted in unexpected {typeof(ushort)} hash {lsb}");
-
-            var cnt = s_trail16u[lsb];
-            return cnt;
-        }
+            => TrailingZeros((ushort)~(uint)value); // Ones(N) == Zeros(~N)
 
         // See algorithm notes in TrailingCount(byte)
+        // 37 is the closest prime greater than the range's cardinality of 33.
         private static readonly byte[] s_trail32u = new byte[37] // mod 37
         {
             //                2^n  % 37       b=bin(n)                                 z=tz(b)
@@ -1030,17 +1000,16 @@ namespace System
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static int TrailingZeros(uint value)
         {
-            var val = value;
+            uint val = value;
 
             // See algorithm notes in TrailingZeros(byte)
-            // 37 is the closest prime greater than the range's cardinality of 33.
-            var lsb = val & -val;
+            long lsb = val & -val;
             lsb = lsb % 37; // mod 37
 
             // NoOp: Hashing scheme has unused outputs (inputs 4,294,967,296 and higher do not fit a uint)
-            Debug.Assert(!(lsb == 7 || lsb == 14 || lsb == 19 || lsb == 28), $"{nameof(TrailingZeros)}({value}) resulted in unexpected {typeof(uint)} hash {lsb}");
+            Debug.Assert(!(lsb == 7 || lsb == 14 || lsb == 19 || lsb == 28), $"{value} resulted in unexpected {typeof(uint)} hash {lsb}");
 
-            var cnt = s_trail32u[lsb];
+            byte cnt = s_trail32u[lsb];
             return cnt;
         }
 
@@ -1050,21 +1019,7 @@ namespace System
         /// <param name="value">The mask.</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static int TrailingOnes(uint value)
-        {
-            // Negate mask
-            var val = ~value;
-
-            // See algorithm notes in TrailingOnes(byte)
-            // 37 is the closest prime greater than the range's cardinality of 33.
-            var lsb = val & -val;
-            lsb = lsb % 37; // mod 37
-
-            // NoOp: Hashing scheme has unused outputs (inputs 4,294,967,296 and higher do not fit a uint)
-            Debug.Assert(!(lsb == 7 || lsb == 14 || lsb == 19 || lsb == 28), $"{nameof(TrailingOnes)}({value}) resulted in unexpected {typeof(uint)} hash {lsb}");
-
-            var cnt = s_trail32u[lsb];
-            return cnt;
-        }
+            => TrailingZeros(~value); // Ones(N) == Zeros(~N)
 
         /// <summary>
         /// Count the number of trailing zero bits in a mask.
@@ -1073,7 +1028,7 @@ namespace System
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static int TrailingZeros(ulong value)
         {
-            // 0 is a special case since calling into the uint overload
+            // 0 is a special case since calling into the core uint routine
             // will return 32 instead of 64
             if (value == 0)
                 return 64;
@@ -1082,7 +1037,7 @@ namespace System
 
             // Assume we need only examine low-32
             var val = (uint)value;
-            var inc = 0;
+            byte inc = 0;
 
             // If high-32 is non-zero and low-32 is zero
             if (value > uint.MaxValue && val == 0)
@@ -1101,25 +1056,8 @@ namespace System
         /// </summary>
         /// <param name="value">The mask.</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static int TrailingOnes(ulong value)
-        {
-            // We only have to count the low-32 or the high-32, depending on limits
-
-            // Assume we need only examine low-32
-            var val = (uint)value;
-            var inc = 0;
-
-            // If high-32 is non-zero and low-32 is Max
-            if (value > uint.MaxValue && val == uint.MaxValue)
-            {
-                // Then we need only examine high-32 (and add 32 to the result)
-                val = (uint)(value >> 32); // Use high-32 instead
-                inc = 32;
-            }
-
-            // Examine 32
-            return inc + TrailingOnes(val);
-        }
+        public static int TrailingOnes(ulong value) 
+            => TrailingZeros(~value); // Ones(N) == Zeros(~N)
 
         #endregion
 
@@ -1147,7 +1085,7 @@ namespace System
             val |= val >> 16;
 
             const uint c32 = 0x07C4_ACDDu;
-            var ix = (val * c32) >> 27;
+            uint ix = (val * c32) >> 27;
 
             return s_deBruijn32[ix];
         }
@@ -1162,7 +1100,7 @@ namespace System
 
             // Assume we need only examine low-32
             var val = (uint)value;
-            var inc = 0;
+            byte inc = 0;
 
             // If high-32 is non-zero
             if (value > uint.MaxValue)


### PR DESCRIPTION
- The `offset` parameter is `int` not `byte`. All units pass though there may be bad edge-cases
- Remove redundant `mod` operations
- Cleanup