### PR TITLE
System.Memory

### DIFF
--- a/coverage.runsettings
+++ b/coverage.runsettings
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RunSettings>
+  <RunConfiguration>
+    <TargetPlatform>x86</TargetPlatform>
+  </RunConfiguration>
+
+  <DataCollectionRunSettings>
+    <DataCollectors>
+      <DataCollector friendlyName="Code Coverage" uri="datacollector://Microsoft/CodeCoverage/2.0" assemblyQualifiedName="Microsoft.VisualStudio.Coverage.DynamicCoverageDataCollector, Microsoft.VisualStudio.TraceCollector, Version=11.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+        <Configuration>
+          <CodeCoverage>
+            <Attributes>
+              <Exclude>
+                <Attribute>^System.Diagnostics.DebuggerHiddenAttribute$</Attribute>
+                <Attribute>^System.Diagnostics.DebuggerNonUserCodeAttribute$</Attribute>
+                <Attribute>^System.Runtime.CompilerServices.CompilerGeneratedAttribute$</Attribute>
+                <Attribute>^System.CodeDom.Compiler.GeneratedCodeAttribute$</Attribute>
+                <Attribute>^System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute$</Attribute>
+              </Exclude>
+            </Attributes>
+
+            <PublicKeyTokens>
+              <Exclude>
+                <PublicKeyToken>^B77A5C561934E089$</PublicKeyToken>
+                <PublicKeyToken>^B03F5F7F11D50A3A$</PublicKeyToken>
+                <PublicKeyToken>^31BF3856AD364E35$</PublicKeyToken>
+                <PublicKeyToken>^89845DCD8080CC91$</PublicKeyToken>
+                <PublicKeyToken>^71E9BCE111E9429C$</PublicKeyToken>
+                <PublicKeyToken>^8F50407C4E9E73B6$</PublicKeyToken>
+                <PublicKeyToken>^E361AF139669C375$</PublicKeyToken>
+              </Exclude>
+            </PublicKeyTokens>
+            
+            <ModulePaths>
+              <Exclude>
+                <ModulePath>.*Tests.dll$</ModulePath>
+                <ModulePath>^(?!.*(SourceCode.Clay.))$</ModulePath>
+              </Exclude>
+            </ModulePaths>
+
+            <UseVerifiableInstrumentation>True</UseVerifiableInstrumentation>
+            <AllowLowIntegrityProcesses>True</AllowLowIntegrityProcesses>
+            <CollectFromChildProcesses>True</CollectFromChildProcesses>
+            <CollectAspDotNet>False</CollectAspDotNet>
+
+          </CodeCoverage>
+        </Configuration>
+      </DataCollector>
+    </DataCollectors>
+  </DataCollectionRunSettings>
+</RunSettings>

--- a/src/SourceCode.Clay.Net.UrlTemplate/HttpClientUrlTemplateExtensions.cs
+++ b/src/SourceCode.Clay.Net.UrlTemplate/HttpClientUrlTemplateExtensions.cs
@@ -27,7 +27,7 @@ namespace SourceCode.Clay.Net
             if (httpClient == null) throw new ArgumentNullException(nameof(httpClient));
             if (urlTemplate == null) throw new ArgumentNullException(nameof(urlTemplate));
             var uri = urlTemplate.ToString(parameters);
-            return httpClient.DeleteAsync(uri, cancellationToken);
+            return httpClient.DeleteAsync(new Uri(uri), cancellationToken);
         }
 
         /// <summary>
@@ -44,7 +44,7 @@ namespace SourceCode.Clay.Net
             if (httpClient == null) throw new ArgumentNullException(nameof(httpClient));
             if (urlTemplate == null) throw new ArgumentNullException(nameof(urlTemplate));
             var uri = urlTemplate.ToString(parameters);
-            return httpClient.GetAsync(uri, cancellationToken);
+            return httpClient.GetAsync(new Uri(uri), cancellationToken);
         }
 
         /// <summary>
@@ -62,7 +62,7 @@ namespace SourceCode.Clay.Net
             if (httpClient == null) throw new ArgumentNullException(nameof(httpClient));
             if (urlTemplate == null) throw new ArgumentNullException(nameof(urlTemplate));
             var uri = urlTemplate.ToString(parameters);
-            return httpClient.GetAsync(uri, completionOption, cancellationToken);
+            return httpClient.GetAsync(new Uri(uri), completionOption, cancellationToken);
         }
 
         /// <summary>
@@ -78,7 +78,7 @@ namespace SourceCode.Clay.Net
             if (httpClient == null) throw new ArgumentNullException(nameof(httpClient));
             if (urlTemplate == null) throw new ArgumentNullException(nameof(urlTemplate));
             var uri = urlTemplate.ToString(parameters);
-            return httpClient.GetByteArrayAsync(uri);
+            return httpClient.GetByteArrayAsync(new Uri(uri));
         }
 
         /// <summary>
@@ -94,7 +94,7 @@ namespace SourceCode.Clay.Net
             if (httpClient == null) throw new ArgumentNullException(nameof(httpClient));
             if (urlTemplate == null) throw new ArgumentNullException(nameof(urlTemplate));
             var uri = urlTemplate.ToString(parameters);
-            return httpClient.GetStreamAsync(uri);
+            return httpClient.GetStreamAsync(new Uri(uri));
         }
 
         /// <summary>
@@ -110,7 +110,7 @@ namespace SourceCode.Clay.Net
             if (httpClient == null) throw new ArgumentNullException(nameof(httpClient));
             if (urlTemplate == null) throw new ArgumentNullException(nameof(urlTemplate));
             var uri = urlTemplate.ToString(parameters);
-            return httpClient.GetStringAsync(uri);
+            return httpClient.GetStringAsync(new Uri(uri));
         }
 
         /// <summary>
@@ -127,7 +127,7 @@ namespace SourceCode.Clay.Net
             if (httpClient == null) throw new ArgumentNullException(nameof(httpClient));
             if (urlTemplate == null) throw new ArgumentNullException(nameof(urlTemplate));
             var uri = urlTemplate.ToString(parameters);
-            return httpClient.PostAsync(uri, content, cancellationToken);
+            return httpClient.PostAsync(new Uri(uri), content, cancellationToken);
         }
 
         /// <summary>
@@ -144,7 +144,7 @@ namespace SourceCode.Clay.Net
             if (httpClient == null) throw new ArgumentNullException(nameof(httpClient));
             if (urlTemplate == null) throw new ArgumentNullException(nameof(urlTemplate));
             var uri = urlTemplate.ToString(parameters);
-            return httpClient.PutAsync(uri, content, cancellationToken);
+            return httpClient.PutAsync(new Uri(uri), content, cancellationToken);
         }
 
         /// <summary>
@@ -161,7 +161,7 @@ namespace SourceCode.Clay.Net
             if (method == null) throw new ArgumentNullException(nameof(method));
             if (urlTemplate == null) throw new ArgumentNullException(nameof(urlTemplate));
             var uri = urlTemplate.ToString(parameters);
-            return new HttpRequestMessage(method, uri);
+            return new HttpRequestMessage(method, new Uri(uri));
         }
         #endregion
 
@@ -181,7 +181,7 @@ namespace SourceCode.Clay.Net
             if (httpClient == null) throw new ArgumentNullException(nameof(httpClient));
             if (urlTemplate == null) throw new ArgumentNullException(nameof(urlTemplate));
             var uri = urlTemplate.ToString(parameters);
-            return httpClient.DeleteAsync(uri, cancellationToken);
+            return httpClient.DeleteAsync(new Uri(uri), cancellationToken);
         }
 
         /// <summary>
@@ -199,7 +199,7 @@ namespace SourceCode.Clay.Net
             if (httpClient == null) throw new ArgumentNullException(nameof(httpClient));
             if (urlTemplate == null) throw new ArgumentNullException(nameof(urlTemplate));
             var uri = urlTemplate.ToString(parameters);
-            return httpClient.GetAsync(uri, cancellationToken);
+            return httpClient.GetAsync(new Uri(uri), cancellationToken);
         }
 
         /// <summary>
@@ -218,7 +218,7 @@ namespace SourceCode.Clay.Net
             if (httpClient == null) throw new ArgumentNullException(nameof(httpClient));
             if (urlTemplate == null) throw new ArgumentNullException(nameof(urlTemplate));
             var uri = urlTemplate.ToString(parameters);
-            return httpClient.GetAsync(uri, completionOption, cancellationToken);
+            return httpClient.GetAsync(new Uri(uri), completionOption, cancellationToken);
         }
 
         /// <summary>
@@ -235,7 +235,7 @@ namespace SourceCode.Clay.Net
             if (httpClient == null) throw new ArgumentNullException(nameof(httpClient));
             if (urlTemplate == null) throw new ArgumentNullException(nameof(urlTemplate));
             var uri = urlTemplate.ToString(parameters);
-            return httpClient.GetByteArrayAsync(uri);
+            return httpClient.GetByteArrayAsync(new Uri(uri));
         }
 
         /// <summary>
@@ -252,7 +252,7 @@ namespace SourceCode.Clay.Net
             if (httpClient == null) throw new ArgumentNullException(nameof(httpClient));
             if (urlTemplate == null) throw new ArgumentNullException(nameof(urlTemplate));
             var uri = urlTemplate.ToString(parameters);
-            return httpClient.GetStreamAsync(uri);
+            return httpClient.GetStreamAsync(new Uri(uri));
         }
 
         /// <summary>
@@ -269,7 +269,7 @@ namespace SourceCode.Clay.Net
             if (httpClient == null) throw new ArgumentNullException(nameof(httpClient));
             if (urlTemplate == null) throw new ArgumentNullException(nameof(urlTemplate));
             var uri = urlTemplate.ToString(parameters);
-            return httpClient.GetStringAsync(uri);
+            return httpClient.GetStringAsync(new Uri(uri));
         }
 
         /// <summary>
@@ -287,7 +287,7 @@ namespace SourceCode.Clay.Net
             if (httpClient == null) throw new ArgumentNullException(nameof(httpClient));
             if (urlTemplate == null) throw new ArgumentNullException(nameof(urlTemplate));
             var uri = urlTemplate.ToString(parameters);
-            return httpClient.PostAsync(uri, content, cancellationToken);
+            return httpClient.PostAsync(new Uri(uri), content, cancellationToken);
         }
 
         /// <summary>
@@ -305,7 +305,7 @@ namespace SourceCode.Clay.Net
             if (httpClient == null) throw new ArgumentNullException(nameof(httpClient));
             if (urlTemplate == null) throw new ArgumentNullException(nameof(urlTemplate));
             var uri = urlTemplate.ToString(parameters);
-            return httpClient.PutAsync(uri, content, cancellationToken);
+            return httpClient.PutAsync(new Uri(uri), content, cancellationToken);
         }
 
         /// <summary>
@@ -323,7 +323,7 @@ namespace SourceCode.Clay.Net
             if (method == null) throw new ArgumentNullException(nameof(method));
             if (urlTemplate == null) throw new ArgumentNullException(nameof(urlTemplate));
             var uri = urlTemplate.ToString(parameters);
-            return new HttpRequestMessage(method, uri);
+            return new HttpRequestMessage(method, new Uri(uri));
         }
         #endregion
     }

--- a/src/SourceCode.Clay.Net.UrlTemplate/SourceCode.Clay.Net.UrlTemplate.csproj
+++ b/src/SourceCode.Clay.Net.UrlTemplate/SourceCode.Clay.Net.UrlTemplate.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <!-- Common properties defined in Directory.Build.props -->
 
@@ -14,7 +14,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)'=='netstandard2.0'">
-    <PackageReference Include="System.Memory" Version="4.5.2" />
+    <PackageReference Include="System.Memory" Version="4.5.1" />
   </ItemGroup>
 
   <PropertyGroup>

--- a/src/SourceCode.Clay.Net.UrlTemplate/TemplateCompiler.cs
+++ b/src/SourceCode.Clay.Net.UrlTemplate/TemplateCompiler.cs
@@ -331,12 +331,12 @@ namespace SourceCode.Clay.Net
 
         private static string ToString<T>(T value, string formatString, string @default)
             where T : IFormattable
-            => !(value is null)
+            => value != null
             ? Uri.EscapeDataString(value.ToString(formatString, CultureInfo.InvariantCulture))
             : @default;
 
         private static string ToString<T>(T value, string @default)
-            => !(value is null)
+            => value != null
             ? Uri.EscapeDataString(value.ToString())
             : @default;
     }

--- a/src/SourceCode.Clay.Net.UrlTemplate/UriToken.cs
+++ b/src/SourceCode.Clay.Net.UrlTemplate/UriToken.cs
@@ -24,7 +24,7 @@ namespace SourceCode.Clay.Net
             SubName = null;
             if (type == UriTokenType.Value)
             {
-                var idx = name.IndexOf('.');
+                var idx = name.AsSpan().IndexOf('.');
                 if (name.EndsWith("[]", StringComparison.Ordinal))
                 {
                     name = name.Substring(0, name.Length - 2);

--- a/src/SourceCode.Clay.Net.UrlTemplate/UrlTemplateWebRequestExtensions.cs
+++ b/src/SourceCode.Clay.Net.UrlTemplate/UrlTemplateWebRequestExtensions.cs
@@ -17,7 +17,7 @@ namespace SourceCode.Clay.Net
         {
             if (urlTemplate == null) throw new ArgumentNullException(nameof(urlTemplate));
             var uri = urlTemplate.ToString(parameters);
-            return WebRequest.Create(uri);
+            return WebRequest.Create(new Uri(uri));
         }
 
         /// <summary>
@@ -31,7 +31,7 @@ namespace SourceCode.Clay.Net
         {
             if (urlTemplate == null) throw new ArgumentNullException(nameof(urlTemplate));
             var uri = urlTemplate.ToString(parameters);
-            return WebRequest.CreateHttp(uri);
+            return WebRequest.CreateHttp(new Uri(uri));
         }
         #endregion
 
@@ -48,7 +48,7 @@ namespace SourceCode.Clay.Net
         {
             if (urlTemplate == null) throw new ArgumentNullException(nameof(urlTemplate));
             var uri = urlTemplate.ToString(parameters);
-            return WebRequest.Create(uri);
+            return WebRequest.Create(new Uri(uri));
         }
 
         /// <summary>
@@ -63,7 +63,7 @@ namespace SourceCode.Clay.Net
         {
             if (urlTemplate == null) throw new ArgumentNullException(nameof(urlTemplate));
             var uri = urlTemplate.ToString(parameters);
-            return WebRequest.CreateHttp(uri);
+            return WebRequest.CreateHttp(new Uri(uri));
         }
         #endregion
     }

--- a/src/SourceCode.Clay/SourceCode.Clay.csproj
+++ b/src/SourceCode.Clay/SourceCode.Clay.csproj
@@ -14,7 +14,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)'=='netstandard2.0'">
-    <PackageReference Include="System.Memory" Version="4.5.2" />
+    <PackageReference Include="System.Memory" Version="4.5.1" />
   </ItemGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
Fix warnings.
Drop System.Memory version to 4.5.1 where possible.
Add runsettings for IDE code coverage.