### PR TITLE
Experiment: Decouple Sha

### DIFF
--- a/src/SourceCode.Clay/Sha1.cs
+++ b/src/SourceCode.Clay/Sha1.cs
@@ -6,13 +6,10 @@
 #endregion
 
 using System;
-using System.Buffers;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
-using System.Text;
 using System.Threading;
 using crypt = System.Security.Cryptography;
 
@@ -39,8 +36,6 @@ namespace SourceCode.Clay
         /// The number of hex characters required to represent a <see cref="Sha1"/> value.
         /// </summary>
         public const byte HexLength = ByteLength * 2;
-
-        private static readonly Sha1 s_empty1 = HashImpl(ReadOnlySpan<byte>.Empty);
 
         // We choose to use value types for primary storage so that we can live on the stack
         // TODO: In C# 7.4+ we can use 'readonly fixed byte'
@@ -81,12 +76,7 @@ namespace SourceCode.Clay
         /// </summary>
         /// <param name="span">The bytes to hash.</param>
         public static Sha1 Hash(ReadOnlySpan<byte> span)
-        {
-            if (span.Length == 0) return s_empty1;
-
-            Sha1 sha = HashImpl(span);
-            return sha;
-        }
+            => Sha1Extensions.HashData(t_sha1.Value, span);
 
         /// <summary>
         /// Hashes the specified value using utf8 encoding.
@@ -94,27 +84,7 @@ namespace SourceCode.Clay
         /// <param name="value">The string to hash.</param>
         /// <returns></returns>
         public static Sha1 Hash(string value)
-        {
-            if (value is null) throw new ArgumentNullException(nameof(value));
-            if (value.Length == 0) return s_empty1;
-
-            int maxLen = Encoding.UTF8.GetMaxByteCount(value.Length); // Utf8 is 1-4 bpc
-
-            byte[] rented = ArrayPool<byte>.Shared.Rent(maxLen);
-            try
-            {
-                int count = Encoding.UTF8.GetBytes(value, 0, value.Length, rented, 0);
-
-                var span = new ReadOnlySpan<byte>(rented, 0, count);
-
-                Sha1 sha = HashImpl(span);
-                return sha;
-            }
-            finally
-            {
-                ArrayPool<byte>.Shared.Return(rented);
-            }
-        }
+            => Sha1Extensions.HashData(t_sha1.Value, value);
 
         /// <summary>
         /// Hashes the specified bytes.
@@ -122,15 +92,7 @@ namespace SourceCode.Clay
         /// <param name="bytes">The bytes to hash.</param>
         /// <returns></returns>
         public static Sha1 Hash(byte[] bytes)
-        {
-            if (bytes is null) throw new ArgumentNullException(nameof(bytes));
-            if (bytes.Length == 0) return s_empty1;
-
-            var span = new ReadOnlySpan<byte>(bytes);
-
-            Sha1 sha = HashImpl(span);
-            return sha;
-        }
+            => Sha1Extensions.HashData(t_sha1.Value, bytes);
 
         /// <summary>
         /// Hashes the specified <paramref name="bytes"/>, starting at the specified <paramref name="start"/> and <paramref name="length"/>.
@@ -139,44 +101,16 @@ namespace SourceCode.Clay
         /// <param name="start">The offset.</param>
         /// <param name="length">The count.</param>
         /// <returns></returns>
-        public static Sha1 Hash(byte[] bytes, in int start, in int length)
-        {
-            if (bytes is null) throw new ArgumentNullException(nameof(bytes));
-
-            var span = new ReadOnlySpan<byte>(bytes, start, length); // Check validity of start/length
-            if (length == 0) return s_empty1;
-
-            Sha1 sha = HashImpl(span);
-            return sha;
-        }
+        public static Sha1 Hash(byte[] bytes, int start, int length)
+            => Sha1Extensions.HashData(t_sha1.Value, bytes, start, length);
 
         /// <summary>
         /// Hashes the specified stream.
         /// </summary>
         /// <param name="stream">The stream to hash.</param>
         /// <returns></returns>
-        public static Sha1 Hash(in Stream stream)
-        {
-            if (stream is null) throw new ArgumentNullException(nameof(stream));
-            // Note that length==0 should NOT short-circuit
-
-            byte[] hash = t_sha1.Value.ComputeHash(stream);
-
-            var sha = new Sha1(hash);
-            return sha;
-        }
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static Sha1 HashImpl(ReadOnlySpan<byte> span)
-        {
-            // Do NOT short-circuit here; rely on call-sites to do so
-
-            Span<byte> hash = stackalloc byte[ByteLength];
-            t_sha1.Value.TryComputeHash(span, hash, out _);
-
-            var sha = new Sha1(hash);
-            return sha;
-        }
+        public static Sha1 Hash(Stream stream)
+            => Sha1Extensions.HashData(t_sha1.Value, stream);
 
         /// <summary>
         /// Copies the <see cref="Sha1"/> value to the provided buffer.

--- a/src/SourceCode.Clay/Sha1.cs
+++ b/src/SourceCode.Clay/Sha1.cs
@@ -40,7 +40,7 @@ namespace SourceCode.Clay
         /// </summary>
         public const byte HexLength = ByteLength * 2;
 
-        private static readonly Sha1 s_empty = HashImpl(ReadOnlySpan<byte>.Empty);
+        private static readonly Sha1 s_empty1 = HashImpl(ReadOnlySpan<byte>.Empty);
 
         // We choose to use value types for primary storage so that we can live on the stack
         // TODO: In C# 7.4+ we can use 'readonly fixed byte'
@@ -80,10 +80,9 @@ namespace SourceCode.Clay
         /// Hashes the specified bytes.
         /// </summary>
         /// <param name="span">The bytes to hash.</param>
-        /// <returns></returns>
         public static Sha1 Hash(ReadOnlySpan<byte> span)
         {
-            if (span.Length == 0) return s_empty;
+            if (span.Length == 0) return s_empty1;
 
             Sha1 sha = HashImpl(span);
             return sha;
@@ -97,7 +96,7 @@ namespace SourceCode.Clay
         public static Sha1 Hash(string value)
         {
             if (value is null) throw new ArgumentNullException(nameof(value));
-            if (value.Length == 0) return s_empty;
+            if (value.Length == 0) return s_empty1;
 
             int maxLen = Encoding.UTF8.GetMaxByteCount(value.Length); // Utf8 is 1-4 bpc
 
@@ -125,7 +124,7 @@ namespace SourceCode.Clay
         public static Sha1 Hash(byte[] bytes)
         {
             if (bytes is null) throw new ArgumentNullException(nameof(bytes));
-            if (bytes.Length == 0) return s_empty;
+            if (bytes.Length == 0) return s_empty1;
 
             var span = new ReadOnlySpan<byte>(bytes);
 
@@ -144,10 +143,8 @@ namespace SourceCode.Clay
         {
             if (bytes is null) throw new ArgumentNullException(nameof(bytes));
 
-            // Do this first to check validity of start/length
-            var span = new ReadOnlySpan<byte>(bytes, start, length);
-
-            if (length == 0) return s_empty;
+            var span = new ReadOnlySpan<byte>(bytes, start, length); // Check validity of start/length
+            if (length == 0) return s_empty1;
 
             Sha1 sha = HashImpl(span);
             return sha;
@@ -161,7 +158,7 @@ namespace SourceCode.Clay
         public static Sha1 Hash(in Stream stream)
         {
             if (stream is null) throw new ArgumentNullException(nameof(stream));
-            // Note that length=0 should NOT short-circuit
+            // Note that length==0 should NOT short-circuit
 
             byte[] hash = t_sha1.Value.ComputeHash(stream);
 

--- a/src/SourceCode.Clay/Sha1.cs
+++ b/src/SourceCode.Clay/Sha1.cs
@@ -75,6 +75,7 @@ namespace SourceCode.Clay
         /// Hashes the specified bytes.
         /// </summary>
         /// <param name="span">The bytes to hash.</param>
+        [Obsolete("Use extension methods", false)]
         public static Sha1 Hash(ReadOnlySpan<byte> span)
             => Sha1Extensions.HashData(t_sha1.Value, span);
 
@@ -82,7 +83,7 @@ namespace SourceCode.Clay
         /// Hashes the specified value using utf8 encoding.
         /// </summary>
         /// <param name="value">The string to hash.</param>
-        /// <returns></returns>
+        [Obsolete("Use extension methods", false)]
         public static Sha1 Hash(string value)
             => Sha1Extensions.HashData(t_sha1.Value, value);
 
@@ -90,7 +91,7 @@ namespace SourceCode.Clay
         /// Hashes the specified bytes.
         /// </summary>
         /// <param name="bytes">The bytes to hash.</param>
-        /// <returns></returns>
+        [Obsolete("Use extension methods", false)]
         public static Sha1 Hash(byte[] bytes)
             => Sha1Extensions.HashData(t_sha1.Value, bytes);
 
@@ -100,7 +101,7 @@ namespace SourceCode.Clay
         /// <param name="bytes">The bytes to hash.</param>
         /// <param name="start">The offset.</param>
         /// <param name="length">The count.</param>
-        /// <returns></returns>
+        [Obsolete("Use extension methods", false)]
         public static Sha1 Hash(byte[] bytes, int start, int length)
             => Sha1Extensions.HashData(t_sha1.Value, bytes, start, length);
 
@@ -108,7 +109,7 @@ namespace SourceCode.Clay
         /// Hashes the specified stream.
         /// </summary>
         /// <param name="stream">The stream to hash.</param>
-        /// <returns></returns>
+        [Obsolete("Use extension methods", false)]
         public static Sha1 Hash(Stream stream)
             => Sha1Extensions.HashData(t_sha1.Value, stream);
 

--- a/src/SourceCode.Clay/Sha1Extensions.cs
+++ b/src/SourceCode.Clay/Sha1Extensions.cs
@@ -1,0 +1,131 @@
+using System;
+using System.Buffers;
+using System.Diagnostics;
+using System.IO;
+using System.Runtime.CompilerServices;
+using System.Text;
+using crypt = System.Security.Cryptography;
+
+namespace SourceCode.Clay
+{
+    public static class Sha1Extensions
+    {
+        private static readonly Sha1 s_empty1 = Sha1.Parse("da39a3ee-5e6b4b0d-3255bfef-95601890-afd80709");
+
+        /// <summary>
+        /// Hashes the specified bytes.
+        /// </summary>
+        /// <param name="alg">The SHA1 instance to use.</param>
+        /// <param name="span">The bytes to hash.</param>
+        /// <returns></returns>
+        public static Sha1 HashData(this crypt.SHA1 alg, ReadOnlySpan<byte> span)
+        {
+            if (alg == null) throw new ArgumentNullException(nameof(alg));
+            if (span.Length == 0) return s_empty1;
+
+            Sha1 sha = HashImpl(alg, span);
+            return sha;
+        }
+
+        /// <summary>
+        /// Hashes the specified value using utf8 encoding.
+        /// </summary>
+        /// <param name="alg">The SHA1 instance to use.</param>
+        /// <param name="value">The string to hash.</param>
+        /// <returns></returns>
+        public static Sha1 HashData(this crypt.SHA1 alg, string value)
+        {
+            if (alg == null) throw new ArgumentNullException(nameof(alg));
+            if (value is null) throw new ArgumentNullException(nameof(value));
+            if (value.Length == 0) return s_empty1;
+
+            int maxLen = Encoding.UTF8.GetMaxByteCount(value.Length); // Utf8 is 1-4 bpc
+
+            byte[] rented = ArrayPool<byte>.Shared.Rent(maxLen);
+            try
+            {
+                int count = Encoding.UTF8.GetBytes(value, 0, value.Length, rented, 0);
+
+                var span = new ReadOnlySpan<byte>(rented, 0, count);
+
+                Sha1 sha = HashImpl(alg, span);
+                return sha;
+            }
+            finally
+            {
+                ArrayPool<byte>.Shared.Return(rented);
+            }
+        }
+
+        /// <summary>
+        /// Hashes the specified bytes.
+        /// </summary>
+        /// <param name="alg">The SHA1 instance to use.</param>
+        /// <param name="bytes">The bytes to hash.</param>
+        /// <returns></returns>
+        public static Sha1 HashData(this crypt.SHA1 alg, byte[] bytes)
+        {
+            if (alg == null) throw new ArgumentNullException(nameof(alg));
+            if (bytes is null) throw new ArgumentNullException(nameof(bytes));
+            if (bytes.Length == 0) return s_empty1;
+
+            var span = new ReadOnlySpan<byte>(bytes);
+
+            Sha1 sha = HashImpl(alg, span);
+            return sha;
+        }
+
+        /// <summary>
+        /// Hashes the specified <paramref name="bytes"/>, starting at the specified <paramref name="start"/> and <paramref name="length"/>.
+        /// </summary>
+        /// <param name="alg">The SHA1 instance to use.</param>
+        /// <param name="bytes">The bytes to hash.</param>
+        /// <param name="start">The offset.</param>
+        /// <param name="length">The count.</param>
+        /// <returns></returns>
+        public static Sha1 HashData(this crypt.SHA1 alg, byte[] bytes, in int start, in int length)
+        {
+            if (alg == null) throw new ArgumentNullException(nameof(alg));
+            if (bytes is null) throw new ArgumentNullException(nameof(bytes));
+
+            var span = new ReadOnlySpan<byte>(bytes, start, length); // Check validity of start/length
+            if (length == 0) return s_empty1;
+
+            Sha1 sha = HashImpl(alg, span);
+            return sha;
+        }
+
+        /// <summary>
+        /// Hashes the specified stream.
+        /// </summary>
+        /// <param name="alg">The SHA1 instance to use.</param>
+        /// <param name="stream">The stream to hash.</param>
+        /// <returns></returns>
+        public static Sha1 HashData(this crypt.SHA1 alg, in Stream stream)
+        {
+            if (alg == null) throw new ArgumentNullException(nameof(alg));
+            if (stream is null) throw new ArgumentNullException(nameof(stream));
+
+            // Note that length==0 should NOT short-circuit
+
+            byte[] hash = alg.ComputeHash(stream);
+
+            var sha = new Sha1(hash);
+            return sha;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static Sha1 HashImpl(crypt.SHA1 alg, ReadOnlySpan<byte> span)
+        {
+            Debug.Assert(alg != null);
+
+            // Do NOT short-circuit here; rely on call-sites to do so
+
+            Span<byte> hash = stackalloc byte[Sha1.ByteLength];
+            alg.TryComputeHash(span, hash, out _);
+
+            var sha = new Sha1(hash);
+            return sha;
+        }
+    }
+}

--- a/src/SourceCode.Clay/Sha256.cs
+++ b/src/SourceCode.Clay/Sha256.cs
@@ -76,7 +76,7 @@ namespace SourceCode.Clay
         /// Hashes the specified bytes.
         /// </summary>
         /// <param name="span">The bytes to hash.</param>
-        /// <returns></returns>
+        [Obsolete("Use extension methods", false)]
         public static Sha256 Hash(ReadOnlySpan<byte> span)
             => Sha256Extensions.HashData(t_sha256.Value, span);
 
@@ -84,7 +84,7 @@ namespace SourceCode.Clay
         /// Hashes the specified value using utf8 encoding.
         /// </summary>
         /// <param name="value">The string to hash.</param>
-        /// <returns></returns>
+        [Obsolete("Use extension methods", false)]
         public static Sha256 Hash(string value)
             => Sha256Extensions.HashData(t_sha256.Value, value);
 
@@ -92,7 +92,7 @@ namespace SourceCode.Clay
         /// Hashes the specified bytes.
         /// </summary>
         /// <param name="bytes">The bytes to hash.</param>
-        /// <returns></returns>
+        [Obsolete("Use extension methods", false)]
         public static Sha256 Hash(byte[] bytes)
             => Sha256Extensions.HashData(t_sha256.Value, bytes);
 
@@ -102,7 +102,7 @@ namespace SourceCode.Clay
         /// <param name="bytes">The bytes to hash.</param>
         /// <param name="start">The offset.</param>
         /// <param name="length">The count.</param>
-        /// <returns></returns>
+        [Obsolete("Use extension methods", false)]
         public static Sha256 Hash(byte[] bytes, int start, int length)
             => Sha256Extensions.HashData(t_sha256.Value, bytes, start, length);
 
@@ -110,7 +110,7 @@ namespace SourceCode.Clay
         /// Hashes the specified stream.
         /// </summary>
         /// <param name="stream">The stream to hash.</param>
-        /// <returns></returns>
+        [Obsolete("Use extension methods", false)]
         public static Sha256 Hash(Stream stream)
             => Sha256Extensions.HashData(t_sha256.Value, stream);
 

--- a/src/SourceCode.Clay/Sha256.cs
+++ b/src/SourceCode.Clay/Sha256.cs
@@ -41,7 +41,7 @@ namespace SourceCode.Clay
         /// </summary>
         public const byte HexLength = ByteLength * 2;
 
-        private static readonly Sha256 s_empty = HashImpl(ReadOnlySpan<byte>.Empty);
+        private static readonly Sha256 s_empty256 = HashImpl(ReadOnlySpan<byte>.Empty);
 
         // We choose to use value types for primary storage so that we can live on the stack
         // TODO: In C# 7.4+ we can use 'readonly fixed byte'
@@ -84,7 +84,7 @@ namespace SourceCode.Clay
         /// <returns></returns>
         public static Sha256 Hash(ReadOnlySpan<byte> span)
         {
-            if (span.Length == 0) return s_empty;
+            if (span.Length == 0) return s_empty256;
 
             Sha256 sha = HashImpl(span);
             return sha;
@@ -98,7 +98,7 @@ namespace SourceCode.Clay
         public static Sha256 Hash(string value)
         {
             if (value is null) throw new ArgumentNullException(nameof(value));
-            if (value.Length == 0) return s_empty;
+            if (value.Length == 0) return s_empty256;
 
             int maxLen = Encoding.UTF8.GetMaxByteCount(value.Length); // Utf8 is 1-4 bpc
 
@@ -126,7 +126,7 @@ namespace SourceCode.Clay
         public static Sha256 Hash(byte[] bytes)
         {
             if (bytes is null) throw new ArgumentNullException(nameof(bytes));
-            if (bytes.Length == 0) return s_empty;
+            if (bytes.Length == 0) return s_empty256;
 
             var span = new ReadOnlySpan<byte>(bytes);
 
@@ -145,10 +145,8 @@ namespace SourceCode.Clay
         {
             if (bytes is null) throw new ArgumentNullException(nameof(bytes));
 
-            // Do this first to check validity of start/length
-            var span = new ReadOnlySpan<byte>(bytes, start, length);
-
-            if (length == 0) return s_empty;
+            var span = new ReadOnlySpan<byte>(bytes, start, length); // Check validity of start/length
+            if (length == 0) return s_empty256;
 
             Sha256 sha = HashImpl(span);
             return sha;
@@ -162,7 +160,7 @@ namespace SourceCode.Clay
         public static Sha256 Hash(Stream stream)
         {
             if (stream is null) throw new ArgumentNullException(nameof(stream));
-            // Note that length=0 should NOT short-circuit
+            // Note that length==0 should NOT short-circuit
 
             byte[] hash = t_sha256.Value.ComputeHash(stream);
 

--- a/src/SourceCode.Clay/Sha256.cs
+++ b/src/SourceCode.Clay/Sha256.cs
@@ -6,13 +6,10 @@
 #endregion
 
 using System;
-using System.Buffers;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
-using System.Text;
 using System.Threading;
 using crypt = System.Security.Cryptography;
 
@@ -40,8 +37,6 @@ namespace SourceCode.Clay
         /// The number of hex characters required to represent a <see cref="Sha256"/> value.
         /// </summary>
         public const byte HexLength = ByteLength * 2;
-
-        private static readonly Sha256 s_empty256 = HashImpl(ReadOnlySpan<byte>.Empty);
 
         // We choose to use value types for primary storage so that we can live on the stack
         // TODO: In C# 7.4+ we can use 'readonly fixed byte'
@@ -83,12 +78,7 @@ namespace SourceCode.Clay
         /// <param name="span">The bytes to hash.</param>
         /// <returns></returns>
         public static Sha256 Hash(ReadOnlySpan<byte> span)
-        {
-            if (span.Length == 0) return s_empty256;
-
-            Sha256 sha = HashImpl(span);
-            return sha;
-        }
+            => Sha256Extensions.HashData(t_sha256.Value, span);
 
         /// <summary>
         /// Hashes the specified value using utf8 encoding.
@@ -96,27 +86,7 @@ namespace SourceCode.Clay
         /// <param name="value">The string to hash.</param>
         /// <returns></returns>
         public static Sha256 Hash(string value)
-        {
-            if (value is null) throw new ArgumentNullException(nameof(value));
-            if (value.Length == 0) return s_empty256;
-
-            int maxLen = Encoding.UTF8.GetMaxByteCount(value.Length); // Utf8 is 1-4 bpc
-
-            byte[] rented = ArrayPool<byte>.Shared.Rent(maxLen);
-            try
-            {
-                int count = Encoding.UTF8.GetBytes(value, 0, value.Length, rented, 0);
-
-                var span = new ReadOnlySpan<byte>(rented, 0, count);
-
-                Sha256 sha = HashImpl(span);
-                return sha;
-            }
-            finally
-            {
-                ArrayPool<byte>.Shared.Return(rented);
-            }
-        }
+            => Sha256Extensions.HashData(t_sha256.Value, value);
 
         /// <summary>
         /// Hashes the specified bytes.
@@ -124,15 +94,7 @@ namespace SourceCode.Clay
         /// <param name="bytes">The bytes to hash.</param>
         /// <returns></returns>
         public static Sha256 Hash(byte[] bytes)
-        {
-            if (bytes is null) throw new ArgumentNullException(nameof(bytes));
-            if (bytes.Length == 0) return s_empty256;
-
-            var span = new ReadOnlySpan<byte>(bytes);
-
-            Sha256 sha = HashImpl(span);
-            return sha;
-        }
+            => Sha256Extensions.HashData(t_sha256.Value, bytes);
 
         /// <summary>
         /// Hashes the specified <paramref name="bytes"/>, starting at the specified <paramref name="start"/> and <paramref name="length"/>.
@@ -142,15 +104,7 @@ namespace SourceCode.Clay
         /// <param name="length">The count.</param>
         /// <returns></returns>
         public static Sha256 Hash(byte[] bytes, int start, int length)
-        {
-            if (bytes is null) throw new ArgumentNullException(nameof(bytes));
-
-            var span = new ReadOnlySpan<byte>(bytes, start, length); // Check validity of start/length
-            if (length == 0) return s_empty256;
-
-            Sha256 sha = HashImpl(span);
-            return sha;
-        }
+            => Sha256Extensions.HashData(t_sha256.Value, bytes, start, length);
 
         /// <summary>
         /// Hashes the specified stream.
@@ -158,27 +112,7 @@ namespace SourceCode.Clay
         /// <param name="stream">The stream to hash.</param>
         /// <returns></returns>
         public static Sha256 Hash(Stream stream)
-        {
-            if (stream is null) throw new ArgumentNullException(nameof(stream));
-            // Note that length==0 should NOT short-circuit
-
-            byte[] hash = t_sha256.Value.ComputeHash(stream);
-
-            var sha = new Sha256(hash);
-            return sha;
-        }
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static Sha256 HashImpl(ReadOnlySpan<byte> span)
-        {
-            // Do NOT short-circuit here; rely on call-sites to do so
-
-            Span<byte> hash = stackalloc byte[ByteLength];
-            t_sha256.Value.TryComputeHash(span, hash, out _);
-
-            var sha = new Sha256(hash);
-            return sha;
-        }
+            => Sha256Extensions.HashData(t_sha256.Value, stream);
 
         /// <summary>
         /// Copies the <see cref="Sha256"/> value to the provided buffer.

--- a/src/SourceCode.Clay/Sha256Extensions.cs
+++ b/src/SourceCode.Clay/Sha256Extensions.cs
@@ -1,0 +1,131 @@
+using System;
+using System.Buffers;
+using System.Diagnostics;
+using System.IO;
+using System.Runtime.CompilerServices;
+using System.Text;
+using crypt = System.Security.Cryptography;
+
+namespace SourceCode.Clay
+{
+    public static class Sha256Extensions
+    {
+        private static readonly Sha256 s_empty256 = Sha256.Parse("E3B0C442-98FC1C14-9AFBF4C8-996FB924-27AE41E4-649B934C-A495991B-7852B855");
+
+        /// <summary>
+        /// Hashes the specified bytes.
+        /// </summary>
+        /// <param name="alg">The SHA256 instance to use.</param>
+        /// <param name="span">The bytes to hash.</param>
+        /// <returns></returns>
+        public static Sha256 HashData(this crypt.SHA256 alg, ReadOnlySpan<byte> span)
+        {
+            if (alg == null) throw new ArgumentNullException(nameof(alg));
+            if (span.Length == 0) return s_empty256;
+
+            Sha256 sha = HashImpl(alg, span);
+            return sha;
+        }
+
+        /// <summary>
+        /// Hashes the specified value using utf8 encoding.
+        /// </summary>
+        /// <param name="alg">The SHA256 instance to use.</param>
+        /// <param name="value">The string to hash.</param>
+        /// <returns></returns>
+        public static Sha256 HashData(this crypt.SHA256 alg, string value)
+        {
+            if (alg == null) throw new ArgumentNullException(nameof(alg));
+            if (value is null) throw new ArgumentNullException(nameof(value));
+            if (value.Length == 0) return s_empty256;
+
+            int maxLen = Encoding.UTF8.GetMaxByteCount(value.Length); // Utf8 is 1-4 bpc
+
+            byte[] rented = ArrayPool<byte>.Shared.Rent(maxLen);
+            try
+            {
+                int count = Encoding.UTF8.GetBytes(value, 0, value.Length, rented, 0);
+
+                var span = new ReadOnlySpan<byte>(rented, 0, count);
+
+                Sha256 sha = HashImpl(alg, span);
+                return sha;
+            }
+            finally
+            {
+                ArrayPool<byte>.Shared.Return(rented);
+            }
+        }
+
+        /// <summary>
+        /// Hashes the specified bytes.
+        /// </summary>
+        /// <param name="alg">The SHA256 instance to use.</param>
+        /// <param name="bytes">The bytes to hash.</param>
+        /// <returns></returns>
+        public static Sha256 HashData(this crypt.SHA256 alg, byte[] bytes)
+        {
+            if (alg == null) throw new ArgumentNullException(nameof(alg));
+            if (bytes is null) throw new ArgumentNullException(nameof(bytes));
+            if (bytes.Length == 0) return s_empty256;
+
+            var span = new ReadOnlySpan<byte>(bytes);
+
+            Sha256 sha = HashImpl(alg, span);
+            return sha;
+        }
+
+        /// <summary>
+        /// Hashes the specified <paramref name="bytes"/>, starting at the specified <paramref name="start"/> and <paramref name="length"/>.
+        /// </summary>
+        /// <param name="alg">The SHA256 instance to use.</param>
+        /// <param name="bytes">The bytes to hash.</param>
+        /// <param name="start">The offset.</param>
+        /// <param name="length">The count.</param>
+        /// <returns></returns>
+        public static Sha256 HashData(this crypt.SHA256 alg, byte[] bytes, int start, int length)
+        {
+            if (alg == null) throw new ArgumentNullException(nameof(alg));
+            if (bytes is null) throw new ArgumentNullException(nameof(bytes));
+
+            var span = new ReadOnlySpan<byte>(bytes, start, length); // Check validity of start/length
+            if (length == 0) return s_empty256;
+
+            Sha256 sha = HashImpl(alg, span);
+            return sha;
+        }
+
+        /// <summary>
+        /// Hashes the specified stream.
+        /// </summary>
+        /// <param name="alg">The SHA256 instance to use.</param>
+        /// <param name="stream">The stream to hash.</param>
+        /// <returns></returns>
+        public static Sha256 HashData(this crypt.SHA256 alg, Stream stream)
+        {
+            if (alg == null) throw new ArgumentNullException(nameof(alg));
+            if (stream is null) throw new ArgumentNullException(nameof(stream));
+
+            // Note that length==0 should NOT short-circuit
+
+            byte[] hash = alg.ComputeHash(stream);
+
+            var sha = new Sha256(hash);
+            return sha;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static Sha256 HashImpl(crypt.SHA256 alg, ReadOnlySpan<byte> span)
+        {
+            Debug.Assert(alg != null);
+
+            // Do NOT short-circuit here; rely on call-sites to do so
+
+            Span<byte> hash = stackalloc byte[Sha256.ByteLength];
+            alg.TryComputeHash(span, hash, out _);
+
+            var sha = new Sha256(hash);
+            return sha;
+        }
+    }
+}

--- a/src/SourceCode.Clay/SourceCode.Clay.xml
+++ b/src/SourceCode.Clay/SourceCode.Clay.xml
@@ -999,37 +999,32 @@
             Hashes the specified bytes.
             </summary>
             <param name="span">The bytes to hash.</param>
-            <returns></returns>
         </member>
         <member name="M:SourceCode.Clay.Sha1.Hash(System.String)">
             <summary>
             Hashes the specified value using utf8 encoding.
             </summary>
             <param name="value">The string to hash.</param>
-            <returns></returns>
         </member>
         <member name="M:SourceCode.Clay.Sha1.Hash(System.Byte[])">
             <summary>
             Hashes the specified bytes.
             </summary>
             <param name="bytes">The bytes to hash.</param>
-            <returns></returns>
         </member>
-        <member name="M:SourceCode.Clay.Sha1.Hash(System.Byte[],System.Int32@,System.Int32@)">
+        <member name="M:SourceCode.Clay.Sha1.Hash(System.Byte[],System.Int32,System.Int32)">
             <summary>
             Hashes the specified <paramref name="bytes"/>, starting at the specified <paramref name="start"/> and <paramref name="length"/>.
             </summary>
             <param name="bytes">The bytes to hash.</param>
             <param name="start">The offset.</param>
             <param name="length">The count.</param>
-            <returns></returns>
         </member>
-        <member name="M:SourceCode.Clay.Sha1.Hash(System.IO.Stream@)">
+        <member name="M:SourceCode.Clay.Sha1.Hash(System.IO.Stream)">
             <summary>
             Hashes the specified stream.
             </summary>
             <param name="stream">The stream to hash.</param>
-            <returns></returns>
         </member>
         <member name="M:SourceCode.Clay.Sha1.CopyTo(System.Span{System.Byte})">
             <summary>
@@ -1189,21 +1184,18 @@
             Hashes the specified bytes.
             </summary>
             <param name="span">The bytes to hash.</param>
-            <returns></returns>
         </member>
         <member name="M:SourceCode.Clay.Sha256.Hash(System.String)">
             <summary>
             Hashes the specified value using utf8 encoding.
             </summary>
             <param name="value">The string to hash.</param>
-            <returns></returns>
         </member>
         <member name="M:SourceCode.Clay.Sha256.Hash(System.Byte[])">
             <summary>
             Hashes the specified bytes.
             </summary>
             <param name="bytes">The bytes to hash.</param>
-            <returns></returns>
         </member>
         <member name="M:SourceCode.Clay.Sha256.Hash(System.Byte[],System.Int32,System.Int32)">
             <summary>
@@ -1212,14 +1204,12 @@
             <param name="bytes">The bytes to hash.</param>
             <param name="start">The offset.</param>
             <param name="length">The count.</param>
-            <returns></returns>
         </member>
         <member name="M:SourceCode.Clay.Sha256.Hash(System.IO.Stream)">
             <summary>
             Hashes the specified stream.
             </summary>
             <param name="stream">The stream to hash.</param>
-            <returns></returns>
         </member>
         <member name="M:SourceCode.Clay.Sha256.CopyTo(System.Span{System.Byte})">
             <summary>

--- a/src/SourceCode.Clay/SourceCode.Clay.xml
+++ b/src/SourceCode.Clay/SourceCode.Clay.xml
@@ -1118,6 +1118,48 @@
         <member name="M:SourceCode.Clay.Sha1Comparer.GetHashCode(SourceCode.Clay.Sha1)">
             <inheritdoc/>
         </member>
+        <member name="M:SourceCode.Clay.Sha1Extensions.HashData(System.Security.Cryptography.SHA1,System.ReadOnlySpan{System.Byte})">
+            <summary>
+            Hashes the specified bytes.
+            </summary>
+            <param name="alg">The SHA1 instance to use.</param>
+            <param name="span">The bytes to hash.</param>
+            <returns></returns>
+        </member>
+        <member name="M:SourceCode.Clay.Sha1Extensions.HashData(System.Security.Cryptography.SHA1,System.String)">
+            <summary>
+            Hashes the specified value using utf8 encoding.
+            </summary>
+            <param name="alg">The SHA1 instance to use.</param>
+            <param name="value">The string to hash.</param>
+            <returns></returns>
+        </member>
+        <member name="M:SourceCode.Clay.Sha1Extensions.HashData(System.Security.Cryptography.SHA1,System.Byte[])">
+            <summary>
+            Hashes the specified bytes.
+            </summary>
+            <param name="alg">The SHA1 instance to use.</param>
+            <param name="bytes">The bytes to hash.</param>
+            <returns></returns>
+        </member>
+        <member name="M:SourceCode.Clay.Sha1Extensions.HashData(System.Security.Cryptography.SHA1,System.Byte[],System.Int32@,System.Int32@)">
+            <summary>
+            Hashes the specified <paramref name="bytes"/>, starting at the specified <paramref name="start"/> and <paramref name="length"/>.
+            </summary>
+            <param name="alg">The SHA1 instance to use.</param>
+            <param name="bytes">The bytes to hash.</param>
+            <param name="start">The offset.</param>
+            <param name="length">The count.</param>
+            <returns></returns>
+        </member>
+        <member name="M:SourceCode.Clay.Sha1Extensions.HashData(System.Security.Cryptography.SHA1,System.IO.Stream@)">
+            <summary>
+            Hashes the specified stream.
+            </summary>
+            <param name="alg">The SHA1 instance to use.</param>
+            <param name="stream">The stream to hash.</param>
+            <returns></returns>
+        </member>
         <member name="T:SourceCode.Clay.Sha256">
             <summary>
             Represents a <see cref="T:SourceCode.Clay.Sha256"/> value.
@@ -1265,6 +1307,48 @@
         </member>
         <member name="M:SourceCode.Clay.Sha256Comparer.GetHashCode(SourceCode.Clay.Sha256)">
             <inheritdoc/>
+        </member>
+        <member name="M:SourceCode.Clay.Sha256Extensions.HashData(System.Security.Cryptography.SHA256,System.ReadOnlySpan{System.Byte})">
+            <summary>
+            Hashes the specified bytes.
+            </summary>
+            <param name="alg">The SHA256 instance to use.</param>
+            <param name="span">The bytes to hash.</param>
+            <returns></returns>
+        </member>
+        <member name="M:SourceCode.Clay.Sha256Extensions.HashData(System.Security.Cryptography.SHA256,System.String)">
+            <summary>
+            Hashes the specified value using utf8 encoding.
+            </summary>
+            <param name="alg">The SHA256 instance to use.</param>
+            <param name="value">The string to hash.</param>
+            <returns></returns>
+        </member>
+        <member name="M:SourceCode.Clay.Sha256Extensions.HashData(System.Security.Cryptography.SHA256,System.Byte[])">
+            <summary>
+            Hashes the specified bytes.
+            </summary>
+            <param name="alg">The SHA256 instance to use.</param>
+            <param name="bytes">The bytes to hash.</param>
+            <returns></returns>
+        </member>
+        <member name="M:SourceCode.Clay.Sha256Extensions.HashData(System.Security.Cryptography.SHA256,System.Byte[],System.Int32,System.Int32)">
+            <summary>
+            Hashes the specified <paramref name="bytes"/>, starting at the specified <paramref name="start"/> and <paramref name="length"/>.
+            </summary>
+            <param name="alg">The SHA256 instance to use.</param>
+            <param name="bytes">The bytes to hash.</param>
+            <param name="start">The offset.</param>
+            <param name="length">The count.</param>
+            <returns></returns>
+        </member>
+        <member name="M:SourceCode.Clay.Sha256Extensions.HashData(System.Security.Cryptography.SHA256,System.IO.Stream)">
+            <summary>
+            Hashes the specified stream.
+            </summary>
+            <param name="alg">The SHA256 instance to use.</param>
+            <param name="stream">The stream to hash.</param>
+            <returns></returns>
         </member>
         <member name="M:SourceCode.Clay.ShaUtil.TryParse(System.ReadOnlySpan{System.Char}@,System.Span{System.Byte}@)">
             <summary>


### PR DESCRIPTION
- Move core hashing methods out into extensions, so that `Sha1` does not keep an expensive static `SHA1` around
- Cleanup