### PR TITLE
Sha1 optimizations

### DIFF
--- a/src/SourceCode.Clay.Algorithms/SourceCode.Clay.Algorithms.csproj
+++ b/src/SourceCode.Clay.Algorithms/SourceCode.Clay.Algorithms.csproj
@@ -14,6 +14,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <None Remove="SourceCode.Clay.Algorithms.xml" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="Microsoft.Net.Compilers" Version="2.9.0" PrivateAssets="All" />
     <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.6.2" PrivateAssets="All" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta-63127-02" PrivateAssets="All" />

--- a/src/SourceCode.Clay.Buffers/SourceCode.Clay.Buffers.csproj
+++ b/src/SourceCode.Clay.Buffers/SourceCode.Clay.Buffers.csproj
@@ -14,6 +14,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <None Remove="SourceCode.Clay.Buffers.xml" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="Microsoft.Net.Compilers" Version="2.9.0" PrivateAssets="All" />
     <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.6.2" PrivateAssets="All" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta-63127-02" PrivateAssets="All" />

--- a/src/SourceCode.Clay.Collections/SourceCode.Clay.Collections.csproj
+++ b/src/SourceCode.Clay.Collections/SourceCode.Clay.Collections.csproj
@@ -14,6 +14,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <None Remove="SourceCode.Clay.Collections.xml" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="Microsoft.Net.Compilers" Version="2.9.0" PrivateAssets="All" />
     <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.6.2" PrivateAssets="All" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta-63127-02" PrivateAssets="All" />

--- a/src/SourceCode.Clay.Data/SourceCode.Clay.Data.csproj
+++ b/src/SourceCode.Clay.Data/SourceCode.Clay.Data.csproj
@@ -14,6 +14,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <None Remove="SourceCode.Clay.Data.xml" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="Microsoft.Net.Compilers" Version="2.9.0" PrivateAssets="All" />
     <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.6.2" PrivateAssets="All" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta-63127-02" PrivateAssets="All" />

--- a/src/SourceCode.Clay.IO/SourceCode.Clay.IO.csproj
+++ b/src/SourceCode.Clay.IO/SourceCode.Clay.IO.csproj
@@ -14,6 +14,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <None Remove="SourceCode.Clay.IO.xml" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="Microsoft.Net.Compilers" Version="2.9.0" PrivateAssets="All" />
     <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.6.2" PrivateAssets="All" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta-63127-02" PrivateAssets="All" />

--- a/src/SourceCode.Clay.Javascript/SourceCode.Clay.Javascript.csproj
+++ b/src/SourceCode.Clay.Javascript/SourceCode.Clay.Javascript.csproj
@@ -22,6 +22,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <None Remove="SourceCode.Clay.Javascript.xml" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="Microsoft.Net.Compilers" Version="2.9.0" PrivateAssets="All" />
     <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.6.2" PrivateAssets="All" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta-63127-02" PrivateAssets="All" />

--- a/src/SourceCode.Clay.Json/SourceCode.Clay.Json.csproj
+++ b/src/SourceCode.Clay.Json/SourceCode.Clay.Json.csproj
@@ -14,6 +14,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <None Remove="SourceCode.Clay.Json.xml" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="Microsoft.Net.Compilers" Version="2.9.0" PrivateAssets="All" />
     <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.6.2" PrivateAssets="All" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta-63127-02" PrivateAssets="All" />

--- a/src/SourceCode.Clay.OpenApi/OasSecurityScheme.cs
+++ b/src/SourceCode.Clay.OpenApi/OasSecurityScheme.cs
@@ -60,7 +60,7 @@ namespace SourceCode.Clay.OpenApi
         /// <summary>Determines whether the specified object is equal to the current object.</summary>
         /// <param name="obj">The object to compare with the current object.</param>
         /// <returns>true if the specified object  is equal to the current object; otherwise, false.</returns>
-        public override abstract bool Equals(object obj);
+        public abstract override bool Equals(object obj);
 
         /// <summary>Indicates whether the current object is equal to another object of the same type.</summary>
         /// <param name="other">An object to compare with this object.</param>

--- a/src/SourceCode.Clay.OpenApi/SourceCode.Clay.OpenApi.csproj
+++ b/src/SourceCode.Clay.OpenApi/SourceCode.Clay.OpenApi.csproj
@@ -22,6 +22,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <None Remove="SourceCode.Clay.OpenApi.xml" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="Microsoft.Net.Compilers" Version="2.9.0" PrivateAssets="All" />
     <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.6.2" PrivateAssets="All" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta-63127-02" PrivateAssets="All" />

--- a/src/SourceCode.Clay.Security/SourceCode.Clay.Security.csproj
+++ b/src/SourceCode.Clay.Security/SourceCode.Clay.Security.csproj
@@ -14,6 +14,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <None Remove="SourceCode.Clay.Security.xml" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="Microsoft.Net.Compilers" Version="2.9.0" PrivateAssets="All" />
     <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.6.2" PrivateAssets="All" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta-63127-02" PrivateAssets="All" />

--- a/src/SourceCode.Clay.Text/SourceCode.Clay.Text.csproj
+++ b/src/SourceCode.Clay.Text/SourceCode.Clay.Text.csproj
@@ -14,6 +14,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <None Remove="SourceCode.Clay.Text.xml" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="Microsoft.Net.Compilers" Version="2.9.0" PrivateAssets="All" />
     <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.6.2" PrivateAssets="All" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta-63127-02" PrivateAssets="All" />

--- a/src/SourceCode.Clay.Threading/SourceCode.Clay.Threading.csproj
+++ b/src/SourceCode.Clay.Threading/SourceCode.Clay.Threading.csproj
@@ -14,6 +14,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <None Remove="SourceCode.Clay.Threading.xml" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="Microsoft.Net.Compilers" Version="2.9.0" PrivateAssets="All" />
     <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.6.2" PrivateAssets="All" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta-63127-02" PrivateAssets="All" />

--- a/src/SourceCode.Clay/Sha1.cs
+++ b/src/SourceCode.Clay/Sha1.cs
@@ -215,19 +215,18 @@ namespace SourceCode.Clay
         }
 
         /// <summary>
-        /// Returns a string representation of the <see cref="Sha1"/> instance using the 'N' format.
+        /// Returns a string representation of the <see cref="Sha1"/> instance using the 'n' format.
         /// </summary>
         /// <returns></returns>
-        public override string ToString() => ToString("N");
+        public override string ToString() => ToString("n");
 
         /// <summary>
         /// Returns a string representation of the <see cref="Sha1"/> instance.
-        /// N: a9993e364706816aba3e25717850c26c9cd0d89d,
-        /// D: a9993e36-4706816a-ba3e2571-7850c26c-9cd0d89d,
-        /// S: a9993e36 4706816a ba3e2571 7850c26c 9cd0d89d
+        /// n: a9993e364706816aba3e25717850c26c9cd0d89d,
+        /// d: a9993e36-4706816a-ba3e2571-7850c26c-9cd0d89d,
+        /// s: a9993e36 4706816a ba3e2571 7850c26c 9cd0d89d
         /// </summary>
         /// <param name="format"></param>
-        /// <returns></returns>
         public string ToString(string format)
         {
             if (string.IsNullOrWhiteSpace(format))
@@ -245,28 +244,16 @@ namespace SourceCode.Clay
                     switch (format[0])
                     {
                         // a9993e364706816aba3e25717850c26c9cd0d89d
-                        case 'n':
-                        case 'N':
-                            {
-                                string str = ShaUtil.ToString(sha);
-                                return str;
-                            }
+                        case 'n': return ShaUtil.ToString(sha, ShaUtil.HexCasing.Lower);
+                        case 'N': return ShaUtil.ToString(sha, ShaUtil.HexCasing.Upper);
 
                         // a9993e36-4706816a-ba3e2571-7850c26c-9cd0d89d
-                        case 'd':
-                        case 'D':
-                            {
-                                string str = ShaUtil.ToString(sha, '-');
-                                return str;
-                            }
+                        case 'd': return ShaUtil.ToString(sha, '-', ShaUtil.HexCasing.Lower);
+                        case 'D': return ShaUtil.ToString(sha, '-', ShaUtil.HexCasing.Upper);
 
                         // a9993e36 4706816a ba3e2571 7850c26c 9cd0d89d
-                        case 's':
-                        case 'S':
-                            {
-                                string str = ShaUtil.ToString(sha, ' ');
-                                return str;
-                            }
+                        case 's': return ShaUtil.ToString(sha, ' ', ShaUtil.HexCasing.Lower);
+                        case 'S': return ShaUtil.ToString(sha, ' ', ShaUtil.HexCasing.Upper);
                     }
                 }
             }
@@ -275,20 +262,22 @@ namespace SourceCode.Clay
         }
 
         /// <summary>
-        /// Converts the <see cref="Sha1"/> instance to a string using the 'N' format,
+        /// Converts the <see cref="Sha1"/> instance to a string using the 'n' or 'N' format,
         /// and returns the value split into two tokens.
         /// </summary>
         /// <param name="prefixLength">The length of the first token.</param>
-        /// <returns></returns>
-        public KeyValuePair<string, string> Split(in int prefixLength)
+        /// <param name="uppercase">If True, output uppercase, else output lowercase.</param>
+        public KeyValuePair<string, string> Split(in int prefixLength, bool uppercase = false)
         {
+            ShaUtil.HexCasing casing = uppercase ? ShaUtil.HexCasing.Upper : ShaUtil.HexCasing.Lower;
+
             unsafe
             {
                 fixed (Block* ptr = &_bytes)
                 {
                     var sha = new ReadOnlySpan<byte>(ptr, ByteLength);
 
-                    KeyValuePair<string, string> kvp = ShaUtil.Split(sha, prefixLength);
+                    KeyValuePair<string, string> kvp = ShaUtil.Split(sha, prefixLength, casing);
                     return kvp;
                 }
             }

--- a/src/SourceCode.Clay/Sha256.cs
+++ b/src/SourceCode.Clay/Sha256.cs
@@ -40,7 +40,7 @@ namespace SourceCode.Clay
         /// The number of hex characters required to represent a <see cref="Sha256"/> value.
         /// </summary>
         public const byte HexLength = ByteLength * 2;
-        
+
         private static readonly Sha256 s_empty = HashImpl(ReadOnlySpan<byte>.Empty);
 
         // We choose to use value types for primary storage so that we can live on the stack
@@ -216,16 +216,16 @@ namespace SourceCode.Clay
         }
 
         /// <summary>
-        /// Returns a string representation of the <see cref="Sha256"/> instance using the 'N' format.
+        /// Returns a string representation of the <see cref="Sha256"/> instance using the 'n' format.
         /// </summary>
         /// <returns></returns>
-        public override string ToString() => ToString("N");
+        public override string ToString() => ToString("n");
 
         /// <summary>
         /// Returns a string representation of the <see cref="Sha256"/> instance.
-        /// N: cdc76e5c9914fb9281a1c7e284d73e67f1809a48a497200e046d39ccc7112cd0,
-        /// D: cdc76e5c-9914fb92-81a1c7e2-84d73e67-f1809a48-a497200e-046d39cc-c7112cd0,
-        /// S: cdc76e5c 9914fb92 81a1c7e2 84d73e67 f1809a48 a497200e 046d39cc c7112cd0
+        /// n: cdc76e5c9914fb9281a1c7e284d73e67f1809a48a497200e046d39ccc7112cd0,
+        /// d: cdc76e5c-9914fb92-81a1c7e2-84d73e67-f1809a48-a497200e-046d39cc-c7112cd0,
+        /// s: cdc76e5c 9914fb92 81a1c7e2 84d73e67 f1809a48 a497200e 046d39cc c7112cd0
         /// </summary>
         /// <param name="format"></param>
         /// <returns></returns>
@@ -246,28 +246,16 @@ namespace SourceCode.Clay
                     switch (format[0])
                     {
                         // cdc76e5c9914fb9281a1c7e284d73e67f1809a48a497200e046d39ccc7112cd0
-                        case 'n':
-                        case 'N':
-                            {
-                                string str = ShaUtil.ToString(sha);
-                                return str;
-                            }
+                        case 'n': return ShaUtil.ToString(sha, ShaUtil.HexCasing.Lower);
+                        case 'N': return ShaUtil.ToString(sha, ShaUtil.HexCasing.Upper);
 
                         // cdc76e5c-9914fb92-81a1c7e2-84d73e67-f1809a48-a497200e-046d39cc-c7112cd0
-                        case 'd':
-                        case 'D':
-                            {
-                                string str = ShaUtil.ToString(sha, '-');
-                                return str;
-                            }
+                        case 'd': return ShaUtil.ToString(sha, '-', ShaUtil.HexCasing.Lower);
+                        case 'D': return ShaUtil.ToString(sha, '-', ShaUtil.HexCasing.Upper);
 
                         // cdc76e5c 9914fb92 81a1c7e2 84d73e67 f1809a48 a497200e 046d39cc c7112cd0
-                        case 's':
-                        case 'S':
-                            {
-                                string str = ShaUtil.ToString(sha, ' ');
-                                return str;
-                            }
+                        case 's': return ShaUtil.ToString(sha, ' ', ShaUtil.HexCasing.Lower);
+                        case 'S': return ShaUtil.ToString(sha, ' ', ShaUtil.HexCasing.Upper);
                     }
                 }
             }
@@ -276,20 +264,22 @@ namespace SourceCode.Clay
         }
 
         /// <summary>
-        /// Converts the <see cref="Sha256"/> instance to a string using the 'N' format,
+        /// Converts the <see cref="Sha256"/> instance to a string using the 'n' or 'N' format,
         /// and returns the value split into two tokens.
         /// </summary>
         /// <param name="prefixLength">The length of the first token.</param>
-        /// <returns></returns>
-        public KeyValuePair<string, string> Split(int prefixLength)
+        /// <param name="uppercase">If True, output uppercase, else output lowercase.</param>
+        public KeyValuePair<string, string> Split(int prefixLength, bool uppercase = false)
         {
+            ShaUtil.HexCasing casing = uppercase ? ShaUtil.HexCasing.Upper : ShaUtil.HexCasing.Lower;
+
             unsafe
             {
                 fixed (Block* ptr = &_bytes)
                 {
                     var sha = new ReadOnlySpan<byte>(ptr, ByteLength);
 
-                    KeyValuePair<string, string> kvp = ShaUtil.Split(sha, prefixLength);
+                    KeyValuePair<string, string> kvp = ShaUtil.Split(sha, prefixLength, casing);
                     return kvp;
                 }
             }
@@ -300,7 +290,6 @@ namespace SourceCode.Clay
         /// </summary>
         /// <param name="hex">The hexadecimal.</param>
         /// <param name="value">The value.</param>
-        /// <returns></returns>
         public static bool TryParse(ReadOnlySpan<char> hex, out Sha256 value)
         {
             value = default;

--- a/src/SourceCode.Clay/ShaUtil.cs
+++ b/src/SourceCode.Clay/ShaUtil.cs
@@ -124,9 +124,12 @@ namespace SourceCode.Clay
             for (int i = 0; i < byteLength; i++) // 20|32
             {
                 // Each byte is two hexits
+                // Write to output starting with *highest* index so codegen can elide all but first bounds check
                 byte byt = sha[i];
-                span[pos++] = HexChars[byt >> 4]; // == b / 16
-                span[pos++] = HexChars[byt & 15]; // == b % 16
+                span[pos + 1] = HexChars[byt & 15]; // == b % 16
+                span[pos] = HexChars[byt >> 4]; // == b / 16
+
+                pos += 2;
             }
 
             if (prefixLength >= hexLength)
@@ -165,9 +168,12 @@ namespace SourceCode.Clay
             for (int i = 0; i < byteLength; i++) // 20|32
             {
                 // Each byte is two hexits
+                // Write to output starting with *highest* index so codegen can elide all but first bounds check
                 byte byt = sha[i];
-                span[pos++] = HexChars[byt >> 4]; // == b / 16
-                span[pos++] = HexChars[byt & 15]; // == b % 16
+                span[pos + 1] = HexChars[byt & 15]; // == b % 16
+                span[pos] = HexChars[byt >> 4]; // == b / 16
+
+                pos += 2;
             }
 
             string str = new string(span);
@@ -200,9 +206,12 @@ namespace SourceCode.Clay
             for (int i = 0; i < byteLength; i++) // 20|32
             {
                 // Each byte is two hexits (convention is lowercase)
+                // Write to output starting with *highest* index so codegen can elide all but first bounds check
                 byte byt = sha[i];
-                span[pos++] = HexChars[byt >> 4]; // == b / 16
-                span[pos++] = HexChars[byt & 15]; // == b % 16
+                span[pos + 1] = HexChars[byt & 15]; // == b % 16
+                span[pos] = HexChars[byt >> 4]; // == b / 16
+
+                pos += 2;
 
                 // Append a separator if required
                 if (pos == sep) // pos >= 2, sep = 0|N

--- a/src/SourceCode.Clay/ShaUtil.cs
+++ b/src/SourceCode.Clay/ShaUtil.cs
@@ -103,6 +103,7 @@ namespace SourceCode.Clay
             return true;
         }
 
+        // https://github.com/dotnet/corefx/blob/master/src/System.Memory/src/System/Buffers/Text/Utf8Formatter/FormattingHelpers.cs
         internal enum HexCasing : uint
         {
             Upper = 0,

--- a/src/SourceCode.Clay/SourceCode.Clay.csproj
+++ b/src/SourceCode.Clay/SourceCode.Clay.csproj
@@ -14,6 +14,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <None Remove="SourceCode.Clay.xml" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="Microsoft.Net.Compilers" Version="2.9.0" PrivateAssets="All" />
     <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.6.2" PrivateAssets="All" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta-63127-02" PrivateAssets="All" />

--- a/src/SourceCode.Clay/SourceCode.Clay.xml
+++ b/src/SourceCode.Clay/SourceCode.Clay.xml
@@ -1154,27 +1154,26 @@
         </member>
         <member name="M:SourceCode.Clay.Sha1.ToString">
             <summary>
-            Returns a string representation of the <see cref="T:SourceCode.Clay.Sha1"/> instance using the 'N' format.
+            Returns a string representation of the <see cref="T:SourceCode.Clay.Sha1"/> instance using the 'n' format.
             </summary>
             <returns></returns>
         </member>
         <member name="M:SourceCode.Clay.Sha1.ToString(System.String)">
             <summary>
             Returns a string representation of the <see cref="T:SourceCode.Clay.Sha1"/> instance.
-            N: a9993e364706816aba3e25717850c26c9cd0d89d,
-            D: a9993e36-4706816a-ba3e2571-7850c26c-9cd0d89d,
-            S: a9993e36 4706816a ba3e2571 7850c26c 9cd0d89d
+            n: a9993e364706816aba3e25717850c26c9cd0d89d,
+            d: a9993e36-4706816a-ba3e2571-7850c26c-9cd0d89d,
+            s: a9993e36 4706816a ba3e2571 7850c26c 9cd0d89d
             </summary>
             <param name="format"></param>
-            <returns></returns>
         </member>
-        <member name="M:SourceCode.Clay.Sha1.Split(System.Int32@)">
+        <member name="M:SourceCode.Clay.Sha1.Split(System.Int32@,System.Boolean)">
             <summary>
-            Converts the <see cref="T:SourceCode.Clay.Sha1"/> instance to a string using the 'N' format,
+            Converts the <see cref="T:SourceCode.Clay.Sha1"/> instance to a string using the 'n' or 'N' format,
             and returns the value split into two tokens.
             </summary>
             <param name="prefixLength">The length of the first token.</param>
-            <returns></returns>
+            <param name="uppercase">If True, output uppercase, else output lowercase.</param>
         </member>
         <member name="M:SourceCode.Clay.Sha1.TryParse(System.ReadOnlySpan{System.Char},SourceCode.Clay.Sha1@)">
             <summary>
@@ -1303,27 +1302,27 @@
         </member>
         <member name="M:SourceCode.Clay.Sha256.ToString">
             <summary>
-            Returns a string representation of the <see cref="T:SourceCode.Clay.Sha256"/> instance using the 'N' format.
+            Returns a string representation of the <see cref="T:SourceCode.Clay.Sha256"/> instance using the 'n' format.
             </summary>
             <returns></returns>
         </member>
         <member name="M:SourceCode.Clay.Sha256.ToString(System.String)">
             <summary>
             Returns a string representation of the <see cref="T:SourceCode.Clay.Sha256"/> instance.
-            N: cdc76e5c9914fb9281a1c7e284d73e67f1809a48a497200e046d39ccc7112cd0,
-            D: cdc76e5c-9914fb92-81a1c7e2-84d73e67-f1809a48-a497200e-046d39cc-c7112cd0,
-            S: cdc76e5c 9914fb92 81a1c7e2 84d73e67 f1809a48 a497200e 046d39cc c7112cd0
+            n: cdc76e5c9914fb9281a1c7e284d73e67f1809a48a497200e046d39ccc7112cd0,
+            d: cdc76e5c-9914fb92-81a1c7e2-84d73e67-f1809a48-a497200e-046d39cc-c7112cd0,
+            s: cdc76e5c 9914fb92 81a1c7e2 84d73e67 f1809a48 a497200e 046d39cc c7112cd0
             </summary>
             <param name="format"></param>
             <returns></returns>
         </member>
-        <member name="M:SourceCode.Clay.Sha256.Split(System.Int32)">
+        <member name="M:SourceCode.Clay.Sha256.Split(System.Int32,System.Boolean)">
             <summary>
-            Converts the <see cref="T:SourceCode.Clay.Sha256"/> instance to a string using the 'N' format,
+            Converts the <see cref="T:SourceCode.Clay.Sha256"/> instance to a string using the 'n' or 'N' format,
             and returns the value split into two tokens.
             </summary>
             <param name="prefixLength">The length of the first token.</param>
-            <returns></returns>
+            <param name="uppercase">If True, output uppercase, else output lowercase.</param>
         </member>
         <member name="M:SourceCode.Clay.Sha256.TryParse(System.ReadOnlySpan{System.Char},SourceCode.Clay.Sha256@)">
             <summary>
@@ -1331,7 +1330,6 @@
             </summary>
             <param name="hex">The hexadecimal.</param>
             <param name="value">The value.</param>
-            <returns></returns>
         </member>
         <member name="M:SourceCode.Clay.Sha256.TryParse(System.String,SourceCode.Clay.Sha256@)">
             <summary>
@@ -1383,30 +1381,34 @@
             <param name="hex">The hexadecimal.</param>
             <param name="sha">The buffer to populate with the Sha value.</param>
         </member>
-        <member name="M:SourceCode.Clay.ShaUtil.Split(System.ReadOnlySpan{System.Byte}@,System.Int32)">
+        <member name="M:SourceCode.Clay.ShaUtil.Split(System.ReadOnlySpan{System.Byte}@,System.Int32,SourceCode.Clay.ShaUtil.HexCasing)">
             <summary>
-            Converts the <see cref="T:SourceCode.Clay.Sha1"/> or <see cref="T:SourceCode.Clay.Sha256"/> instance to a string using the 'N' format,
+            Converts the <see cref="T:SourceCode.Clay.Sha1"/> or <see cref="T:SourceCode.Clay.Sha256"/> instance to a string using the 'n' or 'N' format,
             and returns the value split into two tokens.
             </summary>
             <param name="sha">The sha value.</param>
             <param name="prefixLength">The length of the first token.</param>
+            <param name="casing">The ASCII casing to use.</param>
             <returns></returns>
         </member>
-        <member name="M:SourceCode.Clay.ShaUtil.ToString(System.ReadOnlySpan{System.Byte}@)">
+        <member name="M:SourceCode.Clay.ShaUtil.ToString(System.ReadOnlySpan{System.Byte}@,SourceCode.Clay.ShaUtil.HexCasing)">
             <summary>
-            Returns a string representation of the <see cref="T:SourceCode.Clay.Sha1"/> or <see cref="T:SourceCode.Clay.Sha256"/> instance using the 'N' format.
+            Returns a string representation of the <see cref="T:SourceCode.Clay.Sha1"/> or <see cref="T:SourceCode.Clay.Sha256"/> instance using the 'n' or 'N' format.
             </summary>
+            <param name="sha"></param>
+            <param name="casing">The ASCII casing to use.</param>
             <returns></returns>
         </member>
-        <member name="M:SourceCode.Clay.ShaUtil.ToString(System.ReadOnlySpan{System.Byte}@,System.Char@)">
+        <member name="M:SourceCode.Clay.ShaUtil.ToString(System.ReadOnlySpan{System.Byte}@,System.Char@,SourceCode.Clay.ShaUtil.HexCasing)">
             <summary>
             Returns a string representation of the <see cref="T:SourceCode.Clay.Sha1"/> or <see cref="T:SourceCode.Clay.Sha256"/> instance.
-            N: a9993e364706816aba3e25717850c26c9cd0d89d, cdc76e5c9914fb9281a1c7e284d73e67f1809a48a497200e046d39ccc7112cd0
-            D: a9993e36-4706816a-ba3e2571-7850c26c-9cd0d89d, cdc76e5c-9914fb92-81a1c7e2-84d73e67-f1809a48-a497200e-046d39cc-c7112cd0
-            S: a9993e36 4706816a ba3e2571 7850c26c 9cd0d89d, cdc76e5c 9914fb92 81a1c7e2 84d73e67 f1809a48 a497200e 046d39cc c7112cd0
+            n: a9993e364706816aba3e25717850c26c9cd0d89d, cdc76e5c9914fb9281a1c7e284d73e67f1809a48a497200e046d39ccc7112cd0
+            d: a9993e36-4706816a-ba3e2571-7850c26c-9cd0d89d, cdc76e5c-9914fb92-81a1c7e2-84d73e67-f1809a48-a497200e-046d39cc-c7112cd0
+            s: a9993e36 4706816a ba3e2571 7850c26c 9cd0d89d, cdc76e5c 9914fb92 81a1c7e2 84d73e67 f1809a48 a497200e 046d39cc c7112cd0
             </summary>
             <param name="sha"></param>
             <param name="separator"></param>
+            <param name="casing">The ASCII casing to use.</param>
             <returns></returns>
         </member>
         <member name="T:SourceCode.Clay.StringExtensions">

--- a/tests/SourceCode.Clay.Tests/Sha1Tests.cs
+++ b/tests/SourceCode.Clay.Tests/Sha1Tests.cs
@@ -93,9 +93,12 @@ namespace SourceCode.Clay.Tests
             Assert.True(default == expected);
             Assert.False(default != expected);
             Assert.True(expected.Equals((object)expected));
-            Assert.Equal(new KeyValuePair<string, string>("", Sha1TestVectors.Zero), expected.Split(0));
-            Assert.Equal(new KeyValuePair<string, string>("00", Sha1TestVectors.Zero.Left(Sha1.HexLength - 2)), expected.Split(2));
-            Assert.Equal(new KeyValuePair<string, string>(Sha1TestVectors.Zero, ""), expected.Split(Sha1.HexLength));
+            Assert.Equal(new KeyValuePair<string, string>("", Sha1TestVectors.Zero), expected.Split(0, false));
+            Assert.Equal(new KeyValuePair<string, string>("", Sha1TestVectors.Zero), expected.Split(0, true));
+            Assert.Equal(new KeyValuePair<string, string>("00", Sha1TestVectors.Zero.Left(Sha1.HexLength - 2)), expected.Split(2, false));
+            Assert.Equal(new KeyValuePair<string, string>("00", Sha1TestVectors.Zero.Left(Sha1.HexLength - 2).ToUpperInvariant()), expected.Split(2, true));
+            Assert.Equal(new KeyValuePair<string, string>(Sha1TestVectors.Zero, ""), expected.Split(Sha1.HexLength, false));
+            Assert.Equal(new KeyValuePair<string, string>(Sha1TestVectors.Zero, ""), expected.Split(Sha1.HexLength, true));
 
             // Null string
             Assert.Throws<ArgumentNullException>(() => Sha1.Hash((string)null));

--- a/tests/SourceCode.Clay.Tests/Sha1Tests.cs
+++ b/tests/SourceCode.Clay.Tests/Sha1Tests.cs
@@ -497,17 +497,17 @@ namespace SourceCode.Clay.Tests
                 Assert.Equal(expected, actual);
 
                 // Roundtrip formatted
-                actual = Sha1.Parse(sha1.ToString("D")).ToString();
+                actual = Sha1.Parse(sha1.ToString("d")).ToString();
                 Assert.Equal(expected, actual);
 
-                actual = Sha1.Parse(sha1.ToString("S")).ToString();
+                actual = Sha1.Parse(sha1.ToString("s")).ToString();
                 Assert.Equal(expected, actual);
 
                 // With hex specifier
-                actual = Sha1.Parse("0x" + sha1.ToString("D")).ToString();
+                actual = Sha1.Parse("0x" + sha1.ToString("d")).ToString();
                 Assert.Equal(expected, actual);
 
-                actual = Sha1.Parse("0x" + sha1.ToString("S")).ToString();
+                actual = Sha1.Parse("0x" + sha1.ToString("s")).ToString();
                 Assert.Equal(expected, actual);
 
                 // Get Byte[]
@@ -582,7 +582,7 @@ namespace SourceCode.Clay.Tests
                 Assert.Equal(expected_N, actual);
 
                 actual = sha1.ToString("N");
-                Assert.Equal(expected_N, actual);
+                Assert.Equal(expected_N.ToUpperInvariant(), actual);
 
                 actual = sha1.ToString("n");
                 Assert.Equal(expected_N, actual);
@@ -593,7 +593,7 @@ namespace SourceCode.Clay.Tests
                 const string expected_D = "a9993e36-4706816a-ba3e2571-7850c26c-9cd0d89d";
 
                 string actual = sha1.ToString("D");
-                Assert.Equal(expected_D, actual);
+                Assert.Equal(expected_D.ToUpperInvariant(), actual);
 
                 actual = sha1.ToString("d");
                 Assert.Equal(expected_D, actual);
@@ -604,7 +604,7 @@ namespace SourceCode.Clay.Tests
                 const string expected_S = "a9993e36 4706816a ba3e2571 7850c26c 9cd0d89d";
 
                 string actual = sha1.ToString("S");
-                Assert.Equal(expected_S, actual);
+                Assert.Equal(expected_S.ToUpperInvariant(), actual);
 
                 actual = sha1.ToString("s");
                 Assert.Equal(expected_S, actual);

--- a/tests/SourceCode.Clay.Tests/Sha256Tests.cs
+++ b/tests/SourceCode.Clay.Tests/Sha256Tests.cs
@@ -94,9 +94,12 @@ namespace SourceCode.Clay.Tests
             Assert.True(default == expected);
             Assert.False(default != expected);
             Assert.True(expected.Equals((object)expected));
-            Assert.Equal(new KeyValuePair<string, string>("", Sha256TestVectors.Zero), expected.Split(0));
-            Assert.Equal(new KeyValuePair<string, string>("00", Sha256TestVectors.Zero.Left(Sha256.HexLength - 2)), expected.Split(2));
-            Assert.Equal(new KeyValuePair<string, string>(Sha256TestVectors.Zero, ""), expected.Split(Sha256.HexLength));
+            Assert.Equal(new KeyValuePair<string, string>("", Sha256TestVectors.Zero), expected.Split(0, false));
+            Assert.Equal(new KeyValuePair<string, string>("", Sha256TestVectors.Zero), expected.Split(0, true));
+            Assert.Equal(new KeyValuePair<string, string>("00", Sha256TestVectors.Zero.Left(Sha256.HexLength - 2)), expected.Split(2, false));
+            Assert.Equal(new KeyValuePair<string, string>("00", Sha256TestVectors.Zero.Left(Sha256.HexLength - 2).ToUpperInvariant()), expected.Split(2, true));
+            Assert.Equal(new KeyValuePair<string, string>(Sha256TestVectors.Zero, ""), expected.Split(Sha256.HexLength, false));
+            Assert.Equal(new KeyValuePair<string, string>(Sha256TestVectors.Zero, ""), expected.Split(Sha256.HexLength, true));
 
             // Null string
             Assert.Throws<ArgumentNullException>(() => Sha256.Hash((string)null));

--- a/tests/SourceCode.Clay.Tests/Sha256Tests.cs
+++ b/tests/SourceCode.Clay.Tests/Sha256Tests.cs
@@ -583,7 +583,7 @@ namespace SourceCode.Clay.Tests
                 Assert.Equal(expected_N, actual);
 
                 actual = sha256.ToString("N");
-                Assert.Equal(expected_N, actual);
+                Assert.Equal(expected_N.ToUpperInvariant(), actual);
 
                 actual = sha256.ToString("n");
                 Assert.Equal(expected_N, actual);
@@ -594,7 +594,7 @@ namespace SourceCode.Clay.Tests
                 const string expected_D = "cdc76e5c-9914fb92-81a1c7e2-84d73e67-f1809a48-a497200e-046d39cc-c7112cd0";
 
                 string actual = sha256.ToString("D");
-                Assert.Equal(expected_D, actual);
+                Assert.Equal(expected_D.ToUpperInvariant(), actual);
 
                 actual = sha256.ToString("d");
                 Assert.Equal(expected_D, actual);
@@ -605,7 +605,7 @@ namespace SourceCode.Clay.Tests
                 const string expected_S = "cdc76e5c 9914fb92 81a1c7e2 84d73e67 f1809a48 a497200e 046d39cc c7112cd0";
 
                 string actual = sha256.ToString("S");
-                Assert.Equal(expected_S, actual);
+                Assert.Equal(expected_S.ToUpperInvariant(), actual);
 
                 actual = sha256.ToString("s");
                 Assert.Equal(expected_S, actual);


### PR DESCRIPTION
- Perf
- Enable upper/lower `ToString` formats
- FxCop